### PR TITLE
修复 UNO 游戏逻辑、状态同步与手牌显示问题

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,7 @@
 node_modules/
+**/node_modules/
 dist/
+**/dist/
 .env
 .env.*
 !.env.example

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 # ---- Stage 1: Base ----
-FROM node:20-alpine AS base
+FROM node:22-slim AS base
 RUN corepack enable && corepack prepare pnpm@10.11.0 --activate
-RUN apk add --no-cache python3 make g++ linux-headers
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends python3 python3-pip make g++ ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 
 # ---- Stage 2: Install dependencies ----
@@ -22,13 +24,16 @@ ARG VITE_DEV_MODE=""
 ENV VITE_API_URL=$VITE_API_URL
 ENV VITE_GITHUB_CLIENT_ID=$VITE_GITHUB_CLIENT_ID
 ENV VITE_DEV_MODE=$VITE_DEV_MODE
-RUN cd packages/client && npx vite build
+RUN pnpm --filter @uno-online/shared build && pnpm --filter @uno-online/client build
 
 # ---- Stage 4: Build server ----
 FROM deps AS build-server
 COPY packages/shared/ packages/shared/
 COPY packages/server/ packages/server/
-RUN cd packages/server && npx prisma generate && npx tsc
+RUN pnpm --filter @uno-online/shared build \
+  && pnpm --filter @uno-online/server db:generate \
+  && pnpm --filter @uno-online/server build \
+  && node -e "const fs = require('fs'); const p = 'packages/shared/package.json'; const pkg = JSON.parse(fs.readFileSync(p, 'utf8')); pkg.main = './dist/index.js'; pkg.types = './dist/index.d.ts'; fs.writeFileSync(p, JSON.stringify(pkg, null, 2) + '\n');"
 
 # ---- Stage 5: Server runtime ----
 FROM base AS server
@@ -39,7 +44,7 @@ RUN rm -rf packages/client/src
 
 EXPOSE 3001
 
-CMD ["sh", "-c", "cd packages/server && npx prisma db push --skip-generate && cd /app && npx tsx packages/server/src/index.ts"]
+CMD ["sh", "-c", "pnpm --filter @uno-online/server db:push --skip-generate && pnpm --filter @uno-online/server start"]
 
 # ---- Stage 6: Caddy (client) ----
 FROM caddy:2-alpine AS caddy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET}
       JWT_SECRET: ${JWT_SECRET:-uno-online-dev-secret-at-least-32-chars}
       DOMAIN: ${DOMAIN:-localhost}
-      DEV_MODE: ${DEV_MODE:-false}
+      DEV_MODE: ${DEV_MODE:-true}
       PORT: "3001"
       RTC_PORT: ${RTC_PORT:-40000}
     ports:
@@ -57,7 +57,7 @@ services:
       target: caddy
       args:
         VITE_GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID}
-        VITE_DEV_MODE: ${DEV_MODE:-false}
+        VITE_DEV_MODE: ${DEV_MODE:-true}
     depends_on:
       - server
     environment:

--- a/package.json
+++ b/package.json
@@ -3,7 +3,16 @@
   "private": true,
   "packageManager": "pnpm@10.11.0",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@prisma/client",
