### PR TITLE
docs: 修正 README 中多处不准确描述

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,19 @@
 
 <p align="center"><a href="README.zh-CN.md">中文文档</a></p>
 
-Web-based multiplayer UNO card game with voice chat, 32 configurable house rules, server selector, and a cartoon visual style.
+Web-based multiplayer UNO card game with voice chat, 33 configurable house rules, server selector, and a cartoon visual style.
 
 ## Features
 
 - **2-10 players** per room, invite via 6-character room code
 - **Complete UNO rules** — all card types, challenge mechanics, scoring, multi-round play
-- **32 house rules** — stacking, deflection, jump-in, 0-rotate, 7-swap, elimination, blitz, team mode, and more
+- **33 house rules** — stacking, deflection, jump-in, 0-rotate, 7-swap, elimination, blitz, team mode, and more
 - **3 presets** — Classic (standard), Party (common house rules), Crazy (everything on)
 - **Server selector** — browse and switch between servers, view real-time status (players, rooms, latency), add custom servers
-- **Voice chat** — mediasoup SFU, per-player mute, speaking indicators
+- **Voice chat** — Mumble protocol via mumble-web-gateway, per-player mute, speaking indicators
 - **Real-time** — Socket.IO with authoritative server, client-side prediction
 - **Animations** — Framer Motion card animations, game effects, confetti
-- **Sound effects** — Web Audio API synthesizer (no audio files)
+- **Sound effects** — Web Audio API synthesizer + mp3 assets, 21 sound effects
 - **Color-blind mode** — pattern overlays + symbol markers on cards
 - **Mobile responsive** — touch-optimized hand scrolling, adaptive layout
 - **Admin panel** — user management, room monitoring, dashboard stats
@@ -39,7 +39,7 @@ Web-based multiplayer UNO card game with voice chat, 32 configurable house rules
 | Animation | Framer Motion + CSS |
 | Backend | Fastify, TypeScript |
 | Realtime | Socket.IO |
-| Voice | mediasoup (SFU) |
+| Voice | Mumble (via mumble-web-gateway) |
 | Database | SQLite (Kysely) |
 | Cache | Redis (optional, in-memory fallback) |
 | Auth | GitHub OAuth + password + JWT |
@@ -52,7 +52,7 @@ Web-based multiplayer UNO card game with voice chat, 32 configurable house rules
 uno-online/
 ├── packages/
 │   ├── shared/          # Rules engine, types, constants (pure logic, no I/O)
-│   ├── server/          # Fastify + Socket.IO + mediasoup + SQLite
+│   ├── server/          # Fastify + Socket.IO + SQLite
 │   ├── client/          # React SPA (Vite + Tailwind CSS v4)
 │   └── admin/           # Admin panel (React + Vite)
 ├── Dockerfile
@@ -161,26 +161,33 @@ docker push djkcyl/uno-online-caddy:latest
 
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
-| `GET` | `/api/server/info` | No | Server status (name, version, MOTD, online players, rooms, uptime) |
 | `GET` | `/api/health` | No | Health check |
+| `GET` | `/api/server/info` | No | Server status (name, version, MOTD, online players, rooms, uptime) |
 | `GET` | `/api/auth/config` | No | Auth configuration (dev mode, GitHub client ID) |
+| `POST` | `/api/auth/dev-login` | No | Dev mode login (dev mode only) |
 | `POST` | `/api/auth/login` | No | Password login |
 | `POST` | `/api/auth/register` | No | Register new account |
-| `POST` | `/api/auth/set-password` | Yes | Set/change password |
 | `GET` | `/api/auth/me` | Yes | Current user info |
+| `POST` | `/api/auth/set-password` | Yes | Set/change password |
 | `GET` | `/api/auth/github` | No | Initiate GitHub OAuth flow |
