### PR TITLE
fix: 修复快速模式在多个阶段未生效的问题

### DIFF
--- a/packages/client/src/features/game/components/GameTable.tsx
+++ b/packages/client/src/features/game/components/GameTable.tsx
@@ -766,7 +766,7 @@ export default function GameTable({ onDraw }: GameTableProps) {
             isSpeaking={mumbleSpeakingNames.has(player.name)}
             position={pos}
             turnEndTime={isActive ? turnEndTime : null}
-            turnTimeLimit={settings?.turnTimeLimit}
+            turnTimeLimit={settings ? (settings.houseRules?.fastMode ? Math.floor(settings.turnTimeLimit / 2) : settings.turnTimeLimit) : undefined}
             lastPlayedCard={lastPlayed?.card ?? null}
             chatMessage={chatMessages.get(player.id) ?? null}
             handGain={handGainBumps.get(player.id) ?? null}

--- a/packages/client/src/shared/socket.ts
+++ b/packages/client/src/shared/socket.ts
@@ -34,18 +34,21 @@ export function getSocket(): Socket {
       useGatewayStore.getState().setPlayerVoicePresence(presence ?? {});
     });
 
-    const handleGameView = (view: { phase?: string; settings?: { turnTimeLimit: number } }) => {
+    const handleGameView = (view: { phase?: string; settings?: { turnTimeLimit: number; houseRules?: { fastMode?: boolean } } }) => {
       useGameStore.getState().setGameState(view);
       const settings = view.settings;
       if (!settings || view.phase === 'round_end' || view.phase === 'game_over') {
         useGameStore.getState().setTurnEndTime(null);
       } else {
-        useGameStore.getState().setTurnEndTime(Date.now() + settings.turnTimeLimit * 1000);
+        const timeLimit = settings.houseRules?.fastMode
+          ? Math.floor(settings.turnTimeLimit / 2)
+          : settings.turnTimeLimit;
+        useGameStore.getState().setTurnEndTime(Date.now() + timeLimit * 1000);
       }
     };
 
     socket.on('game:state', (view: Record<string, unknown>) => {
-      handleGameView(view as { phase?: string; settings?: { turnTimeLimit: number } });
+      handleGameView(view as { phase?: string; settings?: { turnTimeLimit: number; houseRules?: { fastMode?: boolean } } });
       const deckHash = (view as { deckHash?: string }).deckHash;
       if (deckHash) {
         useToastStore.getState().addToast(`牌序 Hash: ${deckHash.slice(0, 16)}...`, 'info');

--- a/packages/server/src/ws/room-events.ts
+++ b/packages/server/src/ws/room-events.ts
@@ -318,7 +318,9 @@ export function startTurnTimer(
   }
 
   if (phase === 'challenging' || phase === 'choosing_color' || phase === 'choosing_swap_target') {
-    const timeLimit = state.settings.turnTimeLimit;
+    const timeLimit = state.settings.houseRules.fastMode
+      ? Math.floor(state.settings.turnTimeLimit / 2)
+      : state.settings.turnTimeLimit;
     turnTimer.start(roomCode, timeLimit, async (code) => {
       const s = sessions.get(code);
       if (!s) return;


### PR DESCRIPTION
## Summary

- 服务端 `startTurnTimer` 中 `challenging`/`choosing_color`/`choosing_swap_target` 阶段未应用 fastMode 减半逻辑
- 客户端 `socket.ts` 计算倒计时终止时间时未考虑 fastMode，导致进度条显示与实际不符
- 客户端 `GameTable.tsx` 传给 `CountdownRing` 的 totalSeconds 未减半

## Test plan

- [ ] 开启快速模式，确认 playing 阶段回合时间减半
- [ ] 开启快速模式，出 Wild 牌进入选颜色阶段，确认计时也减半
- [ ] 开启快速模式，出 Wild Draw Four 进入质疑阶段，确认计时也减半
- [ ] 确认客户端倒计时进度环与服务端超时时间一致
- [ ] 不开启快速模式时，所有阶段计时保持原样

🤖 Generated with [Claude Code](https://claude.com/claude-code)