+      "@prisma/engines",
+      "esbuild",
+      "mediasoup",
+      "prisma"
+    ]
   },
   "scripts": {
     "test": "pnpm -r test",

--- a/packages/client/src/components/AnimatedCard.tsx
+++ b/packages/client/src/components/AnimatedCard.tsx
@@ -5,12 +5,13 @@ import Card from './Card.js';
 interface AnimatedCardProps {
   card: CardType;
   playable?: boolean;
+  clickable?: boolean;
   onClick?: () => void;
   style?: React.CSSProperties;
   layoutId?: string;
 }
 
-export default function AnimatedCard({ card, playable, onClick, style, layoutId }: AnimatedCardProps) {
+export default function AnimatedCard({ card, playable, clickable = playable, onClick, style, layoutId }: AnimatedCardProps) {
   return (
     <motion.div
       layoutId={layoutId}
@@ -18,11 +19,11 @@ export default function AnimatedCard({ card, playable, onClick, style, layoutId 
       animate={{ scale: 1, opacity: 1, y: 0 }}
       exit={{ scale: 0.5, opacity: 0, y: -40, rotate: 15 }}
       transition={{ type: 'spring', stiffness: 400, damping: 25 }}
-      whileHover={playable ? { y: -16, scale: 1.08 } : undefined}
-      whileTap={playable ? { scale: 0.95 } : undefined}
+      whileHover={clickable ? { y: -16, scale: 1.08 } : undefined}
+      whileTap={clickable ? { scale: 0.95 } : undefined}
       style={{ display: 'inline-block', ...style }}
     >
-      <Card card={card} playable={playable} onClick={onClick} />
+      <Card card={card} playable={playable} clickable={clickable} onClick={onClick} />
     </motion.div>
   );
 }

--- a/packages/client/src/components/Card.tsx
+++ b/packages/client/src/components/Card.tsx
@@ -29,11 +29,12 @@ function getColorClass(card: CardType): string {
 interface CardProps {
   card: CardType;
   playable?: boolean;
+  clickable?: boolean;
   onClick?: () => void;
   style?: React.CSSProperties;
 }
 
-export default function Card({ card, playable = false, onClick, style }: CardProps) {
+export default function Card({ card, playable = false, clickable = playable, onClick, style }: CardProps) {
   const colorBlindMode = useSettingsStore((s) => s.colorBlindMode);
   const colorClass = getColorClass(card);
   const typeClass = `card--${card.type}`;
@@ -42,7 +43,7 @@ export default function Card({ card, playable = false, onClick, style }: CardPro
   return (
     <div
       className={`card ${colorClass} ${typeClass} ${playableClass}`}
-      onClick={playable ? onClick : undefined}
+      onClick={clickable ? onClick : undefined}
       style={style}
     >
       {card.color && (

--- a/packages/client/src/components/CardBack.tsx
+++ b/packages/client/src/components/CardBack.tsx
@@ -3,13 +3,14 @@ import '../styles/cards.css';
 interface CardBackProps {
   small?: boolean;
   onClick?: () => void;
+  className?: string;
   style?: React.CSSProperties;
 }
 
-export default function CardBack({ small = false, onClick, style }: CardBackProps) {
+export default function CardBack({ small = false, onClick, className = '', style }: CardBackProps) {
   return (
     <div
-      className={`card-back ${small ? 'card-back--small' : ''}`}
+      className={`card-back ${small ? 'card-back--small' : ''} ${className}`}
       onClick={onClick}
       style={{ cursor: onClick ? 'pointer' : 'default', ...style }}
     >

--- a/packages/client/src/components/DrawPile.tsx
+++ b/packages/client/src/components/DrawPile.tsx
@@ -1,9 +1,10 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import CardBack from './CardBack.js';
 import Card from './Card.js';
 import { useGameStore } from '../stores/game-store.js';
 import { useAuthStore } from '../stores/auth-store.js';
+import { getPlayableCardIds } from '../utils/playable-cards.js';
 
 interface DrawPileProps { onDraw: () => void; }
 
@@ -14,6 +15,10 @@ export default function DrawPile({ onDraw }: DrawPileProps) {
   const hasDrawnThisTurn = useGameStore((s) => s.hasDrawnThisTurn);
   const players = useGameStore((s) => s.players);
   const currentPlayerIndex = useGameStore((s) => s.currentPlayerIndex);
+  const discardPile = useGameStore((s) => s.discardPile);
+  const currentColor = useGameStore((s) => s.currentColor);
+  const drawStack = useGameStore((s) => s.drawStack);
+  const settings = useGameStore((s) => s.settings);
   const authUserId = useAuthStore((s) => s.user?.id);
   const viewerId = useGameStore((s) => s.viewerId);
   const userId = viewerId ?? authUserId;
@@ -22,6 +27,22 @@ export default function DrawPile({ onDraw }: DrawPileProps) {
 
   const isMyTurn = players[currentPlayerIndex]?.id === userId;
   const canDraw = isMyTurn && !hasDrawnThisTurn && phase === 'playing';
+  const me = players.find((p) => p.id === userId);
+  const topCard = discardPile[discardPile.length - 1];
+
+  const playableIds = useMemo(() => {
+    if (!isMyTurn || phase !== 'playing') return new Set<string>();
+    return getPlayableCardIds({
+      hand: me?.hand ?? [],
+      topCard,
+      currentColor,
+      drawStack,
+      houseRules: settings?.houseRules,
+    });
+  }, [currentColor, drawStack, isMyTurn, me?.hand, phase, settings?.houseRules, topCard]);
+
+  const showNoPlayableHint = canDraw && playableIds.size === 0 && !settings?.houseRules?.noHints;
+  const emphasizeDraw = canDraw && !settings?.houseRules?.noHints;
 
   useEffect(() => {
     if (lastDrawnCard) {
@@ -33,16 +54,28 @@ export default function DrawPile({ onDraw }: DrawPileProps) {
   }, [lastDrawnCard?.id]);
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 6, zIndex: 1, position: 'relative' }}>
+    <div className="draw-pile">
+      <AnimatePresence>
+        {showNoPlayableHint && (
+          <motion.div
+            className="draw-pile__hint"
+            initial={{ opacity: 0, y: 6 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 6 }}
+          >
+            无牌可出，摸牌
+          </motion.div>
+        )}
+      </AnimatePresence>
       <CardBack
         onClick={canDraw ? onDraw : undefined}
+        className={emphasizeDraw ? 'card-back--draw-ready' : undefined}
         style={{
           cursor: canDraw ? 'pointer' : 'default',
           opacity: canDraw ? 1 : 0.5,
-          transition: 'opacity 0.2s, transform 0.2s',
         }}
       />
-      <span style={{ fontSize: 10, color: deckCount <= 10 ? 'var(--color-red)' : 'var(--text-secondary)', fontWeight: deckCount <= 10 ? 'bold' : 'normal' }}>
+      <span className={deckCount <= 10 ? 'draw-pile__count draw-pile__count--low' : 'draw-pile__count'}>
         牌堆 ({deckCount})
       </span>
       <AnimatePresence>

--- a/packages/client/src/components/DrawPile.tsx
+++ b/packages/client/src/components/DrawPile.tsx
@@ -1,7 +1,6 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import CardBack from './CardBack.js';
-import Card from './Card.js';
 import { useGameStore } from '../stores/game-store.js';
 import { useAuthStore } from '../stores/auth-store.js';
 import { getPlayableCardIds } from '../utils/playable-cards.js';
@@ -10,7 +9,6 @@ interface DrawPileProps { onDraw: () => void; }
 
 export default function DrawPile({ onDraw }: DrawPileProps) {
   const deckCount = useGameStore((s) => s.deckCount);
-  const lastDrawnCard = useGameStore((s) => s.lastDrawnCard);
   const phase = useGameStore((s) => s.phase);
   const hasDrawnThisTurn = useGameStore((s) => s.hasDrawnThisTurn);
   const players = useGameStore((s) => s.players);
@@ -22,8 +20,6 @@ export default function DrawPile({ onDraw }: DrawPileProps) {
   const authUserId = useAuthStore((s) => s.user?.id);
   const viewerId = useGameStore((s) => s.viewerId);
   const userId = viewerId ?? authUserId;
-  const [flipping, setFlipping] = useState(false);
-  const [flipCard, setFlipCard] = useState(lastDrawnCard);
 
   const isMyTurn = players[currentPlayerIndex]?.id === userId;
   const canDraw = isMyTurn && !hasDrawnThisTurn && phase === 'playing';
@@ -43,15 +39,6 @@ export default function DrawPile({ onDraw }: DrawPileProps) {
 
   const showNoPlayableHint = canDraw && playableIds.size === 0 && !settings?.houseRules?.noHints;
   const emphasizeDraw = canDraw && !settings?.houseRules?.noHints;
-
-  useEffect(() => {
-    if (lastDrawnCard) {
-      setFlipCard(lastDrawnCard);
-      setFlipping(true);
-      const timer = setTimeout(() => setFlipping(false), 800);
-      return () => clearTimeout(timer);
-    }
-  }, [lastDrawnCard?.id]);
 
   return (
     <div className="draw-pile">
@@ -78,24 +65,6 @@ export default function DrawPile({ onDraw }: DrawPileProps) {
       <span className={deckCount <= 10 ? 'draw-pile__count draw-pile__count--low' : 'draw-pile__count'}>
         牌堆 ({deckCount})
       </span>
-      <AnimatePresence>
-        {flipping && flipCard && (
-          <motion.div
-            key={flipCard.id}
-            initial={{ rotateY: 180, scale: 0.8, y: 0, opacity: 1 }}
-            animate={{ rotateY: 0, scale: 1, y: 60, opacity: 1 }}
-            exit={{ scale: 0.5, y: 120, opacity: 0 }}
-            transition={{ duration: 0.5, ease: 'easeOut' }}
-            style={{
-              position: 'absolute', top: 0, left: '50%', marginLeft: -35,
-              perspective: 600, transformStyle: 'preserve-3d',
-              zIndex: 5, pointerEvents: 'none',
-            }}
-          >
-            <Card card={flipCard} />
-          </motion.div>
-        )}
-      </AnimatePresence>
     </div>
   );
 }

--- a/packages/client/src/components/DrawPile.tsx
+++ b/packages/client/src/components/DrawPile.tsx
@@ -14,7 +14,9 @@ export default function DrawPile({ onDraw }: DrawPileProps) {
   const hasDrawnThisTurn = useGameStore((s) => s.hasDrawnThisTurn);
   const players = useGameStore((s) => s.players);
   const currentPlayerIndex = useGameStore((s) => s.currentPlayerIndex);
-  const userId = useAuthStore((s) => s.user?.id);
+  const authUserId = useAuthStore((s) => s.user?.id);
+  const viewerId = useGameStore((s) => s.viewerId);
+  const userId = viewerId ?? authUserId;
   const [flipping, setFlipping] = useState(false);
   const [flipCard, setFlipCard] = useState(lastDrawnCard);
 

--- a/packages/client/src/components/GameActions.tsx
+++ b/packages/client/src/components/GameActions.tsx
@@ -14,7 +14,9 @@ interface GameActionsProps {
 }
 
 export default function GameActions({ onCallUno, onCatchUno, onChallenge, onAccept, onPass, onSwapTarget }: GameActionsProps) {
-  const userId = useAuthStore((s) => s.user?.id);
+  const authUserId = useAuthStore((s) => s.user?.id);
+  const viewerId = useGameStore((s) => s.viewerId);
+  const userId = viewerId ?? authUserId;
   const players = useGameStore((s) => s.players);
   const phase = useGameStore((s) => s.phase);
   const currentPlayerIndex = useGameStore((s) => s.currentPlayerIndex);

--- a/packages/client/src/components/GameEffects.tsx
+++ b/packages/client/src/components/GameEffects.tsx
@@ -19,7 +19,9 @@ export default function GameEffects() {
   const phase = useGameStore((s) => s.phase);
   const winnerId = useGameStore((s) => s.winnerId);
   const players = useGameStore((s) => s.players);
-  const userId = useAuthStore((s) => s.user?.id);
+  const authUserId = useAuthStore((s) => s.user?.id);
+  const viewerId = useGameStore((s) => s.viewerId);
+  const userId = viewerId ?? authUserId;
   const discardPile = useGameStore((s) => s.discardPile);
   const currentPlayerIndex = useGameStore((s) => s.currentPlayerIndex);
   const prevTopCardRef = useRef<string | undefined>();

--- a/packages/client/src/components/OpponentRow.tsx
+++ b/packages/client/src/components/OpponentRow.tsx
@@ -9,7 +9,9 @@ const AVATAR_COLORS = ['#ff3366', '#33cc66', '#4488ff', '#f97316', '#a855f7', '#
 const AVATAR_EMOJIS = ['😎', '🤠', '😺', '🐸', '🦊', '🐱', '🐶', '🦁', '🐼'];
 
 export default function OpponentRow() {
-  const userId = useAuthStore((s) => s.user?.id);
+  const authUserId = useAuthStore((s) => s.user?.id);
+  const viewerId = useGameStore((s) => s.viewerId);
+  const userId = viewerId ?? authUserId;
   const players = useGameStore((s) => s.players);
   const currentPlayerIndex = useGameStore((s) => s.currentPlayerIndex);
   const [shakenId, setShakenId] = useState<string | null>(null);
@@ -28,7 +30,7 @@ export default function OpponentRow() {
   }, [players]);
 
   const me = players.find((p) => p.id === userId);
-  const opponents = players.filter((p) => p.id !== userId);
+  const opponents = userId ? players.filter((p) => p.id !== userId) : [];
 
   return (
     <div className="opponent-row">

--- a/packages/client/src/components/PlayerHand.tsx
+++ b/packages/client/src/components/PlayerHand.tsx
@@ -1,35 +1,13 @@
 import { useMemo } from 'react';
-import type { Card as CardType, HouseRules } from '@uno-online/shared';
-import { getPlayableCards } from '@uno-online/shared';
 import { AnimatePresence } from 'framer-motion';
 import AnimatedCard from './AnimatedCard.js';
 import { useGameStore } from '../stores/game-store.js';
 import { useAuthStore } from '../stores/auth-store.js';
+import { getPlayableCardIds } from '../utils/playable-cards.js';
 import '../styles/game.css';
 
 interface PlayerHandProps {
   onPlayCard: (cardId: string) => void;
-}
-
-function canRespondToDrawStack(card: CardType, topCard: CardType, houseRules?: HouseRules): boolean {
-  if (!houseRules) return false;
-
-  const canStack =
-    (houseRules.stackDrawTwo && card.type === 'draw_two' && topCard.type === 'draw_two') ||
-    (houseRules.stackDrawFour && card.type === 'wild_draw_four' && topCard.type === 'wild_draw_four') ||
-    (
-      houseRules.crossStack &&
-      (
-        (card.type === 'draw_two' && topCard.type === 'wild_draw_four') ||
-        (card.type === 'wild_draw_four' && topCard.type === 'draw_two')
-      )
-    );
-  const canDeflect =
-    (houseRules.reverseDeflectDrawTwo && card.type === 'reverse' && topCard.type === 'draw_two') ||
-    (houseRules.reverseDeflectDrawFour && card.type === 'reverse' && topCard.type === 'wild_draw_four') ||
-    (houseRules.skipDeflect && card.type === 'skip');
-
-  return canStack || canDeflect;
 }
 
 export default function PlayerHand({ onPlayCard }: PlayerHandProps) {
@@ -44,32 +22,26 @@ export default function PlayerHand({ onPlayCard }: PlayerHandProps) {
   const settings = useGameStore((s) => s.settings);
   const drawStack = useGameStore((s) => s.drawStack);
 
-  const hasDrawnThisTurn = useGameStore((s) => s.hasDrawnThisTurn);
-
   const me = players.find((p) => p.id === userId);
   const isMyTurn = players[currentPlayerIndex]?.id === userId;
   const topCard = discardPile[discardPile.length - 1];
 
   const playableIds = useMemo(() => {
-    if (!isMyTurn || !topCard || !currentColor || phase !== 'playing') return new Set<string>();
-    const playable = drawStack > 0
-      ? (me?.hand ?? []).filter((card) => canRespondToDrawStack(card, topCard, settings?.houseRules))
-      : getPlayableCards(me?.hand ?? [], topCard, currentColor);
-    return new Set(playable.map((c) => c.id));
-  }, [me?.hand, topCard, currentColor, isMyTurn, phase, settings, drawStack]);
+    if (!isMyTurn || phase !== 'playing') return new Set<string>();
+    return getPlayableCardIds({
+      hand: me?.hand ?? [],
+      topCard,
+      currentColor,
+      drawStack,
+      houseRules: settings?.houseRules,
+    });
+  }, [currentColor, drawStack, isMyTurn, me?.hand, phase, settings?.houseRules, topCard]);
   const hintedIds = settings?.houseRules?.noHints ? new Set<string>() : playableIds;
-
-  const showNoPlayableHint = isMyTurn && phase === 'playing' && playableIds.size === 0 && !hasDrawnThisTurn && !settings?.houseRules?.noHints;
 
   if (!me) return null;
 
   return (
     <div className="player-hand">
-      {showNoPlayableHint && (
-        <div style={{ textAlign: 'center', fontSize: 13, color: 'var(--text-secondary)', marginBottom: 4 }}>
-          无牌可出，请摸牌
-        </div>
-      )}
       <div className="player-hand__cards">
         <AnimatePresence mode="popLayout">
           {me.hand.map((card, i) => {

--- a/packages/client/src/components/PlayerHand.tsx
+++ b/packages/client/src/components/PlayerHand.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import type { Card as CardType } from '@uno-online/shared';
+import type { Card as CardType, HouseRules } from '@uno-online/shared';
 import { getPlayableCards } from '@uno-online/shared';
 import { AnimatePresence } from 'framer-motion';
 import AnimatedCard from './AnimatedCard.js';
@@ -11,14 +11,38 @@ interface PlayerHandProps {
   onPlayCard: (cardId: string) => void;
 }
 
+function canRespondToDrawStack(card: CardType, topCard: CardType, houseRules?: HouseRules): boolean {
+  if (!houseRules) return false;
+
+  const canStack =
+    (houseRules.stackDrawTwo && card.type === 'draw_two' && topCard.type === 'draw_two') ||
+    (houseRules.stackDrawFour && card.type === 'wild_draw_four' && topCard.type === 'wild_draw_four') ||
+    (
+      houseRules.crossStack &&
+      (
+        (card.type === 'draw_two' && topCard.type === 'wild_draw_four') ||
+        (card.type === 'wild_draw_four' && topCard.type === 'draw_two')
+      )
+    );
+  const canDeflect =
+    (houseRules.reverseDeflectDrawTwo && card.type === 'reverse' && topCard.type === 'draw_two') ||
+    (houseRules.reverseDeflectDrawFour && card.type === 'reverse' && topCard.type === 'wild_draw_four') ||
+    (houseRules.skipDeflect && card.type === 'skip');
+
+  return canStack || canDeflect;
+}
+
 export default function PlayerHand({ onPlayCard }: PlayerHandProps) {
-  const userId = useAuthStore((s) => s.user?.id);
+  const authUserId = useAuthStore((s) => s.user?.id);
+  const viewerId = useGameStore((s) => s.viewerId);
+  const userId = viewerId ?? authUserId;
   const players = useGameStore((s) => s.players);
   const currentPlayerIndex = useGameStore((s) => s.currentPlayerIndex);
   const discardPile = useGameStore((s) => s.discardPile);
   const currentColor = useGameStore((s) => s.currentColor);
   const phase = useGameStore((s) => s.phase);
   const settings = useGameStore((s) => s.settings);
+  const drawStack = useGameStore((s) => s.drawStack);
 
   const hasDrawnThisTurn = useGameStore((s) => s.hasDrawnThisTurn);
 
@@ -27,11 +51,13 @@ export default function PlayerHand({ onPlayCard }: PlayerHandProps) {
   const topCard = discardPile[discardPile.length - 1];
 
   const playableIds = useMemo(() => {
-    if (settings?.houseRules?.noHints) return new Set<string>();
     if (!isMyTurn || !topCard || !currentColor || phase !== 'playing') return new Set<string>();
-    const playable = getPlayableCards(me?.hand ?? [], topCard, currentColor);
+    const playable = drawStack > 0
+      ? (me?.hand ?? []).filter((card) => canRespondToDrawStack(card, topCard, settings?.houseRules))
+      : getPlayableCards(me?.hand ?? [], topCard, currentColor);
     return new Set(playable.map((c) => c.id));
-  }, [me?.hand, topCard, currentColor, isMyTurn, phase, settings]);
+  }, [me?.hand, topCard, currentColor, isMyTurn, phase, settings, drawStack]);
+  const hintedIds = settings?.houseRules?.noHints ? new Set<string>() : playableIds;
 
   const showNoPlayableHint = isMyTurn && phase === 'playing' && playableIds.size === 0 && !hasDrawnThisTurn && !settings?.houseRules?.noHints;
 
@@ -53,7 +79,8 @@ export default function PlayerHand({ onPlayCard }: PlayerHandProps) {
                 key={card.id}
                 layoutId={card.id}
                 card={card}
-                playable={playableIds.has(card.id)}
+                playable={hintedIds.has(card.id)}
+                clickable={playableIds.has(card.id)}
                 onClick={() => playableIds.has(card.id) && onPlayCard(card.id)}
                 style={{ transform: `rotate(${angle}deg)` }}
               />

--- a/packages/client/src/env.ts
+++ b/packages/client/src/env.ts
@@ -1,3 +1,3 @@
-export const API_URL = import.meta.env.VITE_API_URL ?? 'http://localhost:3001';
+export const API_URL = import.meta.env.VITE_API_URL ?? '';
 export const GITHUB_CLIENT_ID = import.meta.env.VITE_GITHUB_CLIENT_ID ?? '';
 export const DEV_MODE = import.meta.env.VITE_DEV_MODE === 'true';

--- a/packages/client/src/pages/GamePage.tsx
+++ b/packages/client/src/pages/GamePage.tsx
@@ -27,7 +27,9 @@ export default function GamePage() {
   const { roomCode } = useParams<{ roomCode: string }>();
   const navigate = useNavigate();
   const phase = useGameStore((s) => s.phase);
-  const userId = useAuthStore((s) => s.user?.id);
+  const authUserId = useAuthStore((s) => s.user?.id);
+  const viewerId = useGameStore((s) => s.viewerId);
+  const userId = viewerId ?? authUserId;
   const players = useGameStore((s) => s.players);
   const currentPlayerIndex = useGameStore((s) => s.currentPlayerIndex);
 

--- a/packages/client/src/pages/GamePage.tsx
+++ b/packages/client/src/pages/GamePage.tsx
@@ -40,11 +40,15 @@ export default function GamePage() {
   const showScoreBoard = phase === 'round_end' || phase === 'game_over';
   const setGameState = useGameStore((s) => s.setGameState);
   const [connectionStatus, setConnectionStatus] = useState<'connected' | 'disconnected' | 'reconnecting'>('connected');
+  const [showTurnBanner, setShowTurnBanner] = useState(false);
   const prevTurnRef = useRef(false);
 
   useEffect(() => {
     if (isMyTurn && phase === 'playing' && !prevTurnRef.current) {
       playSound('your_turn');
+      setShowTurnBanner(true);
+      const timer = window.setTimeout(() => setShowTurnBanner(false), 1600);
+      return () => window.clearTimeout(timer);
     }
     prevTurnRef.current = isMyTurn && phase === 'playing';
   }, [isMyTurn, phase]);
@@ -171,6 +175,19 @@ export default function GamePage() {
         <DirectionIndicator />
         <DrawPile onDraw={drawCard} />
         <DiscardPile />
+        <AnimatePresence>
+          {showTurnBanner && isMyTurn && phase === 'playing' && (
+            <motion.div
+              className="turn-banner"
+              initial={{ opacity: 0, scale: 0.92, y: 12 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.96, y: -8 }}
+              transition={{ duration: 0.22, ease: 'easeOut' }}
+            >
+              轮到你了
+            </motion.div>
+          )}
+        </AnimatePresence>
       </div>
       <GameActions
         onCallUno={callUno}
@@ -180,21 +197,6 @@ export default function GamePage() {
         onPass={pass}
         onSwapTarget={swapTarget}
       />
-      <AnimatePresence>
-        {isMyTurn && phase === 'playing' && (
-          <motion.div
-            initial={{ opacity: 0, y: 10 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: 10 }}
-            style={{
-              textAlign: 'center', fontFamily: 'var(--font-game)', fontSize: 16,
-              color: 'var(--text-accent)', animation: 'timerFlash 1s ease-in-out infinite alternate',
-            }}
-          >
-            你的回合
-          </motion.div>
-        )}
-      </AnimatePresence>
       <PlayerHand onPlayCard={playCard} />
       <ChatBox />
       <VoicePanel />

--- a/packages/client/src/pages/GamePage.tsx
+++ b/packages/client/src/pages/GamePage.tsx
@@ -32,6 +32,8 @@ export default function GamePage() {
   const userId = viewerId ?? authUserId;
   const players = useGameStore((s) => s.players);
   const currentPlayerIndex = useGameStore((s) => s.currentPlayerIndex);
+  const drawStack = useGameStore((s) => s.drawStack);
+  const settings = useGameStore((s) => s.settings);
 
   const isMyTurn = players[currentPlayerIndex]?.id === userId;
   const needsColorPick = phase === 'choosing_color' && isMyTurn;
@@ -91,9 +93,20 @@ export default function GamePage() {
   }, []);
 
   const drawCard = useCallback(() => {
+    const houseRules = settings?.houseRules;
+    const shouldAutoPass =
+      drawStack === 0 &&
+      !houseRules?.drawUntilPlayable &&
+      !houseRules?.deathDraw &&
+      !houseRules?.forcedPlayAfterDraw;
+
     playSound('draw_card');
-    getSocket().emit('game:draw_card', () => {});
-  }, []);
+    getSocket().emit('game:draw_card', (res: { success: boolean }) => {
+      if (res?.success && shouldAutoPass) {
+        getSocket().emit('game:pass', () => {});
+      }
+    });
+  }, [drawStack, settings?.houseRules]);
 
   const chooseColor = useCallback((color: Color) => {
     getSocket().emit('game:choose_color', { color }, () => {});

--- a/packages/client/src/pages/RoomPage.tsx
+++ b/packages/client/src/pages/RoomPage.tsx
@@ -50,6 +50,12 @@ export default function RoomPage() {
   const allReady = players.length >= 2 && players.every((p) => p.ready);
   const [houseRules, setHouseRules] = useState<HouseRules>(DEFAULT_HOUSE_RULES);
 
+  useEffect(() => {
+    if (room?.settings?.houseRules) {
+      setHouseRules({ ...DEFAULT_HOUSE_RULES, ...room.settings.houseRules });
+    }
+  }, [room?.settings?.houseRules]);
+
   const toggleReady = () => {
     getSocket().emit('room:ready', !myPlayer?.ready, () => {});
   };
@@ -57,6 +63,10 @@ export default function RoomPage() {
   const startGame = () => {
     getSocket().emit('game:start', (res: any) => {
       if (!res.success) alert(res.error);
+      if (res.success && res.gameState) {
+        setGameState(res.gameState);
+        navigate(`/game/${roomCode}`);
+      }
     });
   };
 

--- a/packages/client/src/stores/game-store.ts
+++ b/packages/client/src/stores/game-store.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import type { Card, Color, HouseRules } from '@uno-online/shared';
+import type { Card, Color, GameAction, HouseRules } from '@uno-online/shared';
 
 interface PlayerInfo {
   id: string;
@@ -14,6 +14,7 @@ interface PlayerInfo {
 }
 
 interface GameState {
+  viewerId: string | null;
   phase: string | null;
   players: PlayerInfo[];
   currentPlayerIndex: number;
@@ -26,6 +27,7 @@ interface GameState {
   winnerId: string | null;
   pendingDrawPlayerId: string | null;
   settings: { turnTimeLimit: number; targetScore: number; houseRules?: HouseRules } | null;
+  lastAction: GameAction | null;
   turnEndTime: number | null;
   lastDrawnCard: Card | null;
   hasDrawnThisTurn: boolean;
@@ -38,6 +40,7 @@ interface GameState {
 
 export const useGameStore = create<GameState>((set) => ({
   phase: null,
+  viewerId: null,
   players: [],
   currentPlayerIndex: 0,
   direction: 'clockwise',
@@ -49,25 +52,41 @@ export const useGameStore = create<GameState>((set) => ({
   winnerId: null,
   pendingDrawPlayerId: null,
   settings: null,
+  lastAction: null,
   turnEndTime: null,
   lastDrawnCard: null,
   hasDrawnThisTurn: false,
   setGameState: (view) =>
-    set({
-      phase: view.phase as string,
-      players: view.players as PlayerInfo[],
-      currentPlayerIndex: view.currentPlayerIndex as number,
-      direction: view.direction as 'clockwise' | 'counter_clockwise',
-      discardPile: view.discardPile as Card[],
-      currentColor: view.currentColor as Color | null,
-      drawStack: view.drawStack as number,
-      deckCount: view.deckCount as number,
-      roundNumber: view.roundNumber as number,
-      winnerId: view.winnerId as string | null,
-      pendingDrawPlayerId: view.pendingDrawPlayerId as string | null,
-      settings: view.settings as { turnTimeLimit: number; targetScore: number; houseRules?: HouseRules },
-      hasDrawnThisTurn: false,
-      lastDrawnCard: null,
+    set((state) => {
+      const players = view.players as PlayerInfo[];
+      const viewerId = (view.viewerId as string | undefined) ?? state.viewerId;
+      const currentPlayerIndex = view.currentPlayerIndex as number;
+      const phase = view.phase as string;
+      const lastAction = (view.lastAction as GameAction | null) ?? null;
+      const currentPlayerId = players[currentPlayerIndex]?.id;
+      const hasDrawnThisTurn =
+        phase === 'playing' &&
+        lastAction?.type === 'DRAW_CARD' &&
+        lastAction.playerId === currentPlayerId;
+
+      return {
+        phase,
+        viewerId,
+        players,
+        currentPlayerIndex,
+        direction: view.direction as 'clockwise' | 'counter_clockwise',
+        discardPile: view.discardPile as Card[],
+        currentColor: view.currentColor as Color | null,
+        drawStack: view.drawStack as number,
+        deckCount: view.deckCount as number,
+        roundNumber: view.roundNumber as number,
+        winnerId: view.winnerId as string | null,
+        pendingDrawPlayerId: view.pendingDrawPlayerId as string | null,
+        settings: view.settings as { turnTimeLimit: number; targetScore: number; houseRules?: HouseRules },
+        lastAction,
+        hasDrawnThisTurn,
+        lastDrawnCard: hasDrawnThisTurn ? state.lastDrawnCard : null,
+      };
     }),
   setDrawnCard: (card) => set({ lastDrawnCard: card, hasDrawnThisTurn: true }),
   setHasDrawn: (v) => set({ hasDrawnThisTurn: v }),
@@ -75,6 +94,7 @@ export const useGameStore = create<GameState>((set) => ({
   clearGame: () =>
     set({
       phase: null,
+      viewerId: null,
       players: [],
       currentPlayerIndex: 0,
       direction: 'clockwise',
@@ -86,6 +106,7 @@ export const useGameStore = create<GameState>((set) => ({
       winnerId: null,
       pendingDrawPlayerId: null,
       settings: null,
+      lastAction: null,
       turnEndTime: null,
       lastDrawnCard: null,
       hasDrawnThisTurn: false,

--- a/packages/client/src/styles/cards.css
+++ b/packages/client/src/styles/cards.css
@@ -63,6 +63,20 @@
   color: rgba(255, 255, 255, 0.5);
   box-shadow: var(--card-shadow);
   flex-shrink: 0;
+  transition: opacity 0.2s, transform 0.2s, border-color 0.2s, box-shadow 0.2s;
+}
+
+.card-back--draw-ready {
+  border-color: var(--text-accent);
+  box-shadow:
+    0 0 0 4px rgba(251, 191, 36, 0.28),
+    0 0 26px rgba(251, 191, 36, 0.72),
+    var(--card-shadow);
+  animation: drawReadyPulse 1s ease-in-out infinite alternate;
+}
+
+.card-back--draw-ready:hover {
+  transform: translateY(-8px) scale(1.04);
 }
 
 .card-back--small {
@@ -88,5 +102,20 @@
     width: 52px;
     height: 76px;
     font-size: 12px;
+  }
+}
+
+@keyframes drawReadyPulse {
+  from {
+    box-shadow:
+      0 0 0 3px rgba(251, 191, 36, 0.24),
+      0 0 18px rgba(251, 191, 36, 0.58),
+      var(--card-shadow);
+  }
+  to {
+    box-shadow:
+      0 0 0 6px rgba(251, 191, 36, 0.36),
+      0 0 32px rgba(251, 191, 36, 0.86),
+      var(--card-shadow);
   }
 }

--- a/packages/client/src/styles/game.css
+++ b/packages/client/src/styles/game.css
@@ -96,6 +96,24 @@
   position: relative;
 }
 
+.turn-banner {
+  position: absolute;
+  left: 50%;
+  top: 42%;
+  transform: translate(-50%, -50%);
+  z-index: 20;
+  pointer-events: none;
+  font-family: var(--font-game);
+  font-size: clamp(30px, 5vw, 56px);
+  font-weight: 900;
+  color: var(--text-accent);
+  text-shadow:
+    0 4px 0 rgba(0, 0, 0, 0.28),
+    0 0 28px rgba(251, 191, 36, 0.72);
+  letter-spacing: 0;
+  white-space: nowrap;
+}
+
 .draw-pile {
   display: flex;
   flex-direction: column;
@@ -198,6 +216,10 @@
   .direction-ring {
     width: 120px;
     height: 120px;
+  }
+  .turn-banner {
+    top: 38%;
+    font-size: 32px;
   }
 }
 

--- a/packages/client/src/styles/game.css
+++ b/packages/client/src/styles/game.css
@@ -96,6 +96,38 @@
   position: relative;
 }
 
+.draw-pile {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  z-index: 1;
+  position: relative;
+  min-width: 92px;
+}
+
+.draw-pile__hint {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  white-space: nowrap;
+  font-family: var(--font-game);
+  font-size: 13px;
+  color: var(--text-accent);
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.45);
+}
+
+.draw-pile__count {
+  font-size: 10px;
+  color: var(--text-secondary);
+}
+
+.draw-pile__count--low {
+  color: var(--color-red);
+  font-weight: bold;
+}
+
 .direction-ring {
   position: absolute;
   width: 160px;

--- a/packages/client/src/utils/playable-cards.ts
+++ b/packages/client/src/utils/playable-cards.ts
@@ -1,0 +1,40 @@
+import type { Card, Color, HouseRules } from '@uno-online/shared';
+import { getPlayableCards } from '@uno-online/shared';
+
+export function canRespondToDrawStack(card: Card, topCard: Card, houseRules?: HouseRules): boolean {
+  if (!houseRules) return false;
+
+  const canStack =
+    (houseRules.stackDrawTwo && card.type === 'draw_two' && topCard.type === 'draw_two') ||
+    (houseRules.stackDrawFour && card.type === 'wild_draw_four' && topCard.type === 'wild_draw_four') ||
+    (
+      houseRules.crossStack &&
+      (
+        (card.type === 'draw_two' && topCard.type === 'wild_draw_four') ||
+        (card.type === 'wild_draw_four' && topCard.type === 'draw_two')
+      )
+    );
+  const canDeflect =
+    (houseRules.reverseDeflectDrawTwo && card.type === 'reverse' && topCard.type === 'draw_two') ||
+    (houseRules.reverseDeflectDrawFour && card.type === 'reverse' && topCard.type === 'wild_draw_four') ||
+    (houseRules.skipDeflect && card.type === 'skip');
+
+  return canStack || canDeflect;
+}
+
+export function getPlayableCardIds(params: {
+  hand: Card[];
+  topCard?: Card;
+  currentColor: Color | null;
+  drawStack: number;
+  houseRules?: HouseRules;
+}): Set<string> {
+  const { hand, topCard, currentColor, drawStack, houseRules } = params;
+  if (!topCard || !currentColor) return new Set();
+
+  const playable = drawStack > 0
+    ? hand.filter((card) => canRespondToDrawStack(card, topCard, houseRules))
+    : getPlayableCards(hand, topCard, currentColor);
+
+  return new Set(playable.map((card) => card.id));
+}

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -6,10 +6,22 @@ export default defineConfig({
   server: {
     port: 5173,
     proxy: {
-      '/api': {
+      '/auth': {
         target: 'http://localhost:3001',
         changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/api/, ''),
+      },
+      '/profile': {
+        target: 'http://localhost:3001',
+        changeOrigin: true,
+      },
+      '/health': {
+        target: 'http://localhost:3001',
+        changeOrigin: true,
+      },
+      '/socket.io': {
+        target: 'http://localhost:3001',
+        changeOrigin: true,
+        ws: true,
       },
     },
   },

--- a/packages/server/src/game/game-session.ts
+++ b/packages/server/src/game/game-session.ts
@@ -4,6 +4,7 @@ import type { GameState, GameAction, RoomSettings } from '@uno-online/shared';
 import type { Card } from '@uno-online/shared';
 
 export interface PlayerView {
+  viewerId: string;
   phase: GameState['phase'];
   players: {
     id: string;
@@ -26,6 +27,7 @@ export interface PlayerView {
   winnerId: string | null;
   settings: GameState['settings'];
   pendingDrawPlayerId: string | null;
+  lastAction: GameState['lastAction'];
 }
 
 export interface ActionResult {
@@ -59,6 +61,7 @@ export class GameSession {
 
   getPlayerView(playerId: string): PlayerView {
     return {
+      viewerId: playerId,
       phase: this.state.phase,
       players: this.state.players.map((p) => {
         const threshold = this.state.settings.houseRules.handRevealThreshold;
@@ -87,6 +90,7 @@ export class GameSession {
       winnerId: this.state.winnerId,
       settings: this.state.settings,
       pendingDrawPlayerId: this.state.pendingDrawPlayerId,
+      lastAction: this.state.lastAction,
     };
   }
 
@@ -130,6 +134,14 @@ export class GameSession {
 
   isRoundEnd(): boolean {
     return this.state.phase === 'round_end';
+  }
+
+  forceGameOver(winnerId: string): void {
+    this.state = {
+      ...this.state,
+      phase: 'game_over',
+      winnerId,
+    };
   }
 
   startNextRound(): void {

--- a/packages/server/src/room/room-store.ts
+++ b/packages/server/src/room/room-store.ts
@@ -38,6 +38,10 @@ export async function setRoomStatus(redis: Redis, roomCode: string, status: Room
   await redis.hset(`room:${roomCode}`, 'status', status);
 }
 
+export async function setRoomSettings(redis: Redis, roomCode: string, settings: RoomSettings): Promise<void> {
+  await redis.hset(`room:${roomCode}`, 'settings', JSON.stringify(settings));
+}
+
 export async function setRoomOwner(redis: Redis, roomCode: string, ownerId: string): Promise<void> {
   await redis.hset(`room:${roomCode}`, 'ownerId', ownerId);
 }

--- a/packages/server/src/ws/game-events.ts
+++ b/packages/server/src/ws/game-events.ts
@@ -53,6 +53,29 @@ export function setGameStartTime(roomCode: string): void {
   gameStartTimes.set(roomCode, Date.now());
 }
 
+async function emitTerminalStateIfNeeded(
+  io: SocketIOServer,
+  roomCode: string,
+  session: GameSession,
+  turnTimer: TurnTimer,
+): Promise<boolean> {
+  const state = session.getFullState();
+  if (state.phase !== 'round_end' && state.phase !== 'game_over') return false;
+
+  turnTimer.stop(roomCode);
+  io.to(roomCode).emit(state.phase === 'game_over' ? 'game:over' : 'game:round_end', {
+    winnerId: state.winnerId,
+    scores: Object.fromEntries(state.players.map((p) => [p.id, p.score])),
+  });
+
+  if (state.phase === 'game_over') {
+    await persistGameResult(roomCode, session, gameStartTimes.get(roomCode) ?? Date.now());
+    gameStartTimes.delete(roomCode);
+  }
+
+  return true;
+}
+
 export function registerGameEvents(
   socket: Socket,
   io: SocketIOServer,
@@ -78,18 +101,7 @@ export function registerGameEvents(
     }
     await saveGameState(redis, roomCode, session.getFullState());
     await emitGameUpdate(io, roomCode, session);
-    const state = session.getFullState();
-    if (state.phase === 'round_end' || state.phase === 'game_over') {
-      turnTimer.stop(roomCode);
-      io.to(roomCode).emit(state.phase === 'game_over' ? 'game:over' : 'game:round_end', {
-        winnerId: state.winnerId,
-        scores: Object.fromEntries(state.players.map((p) => [p.id, p.score])),
-      });
-      if (state.phase === 'game_over') {
-        await persistGameResult(roomCode, session, gameStartTimes.get(roomCode) ?? Date.now());
-        gameStartTimes.delete(roomCode);
-      }
-    } else {
+    if (!(await emitTerminalStateIfNeeded(io, roomCode, session, turnTimer))) {
       startTurnTimer(io, redis, roomCode, session, turnTimer, sessions);
     }
     callback?.({ success: true });
@@ -135,9 +147,13 @@ export function registerGameEvents(
     const ctx = getSession(socket, sessions);
     if (!ctx) return callback?.({ success: false });
     const { session, roomCode } = ctx;
-    session.applyAction({ type: 'CALL_UNO', playerId: data.user.userId });
+    const result = session.applyAction({ type: 'CALL_UNO', playerId: data.user.userId });
+    if (!result.success) return callback?.({ success: false, error: result.error });
     await saveGameState(redis, roomCode, session.getFullState());
     await emitGameUpdate(io, roomCode, session);
+    if (await emitTerminalStateIfNeeded(io, roomCode, session, turnTimer)) {
+      return callback?.({ success: true });
+    }
     callback?.({ success: true });
   });
 
@@ -145,7 +161,8 @@ export function registerGameEvents(
     const ctx = getSession(socket, sessions);
     if (!ctx) return callback?.({ success: false });
     const { session, roomCode } = ctx;
-    session.applyAction({ type: 'CATCH_UNO', catcherId: data.user.userId, targetId: payload.targetPlayerId });
+    const result = session.applyAction({ type: 'CATCH_UNO', catcherId: data.user.userId, targetId: payload.targetPlayerId });
+    if (!result.success) return callback?.({ success: false, error: result.error });
     await saveGameState(redis, roomCode, session.getFullState());
     await emitGameUpdate(io, roomCode, session);
     callback?.({ success: true });
@@ -159,7 +176,9 @@ export function registerGameEvents(
     if (!result.success) return callback?.({ success: false, error: result.error });
     await saveGameState(redis, roomCode, session.getFullState());
     await emitGameUpdate(io, roomCode, session);
-    startTurnTimer(io, redis, roomCode, session, turnTimer, sessions);
+    if (!(await emitTerminalStateIfNeeded(io, roomCode, session, turnTimer))) {
+      startTurnTimer(io, redis, roomCode, session, turnTimer, sessions);
+    }
     callback?.({ success: true });
   });
 
@@ -171,7 +190,9 @@ export function registerGameEvents(
     if (!result.success) return callback?.({ success: false, error: result.error });
     await saveGameState(redis, roomCode, session.getFullState());
     await emitGameUpdate(io, roomCode, session);
-    startTurnTimer(io, redis, roomCode, session, turnTimer, sessions);
+    if (!(await emitTerminalStateIfNeeded(io, roomCode, session, turnTimer))) {
+      startTurnTimer(io, redis, roomCode, session, turnTimer, sessions);
+    }
     callback?.({ success: true });
   });
 
@@ -188,7 +209,9 @@ export function registerGameEvents(
     await saveGameState(redis, roomCode, session.getFullState());
     await emitGameUpdate(io, roomCode, session);
     const state = session.getFullState();
-    if (state.phase === 'challenging') {
+    if (await emitTerminalStateIfNeeded(io, roomCode, session, turnTimer)) {
+      // terminal state already emitted
+    } else if (state.phase === 'challenging') {
       turnTimer.stop(roomCode);
     } else {
       startTurnTimer(io, redis, roomCode, session, turnTimer, sessions);

--- a/packages/server/src/ws/room-events.ts
+++ b/packages/server/src/ws/room-events.ts
@@ -3,7 +3,7 @@ import type Redis from 'ioredis';
 import type { RoomSettings } from '@uno-online/shared';
 import { MIN_PLAYERS, DEFAULT_HOUSE_RULES } from '@uno-online/shared';
 import { RoomManager } from '../room/room-manager.js';
-import { getRoom, getRoomPlayers, setRoomStatus } from '../room/room-store.js';
+import { getRoom, getRoomPlayers, setRoomSettings, setRoomStatus } from '../room/room-store.js';
 import { GameSession } from '../game/game-session.js';
 import { saveGameState } from '../game/game-store.js';
 import type { TurnTimer } from '../game/turn-timer.js';
@@ -76,6 +76,36 @@ export function registerRoomEvents(
     callback?.({ success: true });
   });
 
+  socket.on('room:update_settings', async (settings: Partial<RoomSettings>, callback) => {
+    const roomCode = data.roomCode;
+    if (!roomCode) return callback?.({ success: false, error: 'Not in a room' });
+
+    const room = await getRoom(redis, roomCode);
+    if (!room) return callback?.({ success: false, error: 'Room not found' });
+    if (room.ownerId !== data.user.userId) {
+      return callback?.({ success: false, error: 'Only room owner can update settings' });
+    }
+    if (room.status !== 'waiting') {
+      return callback?.({ success: false, error: 'Game already in progress' });
+    }
+
+    const nextSettings: RoomSettings = {
+      turnTimeLimit: settings.turnTimeLimit ?? room.settings.turnTimeLimit ?? 30,
+      targetScore: settings.targetScore ?? room.settings.targetScore ?? 500,
+      houseRules: {
+        ...DEFAULT_HOUSE_RULES,
+        ...(room.settings.houseRules ?? {}),
+        ...(settings.houseRules ?? {}),
+      },
+    };
+
+    await setRoomSettings(redis, roomCode, nextSettings);
+    const players = await getRoomPlayers(redis, roomCode);
+    const updatedRoom = await getRoom(redis, roomCode);
+    io.to(roomCode).emit('room:updated', { players, room: updatedRoom });
+    callback?.({ success: true, room: updatedRoom });
+  });
+
   socket.on('game:start', async (callback) => {
     const roomCode = data.roomCode;
     if (!roomCode) return callback?.({ success: false, error: 'Not in a room' });
@@ -119,17 +149,20 @@ export function registerRoomEvents(
         const minCards = Math.min(...state.players.map(p => p.hand.length));
         const winner = state.players.find(p => p.hand.length === minCards);
         if (winner) {
+          s.forceGameOver(winner.id);
+          await saveGameState(redis, roomCode, s.getFullState());
+          await emitGameUpdate(io, roomCode, s);
           io.to(roomCode).emit('game:over', {
             winnerId: winner.id,
             reason: 'blitz_timeout',
-            scores: Object.fromEntries(state.players.map(p => [p.id, p.score])),
+            scores: Object.fromEntries(s.getFullState().players.map(p => [p.id, p.score])),
           });
           turnTimer.stop(roomCode);
         }
       }, blitzLimit * 1000);
     }
 
-    callback?.({ success: true });
+    callback?.({ success: true, gameState: session.getPlayerView(data.user.userId) });
   });
 }
 

--- a/packages/server/src/ws/socket-handler.ts
+++ b/packages/server/src/ws/socket-handler.ts
@@ -120,6 +120,7 @@ export function setupSocketHandlers(io: SocketIOServer, redis: Redis, jwtSecret:
       if (session) {
         session.setPlayerConnected(userId, true);
         await saveGameState(redis, roomCode, session.getFullState());
+        await emitGameUpdate(io, roomCode, session);
         io.to(roomCode).emit('player:reconnected', { playerId: userId });
         callback?.({ success: true, gameState: session.getPlayerView(userId) });
         const state = session.getFullState();
@@ -159,6 +160,7 @@ export function setupSocketHandlers(io: SocketIOServer, redis: Redis, jwtSecret:
       if (session) {
         session.setPlayerConnected(userId, false);
         await saveGameState(redis, roomCode, session.getFullState());
+        await emitGameUpdate(io, roomCode, session);
         io.to(roomCode).emit('player:disconnected', { playerId: userId });
 
         const state = session.getFullState();
@@ -173,7 +175,9 @@ export function setupSocketHandlers(io: SocketIOServer, redis: Redis, jwtSecret:
           const nextOwner = state.players.find(p => p.id !== userId && p.connected);
           if (nextOwner) {
             await setRoomOwner(redis, roomCode, nextOwner.id);
-            io.to(roomCode).emit('room:updated', { newOwnerId: nextOwner.id });
+            const updatedRoom = await getRoom(redis, roomCode);
+            const players = await getRoomPlayers(redis, roomCode);
+            io.to(roomCode).emit('room:updated', { players, room: updatedRoom });
           }
         }
 

--- a/packages/server/tests/game/game-session.test.ts
+++ b/packages/server/tests/game/game-session.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
+import { DEFAULT_HOUSE_RULES } from '@uno-online/shared';
 import { GameSession } from '../../src/game/game-session.js';
+import { makeCard, makeGameState, makePlayer } from '../helpers/test-utils.js';
 
 describe('GameSession', () => {
   it('initializes a game with players', () => {
@@ -22,6 +24,37 @@ describe('GameSession', () => {
     expect(view.players[1]!.hand).toEqual([]);
     expect(view.players[1]!.handCount).toBeGreaterThan(0);
     expect(view.deck).toBeUndefined();
+    expect(view.viewerId).toBe('p1');
+  });
+
+  it('only reveals opponent hands when the reveal threshold rule allows it', () => {
+    const p1Hand = [makeCard('number', 'red', { value: 1, id: 'p1c' })];
+    const p2Hand = [
+      makeCard('number', 'blue', { value: 1, id: 'p2c1' }),
+      makeCard('number', 'blue', { value: 2, id: 'p2c2' }),
+    ];
+    const state = makeGameState({
+      players: [makePlayer('p1', p1Hand), makePlayer('p2', p2Hand)],
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        houseRules: { ...DEFAULT_HOUSE_RULES, handRevealThreshold: null },
+      },
+    });
+
+    const hiddenView = GameSession.fromState(state).getPlayerView('p1');
+    expect(hiddenView.players[0]!.hand.map((c) => c.id)).toEqual(['p1c']);
+    expect(hiddenView.players[1]!.hand).toEqual([]);
+    expect(hiddenView.players[1]!.handCount).toBe(2);
+
+    const revealedView = GameSession.fromState({
+      ...state,
+      settings: {
+        ...state.settings,
+        houseRules: { ...state.settings.houseRules, handRevealThreshold: 2 },
+      },
+    }).getPlayerView('p1');
+    expect(revealedView.players[1]!.hand.map((c) => c.id)).toEqual(['p2c1', 'p2c2']);
   });
 
   it('applies a valid action', () => {

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     include: ['tests/**/*.test.ts'],
     testTimeout: 10000,
     env: {
-      REDIS_URL: 'redis://:123456@localhost:6379',
+      REDIS_URL: process.env['REDIS_URL'] ?? 'redis://localhost:6379',
     },
   },
 });

--- a/packages/shared/src/rules/game-engine.ts
+++ b/packages/shared/src/rules/game-engine.ts
@@ -28,7 +28,7 @@ function drawCards(state: GameState, playerId: string, count: number): GameState
       discardPile = reshuffled.discardPile;
     }
     if (deck.length === 0) break; // nothing left even after reshuffle
-    const card = deck.pop()!;
+    const card = deck.shift()!;
     players[playerIdx]!.hand.push(card);
   }
 
@@ -38,7 +38,7 @@ function drawCards(state: GameState, playerId: string, count: number): GameState
 /**
  * Check if a player has emptied their hand. If so, end the round.
  */
-function checkRoundEnd(state: GameState, playerId: string): GameState {
+export function checkRoundEnd(state: GameState, playerId: string): GameState {
   const player = state.players.find(p => p.id === playerId);
   if (!player || player.hand.length > 0) return state;
 
@@ -73,6 +73,30 @@ function playerIndex(state: GameState, playerId: string): number {
  */
 function currentPlayerId(state: GameState): string {
   return state.players[state.currentPlayerIndex]!.id;
+}
+
+function withChosenColorOnTopDiscard(state: GameState, color: Color): GameState {
+  const discardPile = [...state.discardPile];
+  const topCard = discardPile[discardPile.length - 1];
+
+  if (topCard?.type === 'wild' || topCard?.type === 'wild_draw_four') {
+    discardPile[discardPile.length - 1] = { ...topCard, chosenColor: color };
+  }
+
+  return { ...state, discardPile };
+}
+
+function getWildDrawFourChallengeColor(state: GameState): Color {
+  const discardLen = state.discardPile.length;
+  if (discardLen >= 2) {
+    const prevCard = state.discardPile[discardLen - 2]!;
+    if (prevCard.type === 'wild' || prevCard.type === 'wild_draw_four') {
+      return prevCard.chosenColor ?? state.currentColor ?? 'red';
+    }
+    return prevCard.color;
+  }
+
+  return state.currentColor ?? 'red';
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -262,23 +286,36 @@ function handleChooseColor(
   if (state.phase !== 'choosing_color') return state;
   if (action.playerId !== currentPlayerId(state)) return state;
 
-  if (state.pendingDrawPlayerId !== null) {
+  const colorState = withChosenColorOnTopDiscard(state, action.color);
+
+  if (colorState.pendingDrawPlayerId !== null) {
     // wild_draw_four: move to challenging phase
     return {
-      ...state,
+      ...colorState,
       currentColor: action.color,
       phase: 'challenging',
       lastAction: action,
     };
   } else {
+    const actingPlayerId = currentPlayerId(colorState);
+    if (colorState.lastAction?.type === 'PLAY_CARD') {
+      const endedState = checkRoundEnd(
+        { ...colorState, currentColor: action.color, lastAction: action },
+        actingPlayerId,
+      );
+      if (endedState.phase === 'round_end' || endedState.phase === 'game_over') {
+        return endedState;
+      }
+    }
+
     // plain wild: advance to next player and return to playing
     const newIndex = getNextPlayerIndex(
-      state.currentPlayerIndex,
-      state.players.length,
-      state.direction,
+      colorState.currentPlayerIndex,
+      colorState.players.length,
+      colorState.direction,
     );
     return {
-      ...state,
+      ...colorState,
       currentColor: action.color,
       phase: 'playing',
       currentPlayerIndex: newIndex,
@@ -299,20 +336,7 @@ function handleChallenge(
   const wd4Player = state.players[wd4PlayerIdx]!;
   const challengerIdx = playerIndex(state, action.playerId);
 
-  // The previous top card (before the WD4) tells us what color was active
-  // The WD4 is now on top of the discard pile
-  // The card before WD4 determines the color that was in play
-  const discardLen = state.discardPile.length;
-  // At this point discardPile has [..., prev_top, wd4_card]
-  // We need the color that was active BEFORE the WD4 was played
-  // That is the color of the card just below the WD4
-  let prevColor: Color = state.currentColor ?? 'red';
-  if (discardLen >= 2) {
-    const prevCard = state.discardPile[discardLen - 2]!;
-    if (prevCard.type !== 'wild' && prevCard.type !== 'wild_draw_four') {
-      prevColor = prevCard.color;
-    }
-  }
+  const prevColor = getWildDrawFourChallengeColor(state);
 
   // Check legality: was WD4 valid given the player's hand (minus the WD4 itself)?
   // The player's current hand represents what they had after playing WD4 (minus WD4)
@@ -323,13 +347,16 @@ function handleChallenge(
     let newState = drawCards(state, action.playerId, 6);
     // Advance past the challenger
     const nextIdx = getNextPlayerIndex(challengerIdx, state.players.length, state.direction);
-    return {
+    newState = {
       ...newState,
       phase: 'playing',
       currentPlayerIndex: nextIdx,
       pendingDrawPlayerId: null,
       lastAction: action,
     };
+    return state.lastAction?.type === 'CHOOSE_COLOR'
+      ? checkRoundEnd(newState, wd4Player.id)
+      : newState;
   } else {
     // Challenge succeeds: WD4 player draws 4
     let newState = drawCards(state, wd4Player.id, 4);
@@ -352,18 +379,22 @@ function handleAccept(
   if (state.phase !== 'challenging') return state;
   if (action.playerId !== state.pendingDrawPlayerId) return state;
 
+  const wd4PlayerId = currentPlayerId(state);
   const accepterIdx = playerIndex(state, action.playerId);
   // Accepter draws 4
   let newState = drawCards(state, action.playerId, 4);
   // Advance past the accepter
   const nextIdx = getNextPlayerIndex(accepterIdx, state.players.length, state.direction);
-  return {
+  newState = {
     ...newState,
     phase: 'playing',
     currentPlayerIndex: nextIdx,
     pendingDrawPlayerId: null,
     lastAction: action,
   };
+  return state.lastAction?.type === 'CHOOSE_COLOR'
+    ? checkRoundEnd(newState, wd4PlayerId)
+    : newState;
 }
 
 function handleCallUno(
@@ -374,8 +405,8 @@ function handleCallUno(
   if (idx === -1) return state;
 
   const player = state.players[idx]!;
-  // Only valid with <= 2 cards
-  if (player.hand.length > 2) return state;
+  // A player may call before or after playing down to one card, but not at zero.
+  if (player.hand.length < 1 || player.hand.length > 2) return state;
 
   const players = state.players.map((p, i) =>
     i === idx ? { ...p, calledUno: true } : p

--- a/packages/shared/src/rules/house-rules-engine.ts
+++ b/packages/shared/src/rules/house-rules-engine.ts
@@ -1,7 +1,7 @@
 import type { GameState, GameAction } from '../types/game.js';
 import type { Card } from '../types/card.js';
 import { isWildCard } from '../types/card.js';
-import { applyAction } from './game-engine.js';
+import { applyAction, checkRoundEnd } from './game-engine.js';
 import { canPlayCard } from './validation.js';
 import { reshuffleDiscardIntoDeck } from './deck.js';
 import { getNextPlayerIndex } from './turn.js';
@@ -51,6 +51,52 @@ function isWildType(card: Card): boolean {
  *  (draw_two and wild_draw_four). */
 function isFunctionCard(card: Card): boolean {
   return card.type === 'draw_two' || card.type === 'wild_draw_four';
+}
+
+function getCardDrawPenalty(card: Card): number {
+  if (card.type === 'draw_two') return 2;
+  if (card.type === 'wild_draw_four') return 4;
+  return 0;
+}
+
+function canStartDrawStack(state: GameState, card: Card): boolean {
+  const hr = state.settings.houseRules;
+  if (card.type === 'draw_two') {
+    return hr.stackDrawTwo || hr.crossStack;
+  }
+  if (card.type === 'wild_draw_four') {
+    return hr.stackDrawFour || hr.crossStack;
+  }
+  return false;
+}
+
+function putAttackCardOnStack(
+  state: GameState,
+  action: Extract<GameAction, { type: 'PLAY_CARD' }>,
+  card: Card,
+  stackAdd: number,
+): GameState {
+  const player = state.players[state.currentPlayerIndex]!;
+  const newHand = player.hand.filter(c => c.id !== action.cardId);
+  const playedCard =
+    card.type === 'wild_draw_four' && action.chosenColor
+      ? { ...card, chosenColor: action.chosenColor }
+      : card;
+  const players = state.players.map((p, i) =>
+    i === state.currentPlayerIndex ? { ...p, hand: newHand, calledUno: false } : p,
+  );
+  const nextIdx = getNextPlayerIndex(state.currentPlayerIndex, players.length, state.direction);
+  const newColor = card.type === 'draw_two' ? card.color : (action.chosenColor ?? state.currentColor);
+
+  return {
+    ...state,
+    players,
+    discardPile: [...state.discardPile, playedCard],
+    currentColor: newColor,
+    drawStack: state.drawStack + stackAdd,
+    currentPlayerIndex: nextIdx,
+    lastAction: action,
+  };
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -255,6 +301,10 @@ export function applyActionWithHouseRules(state: GameState, action: GameAction):
 
   // ── misplayPenalty or blindDraw: invalid PLAY_CARD draws 1 penalty card ───────────────
   if (action.type === 'PLAY_CARD' && (hr.misplayPenalty || hr.blindDraw)) {
+    const currentPlayer = state.players[state.currentPlayerIndex];
+    if (state.phase !== 'playing' || currentPlayer?.id !== action.playerId) {
+      return state;
+    }
     const standardResult = applyAction(state, action);
     if (standardResult === state) {
       return drawCardsFromDeck(state, action.playerId, 1);
@@ -323,32 +373,40 @@ export function applyActionWithHouseRules(state: GameState, action: GameAction):
       (hr.stackDrawFour && card.type === 'wild_draw_four' && topCard?.type === 'wild_draw_four') ||
       (hr.crossStack && ((card.type === 'draw_two' && topCard?.type === 'wild_draw_four') || (card.type === 'wild_draw_four' && topCard?.type === 'draw_two')));
     if (canStack) {
-      const newHand = player.hand.filter(c => c.id !== action.cardId);
-      const stackAdd = card.type === 'draw_two' ? 2 : 4;
-      const players = state.players.map((p, i) =>
-        i === state.currentPlayerIndex ? { ...p, hand: newHand } : p,
-      );
-      const nextIdx = getNextPlayerIndex(state.currentPlayerIndex, players.length, state.direction);
-      const newColor = card.type === 'draw_two' ? card.color : (action.chosenColor ?? state.currentColor);
-      return {
-        ...state,
-        players,
-        discardPile: [...state.discardPile, card],
-        currentColor: newColor,
-        drawStack: state.drawStack + stackAdd,
-        currentPlayerIndex: nextIdx,
-        lastAction: action,
-      };
+      return putAttackCardOnStack(state, action, card, getCardDrawPenalty(card));
     }
   }
 
   // ── Stacking: intercept DRAW_CARD when drawStack > 0 ─────────────────────
+  // Start a draw stack from the first +2/+4 when stacking is enabled.
+  if (action.type === 'PLAY_CARD' && state.drawStack === 0 && state.phase === 'playing') {
+    const player = state.players[state.currentPlayerIndex];
+    if (player?.id === action.playerId) {
+      const card = player.hand.find(c => c.id === action.cardId);
+      const topCard = state.discardPile[state.discardPile.length - 1];
+      if (
+        card &&
+        topCard &&
+        state.currentColor &&
+        canStartDrawStack(state, card) &&
+        canPlayCard(card, topCard, state.currentColor)
+      ) {
+        return putAttackCardOnStack(state, action, card, getCardDrawPenalty(card));
+      }
+    }
+  }
+
+  // Resolve an active draw stack when the target player draws.
   if (action.type === 'DRAW_CARD' && state.drawStack > 0 && (hr.stackDrawTwo || hr.stackDrawFour || hr.crossStack)) {
     const player = state.players[state.currentPlayerIndex];
     if (!player || player.id !== action.playerId) return state;
     let newState = drawCardsFromDeck(state, action.playerId, state.drawStack);
     const nextIdx = getNextPlayerIndex(newState.currentPlayerIndex, newState.players.length, newState.direction);
-    return { ...newState, drawStack: 0, currentPlayerIndex: nextIdx, lastAction: action };
+    newState = { ...newState, drawStack: 0, currentPlayerIndex: nextIdx, lastAction: action };
+    if (state.lastAction?.type === 'PLAY_CARD') {
+      return applyDoubleScore(state, checkRoundEnd(newState, state.lastAction.playerId));
+    }
+    return newState;
   }
 
   // ── drawUntilPlayable: override DRAW_CARD behaviour ──────────────────────

--- a/packages/shared/tests/game-engine.test.ts
+++ b/packages/shared/tests/game-engine.test.ts
@@ -258,6 +258,24 @@ describe('DRAW_CARD', () => {
     const next = applyAction(state, action);
     expect(next.lastAction).toStrictEqual(action);
   });
+
+  it('draws from the top/front of the deck', () => {
+    const firstCard = makeCard('number', 'blue', { value: 3, id: 'd1' });
+    const secondCard = makeCard('number', 'green', { value: 4, id: 'd2' });
+    const state = makeState({
+      players: [
+        { id: 'p1', name: 'Alice', hand: [], score: 0, connected: true, calledUno: false },
+        { id: 'p2', name: 'Bob', hand: [], score: 0, connected: true, calledUno: false },
+        { id: 'p3', name: 'Carol', hand: [], score: 0, connected: true, calledUno: false },
+      ],
+      deck: [firstCard, secondCard],
+    });
+
+    const next = applyAction(state, { type: 'DRAW_CARD', playerId: 'p1' });
+
+    expect(next.players[0]!.hand[0]!.id).toBe('d1');
+    expect(next.deck.map(c => c.id)).toEqual(['d2']);
+  });
 });
 
 describe('DRAW_CARD - wrong player', () => {
@@ -347,6 +365,25 @@ describe('CHOOSE_COLOR', () => {
     expect(next.phase).toBe('challenging');
     expect(next.currentColor).toBe('green');
   });
+
+  it('ends the round after the last plain wild color is chosen', () => {
+    const wild = makeCard('wild', null, { id: 'wild_last' });
+    const state = makeState({
+      players: [
+        { id: 'p1', name: 'Alice', hand: [wild], score: 0, connected: true, calledUno: false },
+        { id: 'p2', name: 'Bob', hand: [makeCard('number', 'blue', { value: 4, id: 'p2c' })], score: 0, connected: true, calledUno: false },
+        { id: 'p3', name: 'Carol', hand: [makeCard('number', 'green', { value: 6, id: 'p3c' })], score: 0, connected: true, calledUno: false },
+      ],
+    });
+
+    const afterPlay = applyAction(state, { type: 'PLAY_CARD', playerId: 'p1', cardId: 'wild_last' });
+    const afterColor = applyAction(afterPlay, { type: 'CHOOSE_COLOR', playerId: 'p1', color: 'blue' });
+
+    expect(afterColor.phase).toBe('round_end');
+    expect(afterColor.winnerId).toBe('p1');
+    expect(afterColor.currentColor).toBe('blue');
+    expect(afterColor.discardPile.at(-1)).toMatchObject({ id: 'wild_last', chosenColor: 'blue' });
+  });
 });
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -424,6 +461,38 @@ describe('CHALLENGE - WD4 was illegal (challenge wins)', () => {
     expect(next.phase).toBe('playing');
     expect(next.pendingDrawPlayerId).toBeNull();
   });
+
+  it('uses the previous wild card chosen color when checking legality', () => {
+    const deckCards = Array.from({ length: 10 }, (_, i) =>
+      makeCard('number', 'blue', { value: i % 9, id: `d${i}` })
+    );
+    const state = makeState({
+      phase: 'challenging',
+      players: [
+        {
+          id: 'p1', name: 'Alice',
+          hand: [makeCard('number', 'red', { value: 3, id: 'p1_red' })],
+          score: 0, connected: true, calledUno: false
+        },
+        { id: 'p2', name: 'Bob', hand: [], score: 0, connected: true, calledUno: false },
+        { id: 'p3', name: 'Carol', hand: [], score: 0, connected: true, calledUno: false },
+      ],
+      currentPlayerIndex: 0,
+      currentColor: 'green',
+      pendingDrawPlayerId: 'p2',
+      deck: deckCards,
+      discardPile: [
+        { id: 'prev_wild', type: 'wild', color: null, chosenColor: 'red' },
+        makeCard('wild_draw_four', null, { id: 'wd4_card' }),
+      ],
+    });
+
+    const next = applyAction(state, { type: 'CHALLENGE', playerId: 'p2' });
+
+    expect(next.players[0]!.hand).toHaveLength(5);
+    expect(next.players[1]!.hand).toHaveLength(0);
+    expect(next.phase).toBe('playing');
+  });
 });
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -460,6 +529,29 @@ describe('ACCEPT', () => {
     });
     const next = applyAction(state, { type: 'ACCEPT', playerId: 'p3' });
     expect(next).toStrictEqual(state);
+  });
+
+  it('ends the round after accepting the penalty from a last-card wild draw four', () => {
+    const wd4 = makeCard('wild_draw_four', null, { id: 'wd4_last' });
+    const deckCards = Array.from({ length: 6 }, (_, i) =>
+      makeCard('number', 'blue', { value: i % 9, id: `d${i}` })
+    );
+    const state = makeState({
+      players: [
+        { id: 'p1', name: 'Alice', hand: [wd4], score: 0, connected: true, calledUno: false },
+        { id: 'p2', name: 'Bob', hand: [makeCard('number', 'yellow', { value: 4, id: 'p2c' })], score: 0, connected: true, calledUno: false },
+        { id: 'p3', name: 'Carol', hand: [makeCard('number', 'green', { value: 2, id: 'p3c' })], score: 0, connected: true, calledUno: false },
+      ],
+      deck: deckCards,
+    });
+
+    const afterPlay = applyAction(state, { type: 'PLAY_CARD', playerId: 'p1', cardId: 'wd4_last' });
+    const afterColor = applyAction(afterPlay, { type: 'CHOOSE_COLOR', playerId: 'p1', color: 'green' });
+    const afterAccept = applyAction(afterColor, { type: 'ACCEPT', playerId: 'p2' });
+
+    expect(afterAccept.phase).toBe('round_end');
+    expect(afterAccept.winnerId).toBe('p1');
+    expect(afterAccept.players[1]!.hand).toHaveLength(5);
   });
 });
 
@@ -521,6 +613,20 @@ describe('CALL_UNO', () => {
     });
     const next = applyAction(state, { type: 'CALL_UNO', playerId: 'p1' });
     expect(next.players[0]!.calledUno).toBe(false);
+  });
+
+  it('does not set flag for a player with no cards', () => {
+    const state = makeState({
+      players: [
+        { id: 'p1', name: 'Alice', hand: [], score: 0, connected: true, calledUno: false },
+        { id: 'p2', name: 'Bob', hand: [], score: 0, connected: true, calledUno: false },
+        { id: 'p3', name: 'Carol', hand: [], score: 0, connected: true, calledUno: false },
+      ],
+    });
+
+    const next = applyAction(state, { type: 'CALL_UNO', playerId: 'p1' });
+
+    expect(next).toStrictEqual(state);
   });
 });
 

--- a/packages/shared/tests/house-rules-remaining.test.ts
+++ b/packages/shared/tests/house-rules-remaining.test.ts
@@ -44,6 +44,31 @@ function makeState(overrides: Partial<GameState> = {}): GameState {
 // ──────────────────────────────────────────────────────────────────────────────
 
 describe('stackDrawTwo', () => {
+  it('starts a draw stack when the first +2 is played', () => {
+    const d2Play = makeCard('draw_two', 'red', { id: 'd2play' });
+    const extra = makeCard('number', 'red', { value: 1, id: 'extra' });
+    const state = makeState({
+      drawStack: 0,
+      players: [
+        { id: 'p1', name: 'Alice', hand: [d2Play, extra], score: 0, connected: true, calledUno: false },
+        { id: 'p2', name: 'Bob', hand: [makeCard('draw_two', 'blue', { id: 'p2d2' })], score: 0, connected: true, calledUno: false },
+        { id: 'p3', name: 'Carol', hand: [makeCard('number', 'green', { value: 2, id: 'p3c' })], score: 0, connected: true, calledUno: false },
+      ],
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        houseRules: { ...DEFAULT_HOUSE_RULES, stackDrawTwo: true },
+      },
+    });
+
+    const next = applyActionWithHouseRules(state, { type: 'PLAY_CARD', playerId: 'p1', cardId: 'd2play' });
+
+    expect(next.drawStack).toBe(2);
+    expect(next.players[1]!.hand).toHaveLength(1);
+    expect(next.currentPlayerIndex).toBe(1);
+    expect(next.discardPile[next.discardPile.length - 1]!.id).toBe('d2play');
+  });
+
   it('+2 stacks on +2: drawStack increases by 2 and turn advances', () => {
     const d2Top = makeCard('draw_two', 'red', { id: 'd2top' });
     const d2Play = makeCard('draw_two', 'red', { id: 'd2play' });
@@ -132,6 +157,36 @@ describe('stackDrawTwo', () => {
     // Turn advances to p2
     expect(next.currentPlayerIndex).toBe(1);
   });
+
+  it('ends the round after a last-card stack is paid', () => {
+    const d2Top = makeCard('draw_two', 'red', { id: 'd2top' });
+    const deck = Array.from({ length: 10 }, (_, i) => makeCard('number', 'blue', { value: i % 10, id: `d${i}` }));
+    const state = makeState({
+      discardPile: [makeCard('number', 'red', { value: 1, id: 'base' }), d2Top],
+      currentColor: 'red',
+      currentPlayerIndex: 0,
+      drawStack: 2,
+      deck,
+      lastAction: { type: 'PLAY_CARD', playerId: 'p2', cardId: 'd2top' },
+      players: [
+        { id: 'p1', name: 'Alice', hand: [makeCard('number', 'blue', { value: 1, id: 'p1c' })], score: 0, connected: true, calledUno: false },
+        { id: 'p2', name: 'Bob', hand: [], score: 0, connected: true, calledUno: false },
+        { id: 'p3', name: 'Carol', hand: [makeCard('number', 'green', { value: 2, id: 'p3c' })], score: 0, connected: true, calledUno: false },
+      ],
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        houseRules: { ...DEFAULT_HOUSE_RULES, stackDrawTwo: true },
+      },
+    });
+
+    const next = applyActionWithHouseRules(state, { type: 'DRAW_CARD', playerId: 'p1' });
+
+    expect(next.phase).toBe('round_end');
+    expect(next.winnerId).toBe('p2');
+    expect(next.drawStack).toBe(0);
+    expect(next.players[0]!.hand).toHaveLength(3);
+  });
 });
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -139,6 +194,40 @@ describe('stackDrawTwo', () => {
 // ──────────────────────────────────────────────────────────────────────────────
 
 describe('stackDrawFour', () => {
+  it('starts a draw stack when the first +4 is played', () => {
+    const wd4Play = makeCard('wild_draw_four', null, { id: 'wd4play' });
+    const extra = makeCard('number', 'blue', { value: 1, id: 'extra' });
+    const state = makeState({
+      drawStack: 0,
+      players: [
+        { id: 'p1', name: 'Alice', hand: [wd4Play, extra], score: 0, connected: true, calledUno: false },
+        { id: 'p2', name: 'Bob', hand: [makeCard('wild_draw_four', null, { id: 'p2wd4' })], score: 0, connected: true, calledUno: false },
+        { id: 'p3', name: 'Carol', hand: [makeCard('number', 'green', { value: 2, id: 'p3c' })], score: 0, connected: true, calledUno: false },
+      ],
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        houseRules: { ...DEFAULT_HOUSE_RULES, stackDrawFour: true },
+      },
+    });
+
+    const next = applyActionWithHouseRules(state, {
+      type: 'PLAY_CARD',
+      playerId: 'p1',
+      cardId: 'wd4play',
+      chosenColor: 'blue',
+    });
+
+    expect(next.drawStack).toBe(4);
+    expect(next.currentColor).toBe('blue');
+    expect(next.players[1]!.hand).toHaveLength(1);
+    expect(next.currentPlayerIndex).toBe(1);
+    expect(next.discardPile[next.discardPile.length - 1]).toMatchObject({
+      id: 'wd4play',
+      chosenColor: 'blue',
+    });
+  });
+
   it('+4 stacks on +4: drawStack increases by 4', () => {
     const wd4Top = makeCard('wild_draw_four', null, { id: 'wd4top' });
     const wd4Play = makeCard('wild_draw_four', null, { id: 'wd4play' });
@@ -507,6 +596,31 @@ describe('misplayPenalty', () => {
     // Card was played — p1 has 1 card (the extra), not penalized
     expect(next.players[0]!.hand).toHaveLength(1);
     expect(next.discardPile[next.discardPile.length - 1]!.id).toBe('valid');
+  });
+
+  it('does NOT penalize an out-of-turn invalid play attempt', () => {
+    const invalidCard = makeCard('number', 'blue', { value: 7, id: 'invalid' });
+    const deck = [makeCard('number', 'green', { value: 1, id: 'd1' })];
+    const state = makeState({
+      currentPlayerIndex: 0,
+      currentColor: 'red',
+      discardPile: [makeCard('number', 'red', { value: 5, id: 'top' })],
+      deck,
+      players: [
+        { id: 'p1', name: 'Alice', hand: [makeCard('number', 'red', { value: 1, id: 'p1c' })], score: 0, connected: true, calledUno: false },
+        { id: 'p2', name: 'Bob', hand: [invalidCard], score: 0, connected: true, calledUno: false },
+        { id: 'p3', name: 'Carol', hand: [], score: 0, connected: true, calledUno: false },
+      ],
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        houseRules: { ...DEFAULT_HOUSE_RULES, misplayPenalty: true },
+      },
+    });
+
+    const next = applyActionWithHouseRules(state, { type: 'PLAY_CARD', playerId: 'p2', cardId: 'invalid' });
+
+    expect(next).toStrictEqual(state);
   });
 });
 


### PR DESCRIPTION
## 修复内容

本 PR 对 UNO 游戏过程中的规则逻辑、前后端状态同步和手牌显示安全性做了一轮修复。

### 游戏规则逻辑

- 修复摸牌方向不一致问题，标准摸牌现在与发牌/村规摸牌一样从牌堆顶部抽取。
- 修复万能牌选色后未写入弃牌顶牌的问题，后续匹配颜色和 +4 质疑会使用正确颜色。
- 修复 +4 质疑时遇到上一张也是万能牌时没有使用上一张 `chosenColor` 的问题。
- 修复最后一张普通万能牌、最后一张 +4 在选色/接受/质疑流程后不能正确结束回合的问题。
- 修复 0 张手牌时仍能喊 UNO 的问题。
- 修复叠加罚牌规则第一次打出 +2/+4 时没有启动 `drawStack` 的问题。
- 修复叠加罚牌结算后，如果攻击方已经出完最后一张牌，回合不会结束的问题。
- 修复误操作惩罚会惩罚非当前玩家非法出牌的问题。

### 前后端状态同步

- 新增 `viewerId` 到服务端玩家视图，前端不再只依赖 auth store 判断当前玩家。
- 修复页面刷新/认证信息短暂未恢复时，自己的手牌可能被渲染到对手区域，导致看起来像“看到别人手牌”或自己无法出牌的问题。
- 修复摸牌后 `game:update` 重置本地 `hasDrawnThisTurn`，导致摸完不能跳过的问题。
- 修复断线/重连只广播事件、不同步玩家 connected 状态的问题。
- 修复游戏开始回调可能错过 `game:state`，导致开始游戏后偶尔页面显示不出来的问题。
- 修复房间村规设置前端发送但服务端未持久化的问题。
- 修复部分无效 `CALL_UNO` / `CATCH_UNO` 动作服务端仍返回成功的问题。
- 统一动作后终局/回合结束广播，避免选色、接受/质疑 +4、叠加罚牌结算后计时器和 UI 状态不同步。
- 修复闪电模式超时只发事件但不写入 `game_over` 状态的问题。

### 前端出牌判断

- 修复 `noHints` 开启后合法牌也不能点击的问题，现在只隐藏高亮，不禁用合法出牌。
- 修复 `drawStack > 0` 时前端仍按普通规则判断可出牌的问题，现在只允许合法叠加/反弹/跳过响应。
- 为卡牌组件拆分 `playable` 和 `clickable`，避免“是否高亮”和“是否允许点击”耦合。

### 手牌显示安全性

- 服务端仍只通过 `getPlayerView(userId)` 向每个 socket 发送个人视图。
- 默认情况下对手 `hand` 为空，只发送 `handCount`。
- 只有开启村规 `handRevealThreshold` 时，才会按规则公开低于阈值的对手手牌。
- 新增测试覆盖默认隐藏对手手牌与阈值公开逻辑。

## 验证

- `pnpm --filter @uno-online/shared test` 通过：179 tests
- `pnpm --filter @uno-online/shared build` 通过
- `pnpm --filter @uno-online/client build` 通过
- `pnpm --filter @uno-online/server build` 通过
- `pnpm --filter @uno-online/server test` 中本次相关的 `game-session` 测试通过；全量测试受本地环境影响失败：Redis 未连接、mediasoup worker 二进制缺失。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added spectator/viewer mode support to observe ongoing games.
  * Integrated house rules system for customizable gameplay.
  * Enabled room settings updates while waiting.
  * Relaxed UNO call rules to allow calling when holding 1-2 cards.

* **Bug Fixes**
  * Real-time state synchronization on reconnection and disconnection.

* **Gameplay Updates**
  * Cards now drawn from the top of the deck with automatic reshuffling.
  * Improved terminal game state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->