### PR TITLE
feat: 连续超时自动开启托管模式

### DIFF
--- a/packages/server/src/ws/game-events.ts
+++ b/packages/server/src/ws/game-events.ts
@@ -6,7 +6,7 @@ import type { Kysely } from 'kysely';
 import type { Database } from '../db/database';
 import { GameSession } from '../plugins/core/game/session';
 import { saveGameState } from '../plugins/core/game/state-store';
-import { emitGameUpdate, startTurnTimer } from './room-events';
+import { emitGameUpdate, startTurnTimer, resetPlayerTimeout, clearRoomTimeouts } from './room-events';
 import type { TurnTimer } from '../plugins/core/game/turn-timer';
 import { recordGameResult } from '../db/user-repo';
 import { saveGameEvents, saveDeckInfo } from '../plugins/core/game-history/service';
@@ -149,6 +149,7 @@ async function emitTerminalStateIfNeeded(
   if (state.phase !== 'round_end' && state.phase !== 'game_over') return false;
 
   turnTimer.stop(roomCode);
+  clearRoomTimeouts(roomCode);
   io.to(roomCode).emit(state.phase === 'game_over' ? 'game:over' : 'game:round_end', {
     winnerId: state.winnerId,
     scores: Object.fromEntries(state.players.map((p) => [p.id, p.score])),
@@ -204,6 +205,7 @@ export function registerGameEvents(
       socket.emit('game:action_rejected', { action: 'play_card', reason: result.error });
       return callback?.({ success: false, error: result.error });
     }
+    resetPlayerTimeout(roomCode, data.user.userId);
     const playedCard = session.getFullState().discardPile.at(-1);
     session.recordEvent(GameEventType.PLAY_CARD, {
       cardId: payload.cardId,
@@ -233,6 +235,7 @@ export function registerGameEvents(
       socket.emit('game:action_rejected', { action: 'draw_card', reason: result.error });
       return callback?.({ success: false, error: result.error });
     }
+    resetPlayerTimeout(roomCode, data.user.userId);
     if (result.drawnCard) {
       session.recordEvent(GameEventType.DRAW_CARD, { card: result.drawnCard }, data.user.userId);
     }
@@ -260,6 +263,7 @@ export function registerGameEvents(
     const { session, roomCode } = ctx;
     const result = session.applyAction({ type: 'PASS', playerId: data.user.userId });
     if (!result.success) return callback?.({ success: false, error: result.error });
+    resetPlayerTimeout(roomCode, data.user.userId);
     session.recordEvent(GameEventType.PASS, {}, data.user.userId);
     await touchRoomActivity(redis, roomCode);
     await saveGameState(redis, roomCode, session.getFullState());
@@ -303,6 +307,7 @@ export function registerGameEvents(
     const { session, roomCode } = ctx;
     const result = session.applyAction({ type: 'CHALLENGE', playerId: data.user.userId });
     if (!result.success) return callback?.({ success: false, error: result.error });
+    resetPlayerTimeout(roomCode, data.user.userId);
     const challengeState = session.getFullState();
     session.recordEvent(GameEventType.CHALLENGE, {
       success: challengeState.lastAction?.type === 'CHALLENGE' ? challengeState.lastAction.succeeded ?? false : false,
@@ -323,6 +328,7 @@ export function registerGameEvents(
     const { session, roomCode } = ctx;
     const result = session.applyAction({ type: 'ACCEPT', playerId: data.user.userId });
     if (!result.success) return callback?.({ success: false, error: result.error });
+    resetPlayerTimeout(roomCode, data.user.userId);
     session.recordEvent(GameEventType.ACCEPT, { drawnCards: [] }, data.user.userId);
     await touchRoomActivity(redis, roomCode);
     await saveGameState(redis, roomCode, session.getFullState());
@@ -343,6 +349,7 @@ export function registerGameEvents(
       color: payload.color,
     });
     if (!result.success) return callback?.({ success: false, error: result.error });
+    resetPlayerTimeout(roomCode, data.user.userId);
     session.recordEvent(GameEventType.CHOOSE_COLOR, { color: payload.color }, data.user.userId);
     await touchRoomActivity(redis, roomCode);
     await saveGameState(redis, roomCode, session.getFullState());
@@ -365,6 +372,7 @@ export function registerGameEvents(
       targetId: payload.targetId,
     });
     if (!result.success) return callback?.({ success: false, error: result.error });
+    resetPlayerTimeout(roomCode, data.user.userId);
     session.recordEvent(GameEventType.CHOOSE_SWAP_TARGET, { targetId: payload.targetId }, data.user.userId);
     await touchRoomActivity(redis, roomCode);
     await saveGameState(redis, roomCode, session.getFullState());

--- a/packages/server/src/ws/room-events.ts
+++ b/packages/server/src/ws/room-events.ts
@@ -15,6 +15,23 @@ import { dissolveRoom } from './room-lifecycle';
 import { removeVoicePresence } from './voice-presence';
 
 const DRAW_PENALTY_PAUSE_MS = 500;
+const AUTO_AUTOPILOT_THRESHOLD = 2;
+
+// Track consecutive timeouts per player per room
+const timeoutCounts = new Map<string, Map<string, number>>();
+
+export function getTimeoutCounts(): Map<string, Map<string, number>> {
+  return timeoutCounts;
+}
+
+export function resetPlayerTimeout(roomCode: string, playerId: string): void {
+  const roomCounts = timeoutCounts.get(roomCode);
+  if (roomCounts) roomCounts.delete(playerId);
+}
+
+export function clearRoomTimeouts(roomCode: string): void {
+  timeoutCounts.delete(roomCode);
+}
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -332,6 +349,7 @@ export function startTurnTimer(
       await saveGameState(redis, code, s.getFullState());
       emitGameUpdate(io, code, s, redis);
       io.to(code).emit('player:timeout', { playerId: pid });
+      incrementTimeoutAndAutoAutopilot(io, redis, code, s, pid);
       startTurnTimer(io, redis, code, s, turnTimer, sessions);
     });
     return;
@@ -355,8 +373,30 @@ export function startTurnTimer(
     await saveGameState(redis, code, s.getFullState());
     emitGameUpdate(io, code, s, redis);
     io.to(code).emit('player:timeout', { playerId: pid });
+    incrementTimeoutAndAutoAutopilot(io, redis, code, s, pid);
     startTurnTimer(io, redis, code, s, turnTimer, sessions);
   });
+}
+
+async function incrementTimeoutAndAutoAutopilot(
+  io: SocketIOServer,
+  redis: KvStore,
+  roomCode: string,
+  session: GameSession,
+  playerId: string,
+): Promise<void> {
+  if (!timeoutCounts.has(roomCode)) timeoutCounts.set(roomCode, new Map());
+  const roomCounts = timeoutCounts.get(roomCode)!;
+  const count = (roomCounts.get(playerId) ?? 0) + 1;
+  roomCounts.set(playerId, count);
+
+  const player = session.getFullState().players.find(p => p.id === playerId);
+  if (count >= AUTO_AUTOPILOT_THRESHOLD && player && !player.autopilot) {
+    session.setPlayerAutopilot(playerId, true);
+    await saveGameState(redis, roomCode, session.getFullState());
+    await emitGameUpdate(io, roomCode, session, redis);
+    io.to(roomCode).emit('player:autopilot', { playerId, enabled: true });
+  }
 }
 
 export async function emitGameUpdate(

--- a/packages/server/src/ws/room-lifecycle.ts
+++ b/packages/server/src/ws/room-lifecycle.ts
@@ -6,6 +6,7 @@ import type { GameSession } from '../plugins/core/game/session';
 import { deleteRoom } from '../plugins/core/room/store';
 import type { TurnTimer } from '../plugins/core/game/turn-timer';
 import { persistGameOnDissolve } from './game-events';
+import { clearRoomTimeouts } from './room-events';
 import type { SocketData } from './types';
 import { clearVoicePresence } from './voice-presence';
 
@@ -19,6 +20,7 @@ export async function dissolveRoom(
   db?: Kysely<Database>,
 ): Promise<void> {
   turnTimer.stop(roomCode);
+  clearRoomTimeouts(roomCode);
   const session = sessions.get(roomCode);
 
   if (session && db) {

--- a/packages/server/src/ws/socket-handler.ts
+++ b/packages/server/src/ws/socket-handler.ts
@@ -4,7 +4,7 @@ import { authenticateSocket } from '../auth/middleware';
 import { RoomManager } from '../plugins/core/room/manager';
 import { TurnTimer } from '../plugins/core/game/turn-timer';
 import { GameSession } from '../plugins/core/game/session';
-import { registerRoomEvents, emitGameUpdate, startTurnTimer, executeAutopilot } from './room-events';
+import { registerRoomEvents, emitGameUpdate, startTurnTimer, executeAutopilot, resetPlayerTimeout } from './room-events';
 import { registerGameEvents } from './game-events';
 import { getRoom, getRoomPlayers, setRoomOwner } from '../plugins/core/room/store';
 import { saveGameState, loadGameState } from '../plugins/core/game/state-store';
@@ -156,6 +156,7 @@ export function setupSocketHandlers(io: SocketIOServer, redis: KvStore, jwtSecre
       if (session) {
         session.setPlayerConnected(userId, true);
         session.setPlayerAutopilot(userId, false);
+        resetPlayerTimeout(roomCode, userId);
         await saveGameState(redis, roomCode, session.getFullState());
         await emitGameUpdate(io, roomCode, session, redis);
         io.to(roomCode).emit('player:reconnected', { playerId: userId });
@@ -204,6 +205,7 @@ export function setupSocketHandlers(io: SocketIOServer, redis: KvStore, jwtSecre
         startAutoPlay(userId, roomCode);
       } else {
         stopAutoPlay(userId);
+        resetPlayerTimeout(roomCode, userId);
       }
       await saveGameState(redis, roomCode, session.getFullState());
       await emitGameUpdate(io, roomCode, session, redis);


### PR DESCRIPTION
## Summary

- 玩家连续超时 2 次后自动进入托管模式，避免挂机卡住其他玩家
- 玩家主动操作（出牌、摸牌、过牌、质疑、选颜色等）时重置超时计数
- 玩家重连或手动关闭托管时也会重置计数
- 游戏结束/房间销毁时自动清理计数数据

## Test plan

- [ ] 玩家连续超时 2 次后自动进入托管
- [ ] 进入托管后由 AI 自动出牌
- [ ] 玩家手动操作后超时计数重置，不会误触发自动托管
- [ ] 玩家手动关闭托管后计数重置
- [ ] 玩家断线重连后计数重置且托管关闭
- [ ] 游戏结束后计数数据被清理

🤖 Generated with [Claude Code](https://claude.com/claude-code)