### PR TITLE
添加严格 UNO 喊牌村规

### DIFF
--- a/packages/client/src/features/game/components/GameActions.tsx
+++ b/packages/client/src/features/game/components/GameActions.tsx
@@ -25,7 +25,10 @@ export default function GameActions({ onCallUno, onCatchUno, onChallenge, onAcce
 
   const me = players.find((p) => p.id === userId);
   const isMyTurn = useIsMyTurn();
-  const canCallUno = me && me.hand.length >= 1 && me.hand.length <= 2 && !me.calledUno;
+  const strictUnoCall = settings?.houseRules?.strictUnoCall ?? false;
+  const canCallUno = me && !me.calledUno && (
+    strictUnoCall ? me.hand.length === 1 : me.hand.length >= 1 && me.hand.length <= 2
+  );
   const catchTargets = players.filter((p) => p.id !== userId && p.handCount === 1 && !p.calledUno && !p.unoCaught);
   const noChallengeWD4 = settings?.houseRules?.noChallengeWildFour ?? false;
   const playableIds = usePlayableCardIds();

--- a/packages/shared/src/constants/house-rules.ts
+++ b/packages/shared/src/constants/house-rules.ts
@@ -22,6 +22,7 @@ export const HOUSE_RULE_DEFINITIONS: HouseRuleDefinition[] = [
   { key: 'forcedPlayAfterDraw', label: '摸牌后必须出', description: '摸到可出的牌时强制打出' },
   { key: 'forcedPlay', label: '强制出牌', description: '有能出的牌就必须出' },
   { key: 'unoPenaltyCount', label: 'UNO 罚摸数量', description: '不喊 UNO 被抓罚摸张数' },
+  { key: 'strictUnoCall', label: '严格 UNO 喊牌', description: '只能在手牌剩 1 张时喊 UNO' },
   { key: 'misplayPenalty', label: '误操作惩罚', description: '出非法牌罚摸 1 张' },
   { key: 'silentUno', label: '静默 UNO', description: '取消 UNO 喊话机制' },
   { key: 'noFunctionCardFinish', label: '空手赢不算', description: '最后一张不能是 +2/+4' },

--- a/packages/shared/src/rules/game-engine.ts
+++ b/packages/shared/src/rules/game-engine.ts
@@ -455,7 +455,11 @@ function handleCallUno(
   if (idx === -1) return state;
 
   const player = state.players[idx]!;
-  if (player.hand.length < 1 || player.hand.length > 2) return state;
+  const strictUnoCall = state.settings.houseRules?.strictUnoCall ?? false;
+  const canCallUno = strictUnoCall
+    ? player.hand.length === 1
+    : player.hand.length >= 1 && player.hand.length <= 2;
+  if (!canCallUno) return state;
 
   const players = state.players.map((p, i) =>
     i === idx ? { ...p, calledUno: true, unoCaught: false } : p

--- a/packages/shared/src/types/house-rules.ts
+++ b/packages/shared/src/types/house-rules.ts
@@ -16,6 +16,7 @@ export interface HouseRules {
   forcedPlay: boolean;
   handRevealThreshold: number | null;
   unoPenaltyCount: 2 | 4 | 6;
+  strictUnoCall: boolean;
   misplayPenalty: boolean;
   deathDraw: boolean;
   fastMode: boolean;
@@ -51,6 +52,7 @@ export const DEFAULT_HOUSE_RULES: HouseRules = {
   forcedPlay: false,
   handRevealThreshold: null,
   unoPenaltyCount: 2,
+  strictUnoCall: false,
   misplayPenalty: false,
   deathDraw: false,
   fastMode: false,

--- a/packages/shared/tests/game-engine.test.ts
+++ b/packages/shared/tests/game-engine.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { applyAction } from '../src/rules/game-engine';
 import type { GameState, Player } from '../src/types/game';
 import type { Card, Color } from '../src/types/card';
+import { DEFAULT_HOUSE_RULES } from '../src/types/house-rules';
 
 function makeCard(type: Card['type'], color: Color | null, extra?: { value?: number; id?: string }): Card {
   const id = extra?.id ?? `card_${Math.random().toString(36).slice(2, 8)}`;
@@ -602,7 +603,7 @@ describe('CALL_UNO', () => {
     expect(next.players[0]!.calledUno).toBe(true);
   });
 
-  it('sets calledUno flag for player with 2 cards', () => {
+  it('sets calledUno flag for player with 2 cards by default', () => {
     const state = makeState({
       players: [
         {
@@ -619,6 +620,32 @@ describe('CALL_UNO', () => {
     });
     const next = applyAction(state, { type: 'CALL_UNO', playerId: 'p1' });
     expect(next.players[0]!.calledUno).toBe(true);
+  });
+
+  it('does not set calledUno flag for player with 2 cards in strict UNO mode', () => {
+    const state = makeState({
+      players: [
+        {
+          id: 'p1', name: 'Alice',
+          hand: [
+            makeCard('number', 'red', { value: 1, id: 'c1' }),
+            makeCard('number', 'blue', { value: 2, id: 'c2' }),
+          ],
+          score: 0, connected: true, calledUno: false
+        },
+        { id: 'p2', name: 'Bob', hand: [], score: 0, connected: true, calledUno: false },
+        { id: 'p3', name: 'Carol', hand: [], score: 0, connected: true, calledUno: false },
+      ],
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        houseRules: { ...DEFAULT_HOUSE_RULES, strictUnoCall: true },
+      },
+    });
+
+    const next = applyAction(state, { type: 'CALL_UNO', playerId: 'p1' });
+
+    expect(next.players[0]!.calledUno).toBe(false);
   });
 
   it('does not set flag for player with more than 2 cards', () => {


### PR DESCRIPTION
## Summary
- Add a strictUnoCall house rule for rooms that only allow calling UNO with exactly one card.
- Keep the default behavior allowing UNO calls with one or two cards.
- Apply the rule consistently in both server action validation and the client call-UNO button.

## Validation
- pnpm --filter shared test
- pnpm --filter shared build
- pnpm --filter client build