-| `GET` | `/api/auth/callback` | No | GitHub OAuth callback |
-| `POST` | `/api/auth/bind-github` | Yes | Bind GitHub account |
+| `POST` | `/api/auth/callback` | No | GitHub OAuth callback |
+| `POST` | `/api/auth/bind-github` | No | Bind GitHub account (password in body) |
+| `GET` | `/api/avatar/:userId` | No | Get user avatar image |
 | `GET` | `/api/profile` | Yes | Get user profile |
-| `PUT` | `/api/profile` | Yes | Update profile |
+| `PATCH` | `/api/profile` | Yes | Update profile |
 | `POST` | `/api/profile/avatar` | Yes | Upload avatar |
 | `GET` | `/api/rooms/active` | Yes | List active rooms |
 | `GET` | `/api/games` | Yes | List game history |
 | `GET` | `/api/games/:id` | Yes | Get game record detail |
+| `GET` | `/api/games/:id/verify` | Yes | Verify game deck integrity |
 | `GET` | `/api/admin/dashboard` | Admin | Admin dashboard stats |
+| `GET` | `/api/admin/users` | Admin | Paginated user list |
+| `PATCH` | `/api/admin/users/:id/role` | Admin | Change user role |
+| `PATCH` | `/api/admin/users/:id/profile` | Admin | Update user profile |
 | `GET` | `/api/admin/rooms` | Admin | List all rooms |
 | `DELETE` | `/api/admin/rooms/:code` | Admin | Force dissolve a room |
-| `DELETE` | `/api/admin/games/:id` | Admin | Delete game record |
+| `GET` | `/api/admin/games` | Admin | Paginated game history |
+| `GET` | `/api/admin/games/:id` | Admin | Game record detail |
 
 ## Testing
 
@@ -220,10 +227,10 @@ House rules wrap the core engine: `applyActionWithHouseRules(state, action) => n
 - **Zustand stores** — auth, room, game, settings, server (with localStorage persistence)
 - **Server selector** — switch between servers with real-time status display, latency measurement (3x HTTP RTT average)
 - **Socket.IO** — auto-reconnect (5 attempts, exponential backoff), auto-rejoin room on reconnect
-- **Voice** — mediasoup-client with transport reconnect, browser capability detection
-- **Sound** — Web Audio API oscillator-based synthesizer, 13 sound effects
+- **Voice** — Mumble protocol via WebSocket gateway, AudioWorklet capture/playback
+- **Sound** — Web Audio API oscillator synthesizer + mp3 throw sounds, 21 effects
 
-## House Rules (32)
+## House Rules (33)
 
 | Category | Rules |
 |----------|-------|
@@ -232,7 +239,7 @@ House rules wrap the core engine: `applyActionWithHouseRules(state, action) => n
 | Card rules | 0-rotate hands, 7-swap hands, jump-in, multi-play same number, wild first turn |
 | Draw rules | Draw until playable, forced play after draw |
 | Hand rules | Hand limit (15/20/25), forced play, hand reveal threshold |
-| Penalties | Custom UNO penalty (2/4/6), misplay penalty |
+| Penalties | Custom UNO penalty (2/4/6), strict UNO call, misplay penalty |
 | Pacing | Death draw, fast mode, no hints |
 | Game modes | Elimination, blitz (timed), revenge mode |
 | Social | Silent UNO, team mode (2v2/3v3) |
