### PR TITLE
feat: 添加网站 Logo 和 SEO 优化

### DIFF
--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -1,10 +1,27 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh-CN">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>UNO Online</title>
+    <title>UNO Online - 多人在线 UNO 卡牌游戏</title>
+    <meta name="description" content="免费在线 UNO 卡牌游戏，支持 2-10 人实时对战、语音通话、自定义村规、观战与回放。无需下载，打开即玩。" />
+    <meta name="keywords" content="UNO,UNO Online,在线UNO,多人卡牌游戏,UNO卡牌,联机UNO,网页游戏" />
+    <meta name="theme-color" content="#1e1b4b" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="apple-touch-icon" href="/favicon.svg" />
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="UNO Online - 多人在线 UNO 卡牌游戏" />
+    <meta property="og:description" content="免费在线 UNO 卡牌游戏，支持 2-10 人实时对战、语音通话、自定义村规、观战与回放。" />
+    <meta property="og:image" content="/og-image.svg" />
+    <meta property="og:locale" content="zh_CN" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="UNO Online - 多人在线 UNO 卡牌游戏" />
+    <meta name="twitter:description" content="免费在线 UNO 卡牌游戏，支持 2-10 人实时对战、语音通话、自定义村规、观战与回放。" />
+    <meta name="twitter:image" content="/og-image.svg" />
   </head>
   <body>
     <div id="root"></div>

--- a/packages/client/public/favicon.svg
+++ b/packages/client/public/favicon.svg
@@ -1,1 +1,28 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><text y=".9em" font-size="90">🎴</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="cardGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ef4444"/>
+      <stop offset="100%" stop-color="#dc2626"/>
+    </linearGradient>
+    <linearGradient id="cardGrad2" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#3b82f6"/>
+      <stop offset="100%" stop-color="#2563eb"/>
+    </linearGradient>
+    <linearGradient id="cardGrad3" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#22c55e"/>
+      <stop offset="100%" stop-color="#16a34a"/>
+    </linearGradient>
+  </defs>
+  <!-- Background circle -->
+  <circle cx="256" cy="256" r="248" fill="#1e1b4b" stroke="#6366f1" stroke-width="8"/>
+  <!-- Green card (back) -->
+  <rect x="100" y="140" width="160" height="220" rx="16" fill="url(#cardGrad3)" transform="rotate(-15 180 250)" opacity="0.85"/>
+  <!-- Blue card (middle) -->
+  <rect x="170" y="130" width="160" height="220" rx="16" fill="url(#cardGrad2)" transform="rotate(0 250 240)" opacity="0.9"/>
+  <!-- Red card (front) -->
+  <rect x="240" y="140" width="160" height="220" rx="16" fill="url(#cardGrad)" transform="rotate(12 320 250)"/>
+  <!-- UNO text -->
+  <text x="256" y="420" font-family="Arial Black, Arial, sans-serif" font-size="100" font-weight="900" fill="#fbbf24" text-anchor="middle" letter-spacing="-2">UNO</text>
+  <!-- Highlight on front card -->
+  <ellipse cx="330" cy="248" rx="50" ry="70" fill="rgba(255,255,255,0.15)" transform="rotate(12 330 248)"/>
+</svg>

--- a/packages/client/public/og-image.svg
+++ b/packages/client/public/og-image.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f0a2e"/>
+      <stop offset="100%" stop-color="#1e1b4b"/>
+    </linearGradient>
+    <linearGradient id="cRed" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ef4444"/>
+      <stop offset="100%" stop-color="#dc2626"/>
+    </linearGradient>
+    <linearGradient id="cBlue" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#3b82f6"/>
+      <stop offset="100%" stop-color="#2563eb"/>
+    </linearGradient>
+    <linearGradient id="cGreen" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#22c55e"/>
+      <stop offset="100%" stop-color="#16a34a"/>
+    </linearGradient>
+    <linearGradient id="cYellow" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#eab308"/>
+      <stop offset="100%" stop-color="#ca8a04"/>
+    </linearGradient>
+  </defs>
+  <!-- Background -->
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <!-- Decorative cards -->
+  <rect x="80" y="160" width="140" height="200" rx="14" fill="url(#cGreen)" transform="rotate(-20 150 260)" opacity="0.7"/>
+  <rect x="160" y="140" width="140" height="200" rx="14" fill="url(#cBlue)" transform="rotate(-8 230 240)" opacity="0.8"/>
+  <rect x="250" y="130" width="140" height="200" rx="14" fill="url(#cRed)" transform="rotate(5 320 230)" opacity="0.9"/>
+  <rect x="340" y="150" width="140" height="200" rx="14" fill="url(#cYellow)" transform="rotate(18 410 250)" opacity="0.75"/>
+  <!-- Title -->
+  <text x="740" y="260" font-family="Arial Black, Arial, sans-serif" font-size="120" font-weight="900" fill="#ffffff" text-anchor="middle">UNO Online</text>
+  <!-- Subtitle -->
+  <text x="740" y="340" font-family="Arial, sans-serif" font-size="36" fill="#a5b4fc" text-anchor="middle">多人在线 UNO 卡牌游戏</text>
+  <!-- Features -->
+  <text x="740" y="420" font-family="Arial, sans-serif" font-size="26" fill="#94a3b8" text-anchor="middle">2-10人对战 · 语音通话 · 自定义村规 · 观战回放</text>
+  <!-- Bottom accent line -->
+  <rect x="540" y="470" width="400" height="4" rx="2" fill="#6366f1" opacity="0.6"/>
+</svg>

--- a/packages/client/public/robots.txt
+++ b/packages/client/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+Disallow: /api/
+Disallow: /admin/


### PR DESCRIPTION
## Summary
- 设计 UNO 风格 SVG favicon（深紫圆形背景 + 三色卡牌扇形展开 + 金色 UNO 文字）
- HTML lang 改为 zh-CN，title 加描述性后缀
- 添加 description/keywords/theme-color meta 标签
- 添加 Open Graph 和 Twitter Card 标签用于社交分享
- 创建 OG 分享预览图（og-image.svg）
- 添加 robots.txt（允许爬虫，屏蔽 /api/ 和 /admin/）

## Test plan
- [x] `pnpm --filter client build` 构建通过
- [ ] 浏览器查看 favicon 显示正常
- [ ] 社交平台分享链接预览正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)