### PR TITLE
修复观战会话恢复构建

### DIFF
--- a/packages/server/src/plugins/core/spectate/ws.ts
+++ b/packages/server/src/plugins/core/spectate/ws.ts
@@ -2,7 +2,7 @@ import type { Server as SocketIOServer } from 'socket.io';
 import type { KvStore } from '../../../kv/types';
 import type { SocketData } from '../../../ws/types';
 import { deleteRoom, getRoom } from '../room/store';
-import type { GameSession } from '../game/session';
+import { GameSession } from '../game/session';
 import { loadGameState } from '../game/state-store';
 
 export function setupSpectateHandlers(


### PR DESCRIPTION
## Summary
- 修复观战 WS 恢复已保存会话时的 `GameSession` 运行时导入。
- 解决最新 `main` 上 server `tsc` 的 TS1361 构建失败。

## Tests
- `pnpm build`