@@ -245,4 +252,4 @@ This project is maintained under [github.com/letsuno](https://github.com/letsuno
 
 ## License
 
-Private project.
+[AGPL-3.0](LICENSE)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,19 +8,19 @@
   <a href="https://github.com/letsuno/uno-online"><img src="https://img.shields.io/github/license/letsuno/uno-online" alt="License" /></a>
 </p>
 
-基于 Web 技术栈的在线多人 UNO 卡牌对战游戏，支持语音通话、32 条可配置村规、多服务器切换、卡通趣味视觉风格。
+基于 Web 技术栈的在线多人 UNO 卡牌对战游戏，支持语音通话、33 条可配置村规、多服务器切换、卡通趣味视觉风格。
 
 ## 功能特性
 
 - **2-10 人房间制** — 通过 6 位房间码邀请好友加入
 - **完整 UNO 规则** — 全部牌型、质疑机制、计分系统、多轮制
-- **32 条可配置村规** — 叠加、反弹、抢出、0 牌轮转、7 牌交换、淘汰制、闪电战、团队模式等
+- **33 条可配置村规** — 叠加、反弹、抢出、0 牌轮转、7 牌交换、淘汰制、闪电战、团队模式等
 - **3 套预设** — 经典（标准规则）、派对（常见村规）、疯狂（全部开启）
 - **服务器选择** — 浏览和切换服务器，实时查看状态（在线人数、房间数、延迟），支持自定义服务器
-- **语音通话** — mediasoup SFU 架构，逐人静音，说话状态指示
+- **语音通话** — Mumble 协议（mumble-web-gateway），逐人静音，说话状态指示
 - **实时对战** — Socket.IO 通信，权威服务器 + 客户端预测
 - **动画效果** — Framer Motion 卡牌动画、功能牌特效、胜利彩纸
-- **音效系统** — Web Audio API 合成器（无需音频文件）
+- **音效系统** — Web Audio API 合成器 + mp3 音效，共 21 种音效
 - **色盲友好** — 纹理图案叠加 + 颜色符号标识（♦♠♣♥）
 - **移动端适配** — 触摸滑动优化、响应式布局
 - **管理后台** — 用户管理、房间监控、数据看板
@@ -37,7 +37,7 @@
 | 动画 | Framer Motion + CSS |
 | 后端 | Fastify + TypeScript |
 | 实时通信 | Socket.IO (WebSocket) |
-| 语音 | mediasoup (SFU) |
+| 语音 | Mumble (mumble-web-gateway) |
 | 数据库 | SQLite (Kysely) |
 | 缓存 | Redis（可选，内存回退） |
 | 认证 | GitHub OAuth + 密码 + JWT |
@@ -50,7 +50,7 @@
 uno-online/
 ├── packages/
 │   ├── shared/          # 规则引擎、类型定义、常量（纯逻辑，无 I/O）
-│   ├── server/          # Fastify + Socket.IO + mediasoup + SQLite
+│   ├── server/          # Fastify + Socket.IO + SQLite
 │   ├── client/          # React SPA (Vite + Tailwind CSS v4)
 │   └── admin/           # 管理后台 (React + Vite)
 ├── Dockerfile
@@ -155,26 +155,33 @@ docker push djkcyl/uno-online-caddy:latest
 
 | 方法 | 路径 | 认证 | 说明 |
 |------|------|------|------|
-| `GET` | `/api/server/info` | 否 | 服务器状态（名称、版本、欢迎信息、在线人数、房间数、运行时长） |
 | `GET` | `/api/health` | 否 | 健康检查 |
+| `GET` | `/api/server/info` | 否 | 服务器状态（名称、版本、欢迎信息、在线人数、房间数、运行时长） |
 | `GET` | `/api/auth/config` | 否 | 认证配置（开发模式、GitHub 客户端 ID） |
+| `POST` | `/api/auth/dev-login` | 否 | 开发模式登录 |
 | `POST` | `/api/auth/login` | 否 | 密码登录 |
 | `POST` | `/api/auth/register` | 否 | 注册新账号 |
-| `POST` | `/api/auth/set-password` | 是 | 设置/修改密码 |
 | `GET` | `/api/auth/me` | 是 | 当前用户信息 |
+| `POST` | `/api/auth/set-password` | 是 | 设置/修改密码 |
 | `GET` | `/api/auth/github` | 否 | 发起 GitHub OAuth 流程 |
-| `GET` | `/api/auth/callback` | 否 | GitHub OAuth 回调 |
-| `POST` | `/api/auth/bind-github` | 是 | 绑定 GitHub 账号 |
+| `POST` | `/api/auth/callback` | 否 | GitHub OAuth 回调 |
+| `POST` | `/api/auth/bind-github` | 否 | 绑定 GitHub 账号（请求体含密码验证） |
+| `GET` | `/api/avatar/:userId` | 否 | 获取用户头像 |
 | `GET` | `/api/profile` | 是 | 获取用户资料 |
-| `PUT` | `/api/profile` | 是 | 更新用户资料 |
+| `PATCH` | `/api/profile` | 是 | 更新用户资料 |
 | `POST` | `/api/profile/avatar` | 是 | 上传头像 |
 | `GET` | `/api/rooms/active` | 是 | 获取活跃房间列表 |
 | `GET` | `/api/games` | 是 | 游戏记录列表 |
 | `GET` | `/api/games/:id` | 是 | 游戏记录详情 |
+| `GET` | `/api/games/:id/verify` | 是 | 验证游戏牌组完整性 |
 | `GET` | `/api/admin/dashboard` | 管理员 | 管理后台统计 |
+| `GET` | `/api/admin/users` | 管理员 | 分页用户列表 |
+| `PATCH` | `/api/admin/users/:id/role` | 管理员 | 修改用户角色 |
+| `PATCH` | `/api/admin/users/:id/profile` | 管理员 | 修改用户资料 |
 | `GET` | `/api/admin/rooms` | 管理员 | 所有房间列表 |
 | `DELETE` | `/api/admin/rooms/:code` | 管理员 | 强制解散房间 |
-| `DELETE` | `/api/admin/games/:id` | 管理员 | 删除游戏记录 |
+| `GET` | `/api/admin/games` | 管理员 | 分页游戏记录 |
+| `GET` | `/api/admin/games/:id` | 管理员 | 游戏记录详情 |
 
 ## 测试
 
@@ -214,10 +221,10 @@ pnpm --filter client exec tsc --noEmit
 - **Zustand 状态管理** — auth、room、game、settings、server（localStorage 持久化）
 - **服务器选择器** — 切换服务器并实时展示状态，延迟测量（3 次 HTTP RTT 取平均）
 - **Socket.IO** — 自动重连（5 次，指数退避），重连后自动恢复房间
-- **语音** — mediasoup-client，transport 断线自动重连，浏览器兼容性检测
-- **音效** — Web Audio API 振荡器合成，13 种音效
+- **语音** — Mumble 协议，WebSocket 网关桥接，AudioWorklet 采集/播放
+- **音效** — Web Audio API 振荡器合成 + mp3 投掷音效，共 21 种
 
-## 村规列表（32 条）
+## 村规列表（33 条）
 
 | 分类 | 规则 |
 |------|------|
@@ -226,7 +233,7 @@ pnpm --filter client exec tsc --noEmit
 | 出牌 | 0 牌轮转手牌、7 牌指定交换、同牌抢出、同数字全出、万能牌开局可出 |
 | 摸牌 | 摸到能出为止、摸牌后必须出 |
 | 手牌 | 手牌上限（15/20/25）、强制出牌、手牌透明 |
-| 惩罚 | UNO 罚摸数量（2/4/6）、误操作惩罚 |
+| 惩罚 | UNO 罚摸数量（2/4/6）、严格喊牌、误操作惩罚 |
 | 节奏 | 死亡抽牌、快速模式、无提示模式 |
 | 模式 | 淘汰制、限时闪电战、复仇模式 |
 | 社交 | 静默 UNO、团队模式（2v2/3v3） |
@@ -239,4 +246,4 @@ pnpm --filter client exec tsc --noEmit
 
 ## 许可证
 
-私有项目。
+[AGPL-3.0](LICENSE)


### PR DESCRIPTION
## Summary
- 语音技术：mediasoup → Mumble (mumble-web-gateway)
- 村规数量：32 → 33（补充 strictUnoCall / 严格喊牌）
- 音效数量：13 → 21，补充 mp3 投掷音效说明
- API 端点表完整修正：方法、认证方式、补充缺失端点、移除不存在端点
- 项目结构 server 描述移除 mediasoup
- 许可证：「私有项目」→ AGPL-3.0
- GitHub 仓库描述同步更新为 33 house rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)