### PR TITLE
修复罚牌摸牌被强制出牌

### DIFF
--- a/packages/client/src/features/game/components/DrawPile.tsx
+++ b/packages/client/src/features/game/components/DrawPile.tsx
@@ -26,7 +26,7 @@ export default function DrawPile({ onDraw, drawTargetX, drawTargetY, drawAnimTri
   const playableIds = usePlayableCardIds();
   const mustDrawUntilPlayable = Boolean(settings?.houseRules?.drawUntilPlayable || settings?.houseRules?.deathDraw);
   const isDrawUntilTurn = mustDrawUntilPlayable && !isPenaltyDrawing;
-  const canContinueDrawUntilPlayable = mustDrawUntilPlayable && hasDrawnThisTurn && playableIds.size === 0;
+  const canContinueDrawUntilPlayable = !isPenaltyDrawing && mustDrawUntilPlayable && hasDrawnThisTurn && playableIds.size === 0;
   const canDraw = isMyTurn && phase === 'playing' && (isPenaltyDrawing || !hasDrawnThisTurn || canContinueDrawUntilPlayable);
 
   const showNoPlayableHint = canDraw && !isDrawUntilTurn && playableIds.size === 0 && !settings?.houseRules?.noHints;

--- a/packages/client/src/features/game/components/GameActions.tsx
+++ b/packages/client/src/features/game/components/GameActions.tsx
@@ -19,6 +19,7 @@ export default function GameActions({ onCallUno, onCatchUno, onChallenge, onAcce
   const players = useGameStore((s) => s.players);
   const phase = useGameStore((s) => s.phase);
   const pendingDrawPlayerId = useGameStore((s) => s.pendingDrawPlayerId);
+  const pendingPenaltyDraws = useGameStore((s) => s.pendingPenaltyDraws);
   const hasDrawnThisTurn = useGameStore((s) => s.hasDrawnThisTurn);
   const settings = useGameStore((s) => s.settings);
   const [cooldown, setCooldown] = useState(false);
@@ -33,7 +34,7 @@ export default function GameActions({ onCallUno, onCatchUno, onChallenge, onAcce
   const noChallengeWD4 = settings?.houseRules?.noChallengeWildFour ?? false;
   const playableIds = usePlayableCardIds();
   const mustDrawUntilPlayable = Boolean(settings?.houseRules?.drawUntilPlayable || settings?.houseRules?.deathDraw);
-  const canPassAfterDraw = hasDrawnThisTurn && (!mustDrawUntilPlayable || playableIds.size > 0);
+  const canPassAfterDraw = pendingPenaltyDraws === 0 && hasDrawnThisTurn && (!mustDrawUntilPlayable || playableIds.size > 0);
 
   const withCooldown = (fn: () => void) => () => {
     if (cooldown) return;

--- a/packages/client/src/features/game/hooks/usePlayableCardIds.ts
+++ b/packages/client/src/features/game/hooks/usePlayableCardIds.ts
@@ -10,6 +10,7 @@ export function usePlayableCardIds(): Set<string> {
   const discardPile = useGameStore((s) => s.discardPile);
   const currentColor = useGameStore((s) => s.currentColor);
   const drawStack = useGameStore((s) => s.drawStack);
+  const pendingPenaltyDraws = useGameStore((s) => s.pendingPenaltyDraws);
   const settings = useGameStore((s) => s.settings);
   const phase = useGameStore((s) => s.phase);
   const isMyTurn = useIsMyTurn();
@@ -19,6 +20,7 @@ export function usePlayableCardIds(): Set<string> {
 
   return useMemo(() => {
     if (!isMyTurn || phase !== 'playing') return new Set<string>();
+    if (pendingPenaltyDraws > 0) return new Set<string>();
     return getPlayableCardIds({
       hand: me?.hand ?? [],
       topCard,
@@ -26,5 +28,5 @@ export function usePlayableCardIds(): Set<string> {
       drawStack,
       houseRules: settings?.houseRules,
     });
-  }, [currentColor, drawStack, isMyTurn, me?.hand, phase, settings?.houseRules, topCard]);
+  }, [currentColor, drawStack, isMyTurn, me?.hand, pendingPenaltyDraws, phase, settings?.houseRules, topCard]);
 }

--- a/packages/shared/src/rules/game-engine.ts
+++ b/packages/shared/src/rules/game-engine.ts
@@ -190,6 +190,9 @@ function handlePlayCard(
   // Must be in playing phase
   if (state.phase !== 'playing') return state;
 
+  // Penalty draws from +2/+4 must be fully paid before the player can act.
+  if ((state.pendingPenaltyDraws ?? 0) > 0) return state;
+
   // Must be the current player
   if (action.playerId !== currentPlayerId(state)) return state;
 
@@ -335,6 +338,10 @@ function handlePass(
   action: Extract<GameAction, { type: 'PASS' }>,
 ): GameState {
   if (state.phase !== 'playing') return state;
+
+  // Penalty draws from +2/+4 are not a normal draw-then-pass turn.
+  if ((state.pendingPenaltyDraws ?? 0) > 0) return state;
+
   if (action.playerId !== currentPlayerId(state)) return state;
 
   // Can only pass after drawing

--- a/packages/shared/tests/house-rules-remaining.test.ts
+++ b/packages/shared/tests/house-rules-remaining.test.ts
@@ -519,6 +519,87 @@ describe('crossStack', () => {
 });
 
 // ──────────────────────────────────────────────────────────────────────────────
+// Penalty draws with forced draw/play rules
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe('penalty draws with forced draw/play rules', () => {
+  const forcedDrawRules = {
+    ...DEFAULT_HOUSE_RULES,
+    drawUntilPlayable: true,
+    forcedPlayAfterDraw: true,
+    forcedPlay: true,
+  };
+
+  it('does not allow playing a playable card drawn while paying a +2 penalty', () => {
+    const drawnPlayable = makeCard('number', 'red', { value: 7, id: 'drawn_playable' });
+    const state = makeState({
+      currentPlayerIndex: 1,
+      currentColor: 'red',
+      discardPile: [makeCard('draw_two', 'red', { id: 'd2top' })],
+      pendingPenaltyDraws: 2,
+      pendingPenaltyNextPlayerIndex: 2,
+      pendingPenaltySourcePlayerId: 'p1',
+      deck: [drawnPlayable, makeCard('number', 'blue', { value: 1, id: 'second_penalty' })],
+      players: [
+        { id: 'p1', name: 'Alice', hand: [makeCard('number', 'green', { value: 1, id: 'p1extra' })], score: 0, connected: true, calledUno: false },
+        { id: 'p2', name: 'Bob', hand: [makeCard('number', 'blue', { value: 9, id: 'p2old' })], score: 0, connected: true, calledUno: false },
+        { id: 'p3', name: 'Carol', hand: [makeCard('number', 'yellow', { value: 2, id: 'p3c' })], score: 0, connected: true, calledUno: false },
+      ],
+      settings: { turnTimeLimit: 30, targetScore: 500, houseRules: forcedDrawRules },
+    });
+
+    const afterFirstDraw = applyActionWithHouseRules(state, { type: 'DRAW_CARD', playerId: 'p2' });
+    expect(afterFirstDraw.players[1]!.hand.map(c => c.id)).toEqual(['p2old', 'drawn_playable']);
+    expect(afterFirstDraw.pendingPenaltyDraws).toBe(1);
+    expect(afterFirstDraw.currentPlayerIndex).toBe(1);
+    expect(afterFirstDraw.discardPile[afterFirstDraw.discardPile.length - 1]!.id).toBe('d2top');
+
+    const playAttempt = applyActionWithHouseRules(afterFirstDraw, {
+      type: 'PLAY_CARD',
+      playerId: 'p2',
+      cardId: 'drawn_playable',
+    });
+    expect(playAttempt).toBe(afterFirstDraw);
+
+    const passAttempt = applyActionWithHouseRules(afterFirstDraw, { type: 'PASS', playerId: 'p2' });
+    expect(passAttempt).toBe(afterFirstDraw);
+
+    const afterSecondDraw = applyActionWithHouseRules(afterFirstDraw, { type: 'DRAW_CARD', playerId: 'p2' });
+    expect(afterSecondDraw.pendingPenaltyDraws).toBe(0);
+    expect(afterSecondDraw.currentPlayerIndex).toBe(2);
+    expect(afterSecondDraw.players[1]!.hand.map(c => c.id)).toEqual(['p2old', 'drawn_playable', 'second_penalty']);
+    expect(afterSecondDraw.discardPile[afterSecondDraw.discardPile.length - 1]!.id).toBe('d2top');
+  });
+
+  it('ends the round after paying a +4 penalty without forcing the drawn playable card', () => {
+    const drawnPlayable = makeCard('number', 'green', { value: 4, id: 'drawn_green' });
+    const state = makeState({
+      currentPlayerIndex: 1,
+      currentColor: 'green',
+      discardPile: [makeCard('wild_draw_four', null, { id: 'wd4top' })],
+      pendingPenaltyDraws: 1,
+      pendingPenaltyNextPlayerIndex: 2,
+      pendingPenaltySourcePlayerId: 'p1',
+      deck: [drawnPlayable],
+      players: [
+        { id: 'p1', name: 'Alice', hand: [], score: 0, connected: true, calledUno: false },
+        { id: 'p2', name: 'Bob', hand: [makeCard('number', 'blue', { value: 9, id: 'p2old' })], score: 0, connected: true, calledUno: false },
+        { id: 'p3', name: 'Carol', hand: [makeCard('number', 'yellow', { value: 2, id: 'p3c' })], score: 0, connected: true, calledUno: false },
+      ],
+      lastAction: { type: 'PLAY_CARD', playerId: 'p1', cardId: 'wd4top' },
+      settings: { turnTimeLimit: 30, targetScore: 500, houseRules: forcedDrawRules },
+    });
+
+    const afterPenalty = applyActionWithHouseRules(state, { type: 'DRAW_CARD', playerId: 'p2' });
+
+    expect(afterPenalty.phase).toBe('round_end');
+    expect(afterPenalty.winnerId).toBe('p1');
+    expect(afterPenalty.players[1]!.hand.map(c => c.id)).toEqual(['p2old', 'drawn_green']);
+    expect(afterPenalty.discardPile[afterPenalty.discardPile.length - 1]!.id).toBe('wd4top');
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
 // zeroRotateHands
 // ──────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- 禁止 +2/+4 抽罚期间出牌或跳过，抽完罚牌后直接结束当前受罚回合
- 前端在抽罚期间不再高亮可出牌或显示跳过按钮
- 增加三条强制摸/出村规与 +2/+4 抽罚的回归测试

## Tests
- pnpm --filter shared test -- house-rules-remaining
- pnpm --filter shared build && pnpm --filter client build