### PR TITLE
fix: 所有已开始的对局都记录到游戏历史

### DIFF
--- a/packages/server/src/db/database.ts
+++ b/packages/server/src/db/database.ts
@@ -23,7 +23,7 @@ interface GameRecordTable {
   id: Generated<string>;
   roomCode: string;
   playerCount: number;
-  winnerId: string;
+  winnerId: string | null;
   rounds: number;
   duration: number;
   deckHash: string | null;
@@ -143,7 +143,7 @@ export async function migrateDb(): Promise<void> {
     .addColumn('id', 'text', (c) => c.primaryKey().defaultTo(sql`(lower(hex(randomblob(16))))`))
     .addColumn('room_code', 'text', (c) => c.notNull())
     .addColumn('player_count', 'integer', (c) => c.notNull())
-    .addColumn('winner_id', 'text', (c) => c.notNull())
+    .addColumn('winner_id', 'text')
     .addColumn('rounds', 'integer', (c) => c.notNull())
     .addColumn('duration', 'integer', (c) => c.notNull())
     .addColumn('created_at', 'text', (c) => c.defaultTo(sql`(datetime('now'))`).notNull())
@@ -181,5 +181,30 @@ export async function migrateDb(): Promise<void> {
       .execute();
   } catch {
     // Column already exists
+  }
+
+  // Migration: make winner_id nullable for interrupted games
+  try {
+    const tableInfo = await sql<{ notnull: number; name: string }>`PRAGMA table_info('game_records')`.execute(k);
+    const winnerCol = tableInfo.rows.find(r => r.name === 'winner_id');
+    if (winnerCol && winnerCol.notnull === 1) {
+      await sql`ALTER TABLE game_records RENAME TO game_records_old`.execute(k);
+      await k.schema
+        .createTable('game_records')
+        .addColumn('id', 'text', (c) => c.primaryKey().defaultTo(sql`(lower(hex(randomblob(16))))`))
+        .addColumn('room_code', 'text', (c) => c.notNull())
+        .addColumn('player_count', 'integer', (c) => c.notNull())
+        .addColumn('winner_id', 'text')
+        .addColumn('rounds', 'integer', (c) => c.notNull())
+        .addColumn('duration', 'integer', (c) => c.notNull())
+        .addColumn('deck_hash', 'text')
+        .addColumn('initial_deck', 'text')
+        .addColumn('created_at', 'text', (c) => c.defaultTo(sql`(datetime('now'))`).notNull())
+        .execute();
+      await sql`INSERT INTO game_records SELECT id, room_code, player_count, winner_id, rounds, duration, deck_hash, initial_deck, created_at FROM game_records_old`.execute(k);
+      await sql`DROP TABLE game_records_old`.execute(k);
+    }
+  } catch {
+    // Migration already applied or table doesn't exist yet
   }
 }

--- a/packages/server/src/db/user-repo.ts
+++ b/packages/server/src/db/user-repo.ts
@@ -194,7 +194,7 @@ export async function getUserProfile(userId: string) {
 
 export async function recordGameResult(
   roomCode: string,
-  winnerId: string,
+  winnerId: string | null,
   rounds: number,
   duration: number,
   playerResults: { userId: string; finalScore: number; placement: number }[],
@@ -230,7 +230,7 @@ export async function recordGameResult(
         .set({ totalGames: sql`total_games + 1`, updatedAt: sql`datetime('now')` })
         .where('id', '=', p.userId);
 
-      if (p.userId === winnerId) {
+      if (winnerId && p.userId === winnerId) {
         await tx
           .updateTable('users')
           .set({

--- a/packages/server/src/plugins/core/game-history/service.ts
+++ b/packages/server/src/plugins/core/game-history/service.ts
@@ -149,7 +149,7 @@ export interface GameListItem {
   id: string;
   roomCode: string;
   players: { userId: string; nickname: string; placement: number; finalScore: number }[];
-  winnerId: string;
+  winnerId: string | null;
   winnerName: string;
   playerCount: number;
   rounds: number;

--- a/packages/server/src/ws/game-events.ts
+++ b/packages/server/src/ws/game-events.ts
@@ -33,12 +33,10 @@ export function setGamePersistence(enabled: boolean): void {
 async function persistGameResult(roomCode: string, session: GameSession, startTime: number, db: Kysely<Database>): Promise<void> {
   if (!persistEnabled) return;
 
-  const key = `${roomCode}:${session.getFullState().roundNumber}`;
+  const state = session.getFullState();
+  const key = `${roomCode}:${state.roundNumber}`;
   if (persistedGames.has(key)) return;
   persistedGames.set(key, Date.now());
-
-  const state = session.getFullState();
-  if (!state.winnerId) return;
 
   const duration = Math.floor((Date.now() - startTime) / 1000);
   const sorted = [...state.players].sort((a, b) => b.score - a.score);
@@ -49,7 +47,7 @@ async function persistGameResult(roomCode: string, session: GameSession, startTi
   }));
 
   try {
-    const gameId = await recordGameResult(roomCode, state.winnerId, state.roundNumber, duration, playerResults);
+    const gameId = await recordGameResult(roomCode, state.winnerId ?? null, state.roundNumber, duration, playerResults);
     const events = session.getEvents();
     await saveGameEvents(db, gameId, events);
     await saveDeckInfo(db, gameId, state.deckHash, session.getInitialDeckSerialized());
@@ -96,6 +94,16 @@ interface NextRoundVoteState {
 
 export function setGameStartTime(roomCode: string): void {
   gameStartTimes.set(roomCode, Date.now());
+}
+
+export function getGameStartTime(roomCode: string): number | undefined {
+  return gameStartTimes.get(roomCode);
+}
+
+export async function persistGameOnDissolve(roomCode: string, session: GameSession, db: Kysely<Database>): Promise<void> {
+  const startTime = gameStartTimes.get(roomCode) ?? Date.now();
+  await persistGameResult(roomCode, session, startTime, db);
+  gameStartTimes.delete(roomCode);
 }
 
 function getNextRoundVoteState(roomCode: string, session: GameSession): NextRoundVoteState {

--- a/packages/server/src/ws/room-events.ts
+++ b/packages/server/src/ws/room-events.ts
@@ -1,7 +1,9 @@
 import type { Socket, Server as SocketIOServer } from 'socket.io';
+import type { Kysely } from 'kysely';
 import type { KvStore } from '../kv/types.js';
 import type { GameAction, GameState, RoomSettings } from '@uno-online/shared';
 import { MIN_PLAYERS, DEFAULT_HOUSE_RULES, chooseAutopilotAction, GameEventType } from '@uno-online/shared';
+import type { Database } from '../db/database';
 import { RoomManager } from '../plugins/core/room/manager';
 import { getRoom, getRoomPlayers, setRoomSettings, setRoomStatus, touchRoomActivity } from '../plugins/core/room/store';
 import { GameSession } from '../plugins/core/game/session';
@@ -38,6 +40,7 @@ export function registerRoomEvents(
   roomManager: RoomManager,
   turnTimer: TurnTimer,
   sessions: Map<string, GameSession>,
+  db: Kysely<Database>,
 ) {
   const data = socket.data as SocketData;
 
@@ -91,7 +94,7 @@ export function registerRoomEvents(
     if (!roomCode) return callback?.({ success: false, error: 'Not in a room' });
     const room = await getRoom(redis, roomCode);
     if (room?.ownerId === data.user.userId) {
-      await dissolveRoom(io, redis, roomCode, sessions, turnTimer, 'host_closed');
+      await dissolveRoom(io, redis, roomCode, sessions, turnTimer, 'host_closed', db);
       return callback?.({ success: true, dissolved: true });
     }
     const { deleted } = await roomManager.leaveRoom(roomCode, data.user.userId);
@@ -158,7 +161,7 @@ export function registerRoomEvents(
     if (!room || room.ownerId !== data.user.userId) {
       return callback?.({ success: false, error: 'Only room owner can dissolve' });
     }
-    await dissolveRoom(io, redis, roomCode, sessions, turnTimer, 'host_closed');
+    await dissolveRoom(io, redis, roomCode, sessions, turnTimer, 'host_closed', db);
     callback?.({ success: true });
   });
 

--- a/packages/server/src/ws/room-lifecycle.ts
+++ b/packages/server/src/ws/room-lifecycle.ts
@@ -1,8 +1,11 @@
 import type { Server as SocketIOServer } from 'socket.io';
+import type { Kysely } from 'kysely';
 import type { KvStore } from '../kv/types';
+import type { Database } from '../db/database';
 import type { GameSession } from '../plugins/core/game/session';
 import { deleteRoom } from '../plugins/core/room/store';
 import type { TurnTimer } from '../plugins/core/game/turn-timer';
+import { persistGameOnDissolve } from './game-events';
 import type { SocketData } from './types';
 
 export async function dissolveRoom(
@@ -12,9 +15,18 @@ export async function dissolveRoom(
   sessions: Map<string, GameSession>,
   turnTimer: TurnTimer,
   reason: 'host_closed' | 'idle_timeout' | 'empty' = 'host_closed',
+  db?: Kysely<Database>,
 ): Promise<void> {
   turnTimer.stop(roomCode);
   const session = sessions.get(roomCode);
+
+  if (session && db) {
+    const state = session.getFullState();
+    if (state.players.length > 0 && state.roundNumber > 0) {
+      await persistGameOnDissolve(roomCode, session, db);
+    }
+  }
+
   session?.clearChatHistory();
   sessions.delete(roomCode);
   io.to(roomCode).emit('chat:cleared');

--- a/packages/server/src/ws/socket-handler.ts
+++ b/packages/server/src/ws/socket-handler.ts
@@ -107,7 +107,7 @@ export function setupSocketHandlers(io: SocketIOServer, redis: KvStore, jwtSecre
       if (!Number.isFinite(lastActivityAt) || now - lastActivityAt < roomIdleTimeoutMs) continue;
 
       stopAutoPlayForRoom(roomCode);
-      await dissolveRoom(io, redis, roomCode, sessions, turnTimer, 'idle_timeout');
+      await dissolveRoom(io, redis, roomCode, sessions, turnTimer, 'idle_timeout', getDb());
     }
   }
 
@@ -183,7 +183,7 @@ export function setupSocketHandlers(io: SocketIOServer, redis: KvStore, jwtSecre
       }
     });
 
-    registerRoomEvents(socket, io, redis, roomManager, turnTimer, sessions);
+    registerRoomEvents(socket, io, redis, roomManager, turnTimer, sessions, getDb());
     registerGameEvents(socket, io, redis, turnTimer, sessions, getDb());
     registerInteractionEvents(socket, io);
 


### PR DESCRIPTION
## Summary
- 之前只有达到目标分数的 `game_over` 才保存记录，现在只要游戏开始过就会保存
- `dissolveRoom` 在销毁前检查是否有进行中的游戏，有则保存记录
- `winner_id` 改为 nullable，中途结束的对局 winnerId 为 null
- 包含 SQLite 迁移：自动将旧库的 `game_records.winner_id` NOT NULL 约束移除

## Test plan
- [x] `tsc --noEmit` server/client/shared 全部通过
- [x] shared 202 个测试通过
- [ ] 手动测试：正常打完一局，记录保存正常（winnerId 有值）
- [ ] 手动测试：中途解散房间，games 列表出现记录（winnerId 为 null）
- [ ] 手动测试：空闲超时解散，记录同样保存

🤖 Generated with [Claude Code](https://claude.com/claude-code)