### PR TITLE
feat: 添加按钮点击音效反馈

### DIFF
--- a/packages/client/src/features/auth/pages/AuthCallback.tsx
+++ b/packages/client/src/features/auth/pages/AuthCallback.tsx
@@ -60,7 +60,7 @@ export default function AuthCallback() {
             className="w-full rounded-xl border-2 border-white/15 bg-card px-3.5 py-2.5 text-base text-foreground"
             autoFocus autoComplete="current-password" />
           {error && <p className="text-sm text-destructive m-0">{error}</p>}
-          <Button type="submit" variant="primary" disabled={submitting}>
+          <Button type="submit" variant="primary" disabled={submitting} sound="click">
             <LogIn size={18} className="inline-block align-middle mr-1.5" />
             {submitting ? '绑定中...' : '确认绑定'}
           </Button>

--- a/packages/client/src/features/auth/pages/HomePage.tsx
+++ b/packages/client/src/features/auth/pages/HomePage.tsx
@@ -105,7 +105,7 @@ export default function HomePage() {
                 inputSize="lg"
                 className="w-dev-input text-center"
               />
-              <Button variant="primary" className="px-6 py-3 text-lg" onClick={handleDevLogin}>
+              <Button variant="primary" className="px-6 py-3 text-lg" onClick={handleDevLogin} sound="click">
                 <LogIn size={20} className="mr-1.5 inline-block align-middle" />登录
               </Button>
             </div>
@@ -128,7 +128,7 @@ export default function HomePage() {
                 autoComplete="current-password"
               />
               {error && <p className="text-sm text-destructive m-0">{error}</p>}
-              <Button type="submit" variant="primary" disabled={loggingIn}>
+              <Button type="submit" variant="primary" disabled={loggingIn} sound="click">
                 <LogIn size={18} className="inline-block align-middle mr-1.5" />
                 {loggingIn ? '登录中...' : '登录'}
               </Button>

--- a/packages/client/src/features/auth/pages/ProfileSetupPage.tsx
+++ b/packages/client/src/features/auth/pages/ProfileSetupPage.tsx
@@ -66,7 +66,7 @@ export default function ProfileSetupPage() {
 
         {error && <p className="text-sm text-destructive m-0">{error}</p>}
 
-        <Button variant="primary" className="w-full" onClick={handleSave} disabled={submitting}>
+        <Button variant="primary" className="w-full" onClick={handleSave} disabled={submitting} sound="click">
           <Check size={18} className="inline-block align-middle mr-1.5" />
           {submitting ? '保存中...' : '确认'}
         </Button>

--- a/packages/client/src/features/auth/pages/RegisterPage.tsx
+++ b/packages/client/src/features/auth/pages/RegisterPage.tsx
@@ -49,7 +49,7 @@ export default function RegisterPage() {
 
         {error && <p className="text-sm text-destructive m-0">{error}</p>}
 
-        <Button type="submit" variant="primary" className="w-full" disabled={submitting}>
+        <Button type="submit" variant="primary" className="w-full" disabled={submitting} sound="click">
           <UserPlus size={18} className="inline-block align-middle mr-1.5" />
           {submitting ? '注册中...' : '注册'}
         </Button>

--- a/packages/client/src/features/game/components/GameActions.tsx
+++ b/packages/client/src/features/game/components/GameActions.tsx
@@ -42,25 +42,25 @@ export default function GameActions({ onCallUno, onCatchUno, onChallenge, onAcce
   return (
     <div className="relative z-actions flex justify-center gap-2.5 py-2 pointer-events-auto">
       {canCallUno && (
-        <Button variant="primary" onClick={withCooldown(onCallUno)} disabled={cooldown}>喊 UNO!</Button>
+        <Button variant="primary" onClick={withCooldown(onCallUno)} disabled={cooldown} sound="action">喊 UNO!</Button>
       )}
       {catchTargets.map((t) => (
-        <Button key={t.id} variant="danger" onClick={withCooldown(() => onCatchUno(t.id))} disabled={cooldown}>抓 {t.name}!</Button>
+        <Button key={t.id} variant="danger" onClick={withCooldown(() => onCatchUno(t.id))} disabled={cooldown} sound="danger">抓 {t.name}!</Button>
       ))}
       {phase === 'challenging' && pendingDrawPlayerId === userId && (
         <>
-          {!noChallengeWD4 && <Button variant="danger" onClick={onChallenge}>质疑!</Button>}
-          <Button variant="secondary" onClick={onAccept}>接受</Button>
+          {!noChallengeWD4 && <Button variant="danger" onClick={onChallenge} sound="action">质疑!</Button>}
+          <Button variant="secondary" onClick={onAccept} sound="action">接受</Button>
         </>
       )}
       {isMyTurn && canPassAfterDraw && phase === 'playing' && (
-        <Button variant="secondary" onClick={onPass}>跳过</Button>
+        <Button variant="secondary" onClick={onPass} sound="click">跳过</Button>
       )}
       {phase === 'choosing_swap_target' && isMyTurn && (
         <>
           <span className="text-accent text-caption font-game">选择交换对象:</span>
           {players.filter(p => p.id !== userId).map(p => (
-            <Button key={p.id} variant="primary" className="!text-caption" onClick={() => onSwapTarget(p.id)}>
+            <Button key={p.id} variant="primary" className="!text-caption" onClick={() => onSwapTarget(p.id)} sound="action">
               {p.name}
             </Button>
           ))}

--- a/packages/client/src/features/game/components/HouseRulesPanel.tsx
+++ b/packages/client/src/features/game/components/HouseRulesPanel.tsx
@@ -50,7 +50,7 @@ export default function HouseRulesPanel({ houseRules, onChange, disabled = false
       </h3>
       <div className="flex gap-2 mb-3 flex-wrap">
         {['classic', 'party', 'crazy'].map((p) => (
-          <Button key={p} variant="secondary" size="sm" onClick={() => applyPreset(p)} disabled={disabled}>
+          <Button key={p} variant="secondary" size="sm" onClick={() => applyPreset(p)} disabled={disabled} sound="click">
             {p === 'classic' ? '经典' : p === 'party' ? '派对' : '疯狂'}
           </Button>
         ))}

--- a/packages/client/src/features/game/components/ScoreBoard.tsx
+++ b/packages/client/src/features/game/components/ScoreBoard.tsx
@@ -69,9 +69,9 @@ export default function ScoreBoard({ onPlayAgain, onRematch, onBackToLobby }: Sc
           </p>
         )}
         <div className="flex gap-3 justify-center">
-          {!isGameOver && <Button variant="primary" onClick={onPlayAgain} disabled={isNextRoundDisabled}>{nextRoundButtonText}</Button>}
-          {isGameOver && <Button variant="primary" onClick={onRematch}>再来一局</Button>}
-          <Button variant="secondary" onClick={onBackToLobby}>返回大厅</Button>
+          {!isGameOver && <Button variant="primary" onClick={onPlayAgain} disabled={isNextRoundDisabled} sound="ready">{nextRoundButtonText}</Button>}
+          {isGameOver && <Button variant="primary" onClick={onRematch} sound="ready">再来一局</Button>}
+          <Button variant="secondary" onClick={onBackToLobby} sound="click">返回大厅</Button>
         </div>
       </div>
     </div>

--- a/packages/client/src/features/game/pages/RoomPage.tsx
+++ b/packages/client/src/features/game/pages/RoomPage.tsx
@@ -147,15 +147,15 @@ export default function RoomPage() {
         disabled={!isOwner}
       />
       <div className="flex gap-3">
-        <Button variant="primary" onClick={toggleReady}>
+        <Button variant="primary" onClick={toggleReady} sound="ready">
           {myPlayer?.ready ? '取消准备' : '准备'}
         </Button>
         {isOwner && (
-          <Button variant="primary" className={cn(!allReady && 'opacity-50')} onClick={startGame} disabled={!allReady}>
+          <Button variant="primary" className={cn(!allReady && 'opacity-50')} onClick={startGame} disabled={!allReady} sound="ready">
             开始游戏
           </Button>
         )}
-        <Button variant="danger" onClick={leaveRoom}>离开房间</Button>
+        <Button variant="danger" onClick={leaveRoom} sound="danger">离开房间</Button>
       </div>
       <VoicePanel />
     </div>

--- a/packages/client/src/features/lobby/pages/LobbyPage.tsx
+++ b/packages/client/src/features/lobby/pages/LobbyPage.tsx
@@ -93,7 +93,7 @@ export default function LobbyPage() {
       {/* Main card */}
       <div className="w-full max-w-sm rounded-panel-ui bg-card/80 backdrop-blur-sm p-6 shadow-card shadow-tech flex flex-col gap-5">
         {/* Create room */}
-        <Button variant="primary" size="lg" className="w-full" onClick={handleCreate} disabled={loading}>
+        <Button variant="primary" size="lg" className="w-full" onClick={handleCreate} disabled={loading} sound="ready">
           {loading ? '创建中...' : '创建房间'}
         </Button>
 
@@ -122,7 +122,7 @@ export default function LobbyPage() {
           >
             <ClipboardPaste size={18} className="text-muted-foreground" />
           </button>
-          <Button variant="outline" onClick={handleJoin} disabled={loading} className="px-6">
+          <Button variant="outline" onClick={handleJoin} disabled={loading} className="px-6" sound="ready">
             加入
           </Button>
         </div>
@@ -148,6 +148,7 @@ export default function LobbyPage() {
                   <Button
                     variant="ghost"
                     size="sm"
+                    sound="click"
                     onClick={() => {
                       connectSocket();
                       getSocket().emit('room:spectate', room.roomCode, (res: any) => {
@@ -199,11 +200,11 @@ export default function LobbyPage() {
       {/* Bottom actions */}
       <div className="flex items-center gap-3">
         {!user?.id.startsWith('ephemeral_') && (
-          <Button variant="ghost" size="sm" onClick={() => navigate('/profile')}>
+          <Button variant="ghost" size="sm" onClick={() => navigate('/profile')} sound="click">
             <User size={14} className="mr-1 inline-block" /> 个人信息
           </Button>
         )}
-        <Button variant="ghost" size="sm" onClick={() => { logout(); navigate('/'); }}>
+        <Button variant="ghost" size="sm" onClick={() => { logout(); navigate('/'); }} sound="click">
           <LogOut size={14} className="mr-1 inline-block" /> 退出登录
         </Button>
       </div>

--- a/packages/client/src/features/profile/pages/ProfilePage.tsx
+++ b/packages/client/src/features/profile/pages/ProfilePage.tsx
@@ -81,7 +81,7 @@ export default function ProfilePage() {
               <div className="flex items-center gap-2">
                 <input value={nickname} onChange={(e) => setNickname(e.target.value)}
                   className="w-40 rounded-lg border border-white/15 bg-card px-3 py-2 text-sm text-foreground" />
-                <Button variant="primary" size="sm" onClick={handleSaveNickname} disabled={saving}>
+                <Button variant="primary" size="sm" onClick={handleSaveNickname} disabled={saving} sound="click">
                   <Save size={14} />
                 </Button>
               </div>
@@ -111,7 +111,7 @@ export default function ProfilePage() {
               {passwordMsg && (
                 <p className={`text-xs m-0 ${passwordMsg.includes('成功') ? 'text-uno-green' : 'text-destructive'}`}>{passwordMsg}</p>
               )}
-              <Button variant="primary" size="sm" onClick={handleSetPassword}>保存密码</Button>
+              <Button variant="primary" size="sm" onClick={handleSetPassword} sound="click">保存密码</Button>
             </div>
           </div>
 
@@ -128,7 +128,7 @@ export default function ProfilePage() {
           )}
         </>
       )}
-      <Button variant="secondary" onClick={() => navigate('/lobby')}>返回大厅</Button>
+      <Button variant="secondary" onClick={() => navigate('/lobby')} sound="click">返回大厅</Button>
     </div>
   );
 }

--- a/packages/client/src/shared/components/ui/Button.tsx
+++ b/packages/client/src/shared/components/ui/Button.tsx
@@ -1,6 +1,8 @@
 import { forwardRef } from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/shared/lib/utils';
+import { playSound } from '@/shared/sound/sound-manager';
+import type { ButtonSound } from '@/shared/sound/sound-manager';
 
 const buttonVariants = cva(
   'font-bold transition-all duration-150 cursor-pointer rounded-btn shadow-tech',
@@ -33,14 +35,22 @@ const buttonVariants = cva(
 
 interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-    VariantProps<typeof buttonVariants> {}
+    VariantProps<typeof buttonVariants> {
+  sound?: ButtonSound;
+}
 
 const Button = forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, ...props }, ref) => {
+  ({ className, variant, size, sound, onClick, ...props }, ref) => {
+    const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+      if (sound) playSound(sound);
+      onClick?.(e);
+    };
+
     return (
       <button
         ref={ref}
         className={cn(buttonVariants({ variant, size }), className)}
+        onClick={handleClick}
         {...props}
       />
     );

--- a/packages/client/src/shared/sound/sound-manager.ts
+++ b/packages/client/src/shared/sound/sound-manager.ts
@@ -17,7 +17,13 @@ type SoundName =
   | 'player_join'
   | 'player_leave'
   | 'your_turn'
-  | 'error';
+  | 'error'
+  | 'click'
+  | 'ready'
+  | 'action'
+  | 'danger';
+
+export type ButtonSound = 'click' | 'ready' | 'action' | 'danger';
 
 const FREQUENCIES: Record<SoundName, { freq: number; duration: number; type: OscillatorType }> = {
   play_card:    { freq: 800, duration: 0.08, type: 'square' },
@@ -37,6 +43,10 @@ const FREQUENCIES: Record<SoundName, { freq: number; duration: number; type: Osc
   player_leave: { freq: 350, duration: 0.15, type: 'sine' },
   your_turn:    { freq: 880, duration: 0.15, type: 'sine' },
   error:        { freq: 200, duration: 0.2, type: 'square' },
+  click:        { freq: 1100, duration: 0.04, type: 'sine' },
+  ready:        { freq: 880, duration: 0.1, type: 'sine' },
+  action:       { freq: 1000, duration: 0.06, type: 'square' },
+  danger:       { freq: 280, duration: 0.1, type: 'sawtooth' },
 };
 
 let audioCtx: AudioContext | null = null;
@@ -78,6 +88,10 @@ export function playSound(name: SoundName): void {
     osc.frequency.linearRampToValueAtTime(90, ctx.currentTime + config.duration);
   } else if (name === 'throw_hit') {
     osc.frequency.exponentialRampToValueAtTime(420, ctx.currentTime + config.duration);
+  } else if (name === 'ready') {
+    osc.frequency.linearRampToValueAtTime(1200, ctx.currentTime + config.duration);
+  } else if (name === 'danger') {
+    osc.frequency.linearRampToValueAtTime(180, ctx.currentTime + config.duration);
   }
 
   gain.gain.setValueAtTime(soundVolume * 0.3, ctx.currentTime);


### PR DESCRIPTION
## Summary
- Button 组件新增可选 `sound` prop，点击时播放对应音效
- 新增 4 种按钮音效：`click`（轻快咔哒）、`ready`（上升确认音）、`action`（干脆短促）、`danger`（低沉警告）
- 按场景为全站按钮分配音效：大厅创建/加入用 ready，游戏操作用 action，抓人/离开用 danger，其余通用操作用 click

## Test plan
- [x] `tsc --noEmit` 客户端类型检查通过
- [ ] 手动测试各页面按钮点击是否有音效
- [ ] 确认关闭音效开关后按钮静音

🤖 Generated with [Claude Code](https://claude.com/claude-code)