### PR TITLE
fix: 修复选颜色阶段被抓UNO后无法继续选色

### DIFF
--- a/packages/shared/src/rules/game-engine.ts
+++ b/packages/shared/src/rules/game-engine.ts
@@ -1,4 +1,4 @@
-import type { GameState, GameAction, PendingPenaltyDraw, DrawSide } from '../types/game';
+import type { GameState, GameAction, DrawSide } from '../types/game';
 import type { Color } from '../types/card';
 import { reshuffleSideFromDiscard } from './deck';
 import { canPlayCard, isValidWildDrawFour } from './validation';
@@ -129,15 +129,19 @@ function startPenaltyDraw(
   if (count <= 0) return state;
   const playerIdx = playerIndex(state, playerId);
   if (playerIdx === -1) return state;
-  const queue: PendingPenaltyDraw[] = state.pendingPenaltyDraws && state.pendingPenaltyDraws > 0
-    ? [
+
+  const shouldQueue =
+    (state.pendingPenaltyDraws && state.pendingPenaltyDraws > 0) ||
+    (state.phase !== 'playing');
+
+  if (shouldQueue) {
+    return {
+      ...state,
+      pendingPenaltyQueue: [
         ...(state.pendingPenaltyQueue ?? []),
         { playerId, count, nextPlayerIndex, sourcePlayerId },
-      ]
-    : (state.pendingPenaltyQueue ?? []);
-
-  if (state.pendingPenaltyDraws && state.pendingPenaltyDraws > 0) {
-    return { ...state, pendingPenaltyQueue: queue };
+      ],
+    };
   }
 
   return {
@@ -147,7 +151,7 @@ function startPenaltyDraw(
     pendingPenaltyDraws: count,
     pendingPenaltyNextPlayerIndex: nextPlayerIndex,
     pendingPenaltySourcePlayerId: sourcePlayerId,
-    pendingPenaltyQueue: queue,
+    pendingPenaltyQueue: state.pendingPenaltyQueue ?? [],
   };
 }
 
@@ -194,6 +198,19 @@ function finishPenaltyDrawIfNeeded(state: GameState, lastAction: GameAction): Ga
   }
 
   return finished;
+}
+
+export function drainPenaltyQueue(state: GameState): GameState {
+  const queue = state.pendingPenaltyQueue ?? [];
+  if (queue.length === 0 || state.phase !== 'playing') return state;
+  const [next, ...rest] = queue;
+  return startPenaltyDraw(
+    { ...state, pendingPenaltyQueue: rest },
+    next!.playerId,
+    next!.count,
+    next!.nextPlayerIndex,
+    next!.sourcePlayerId ?? null,
+  );
 }
 
 function withChosenColorOnTopDiscard(state: GameState, color: Color): GameState {
@@ -438,13 +455,13 @@ function handleChooseColor(
       colorState.players.length,
       colorState.direction,
     );
-    return {
+    return drainPenaltyQueue({
       ...colorState,
       currentColor: action.color,
       phase: 'playing',
       currentPlayerIndex: newIndex,
       lastAction: action,
-    };
+    });
   }
 }
 

--- a/packages/shared/src/rules/house-rules-engine.ts
+++ b/packages/shared/src/rules/house-rules-engine.ts
@@ -1,5 +1,5 @@
 import type { GameState, GameAction } from '../types/game';
-import { applyAction } from './game-engine';
+import { applyAction, drainPenaltyQueue } from './game-engine';
 import { buildRuleContext } from './house-rule-helpers';
 import { PRE_CHECK_PLUGINS, POST_PROCESS_PLUGINS } from './rules/index';
 
@@ -12,7 +12,7 @@ export function applyActionWithHouseRules(state: GameState, action: GameAction):
     if (!plugin.isEnabled(hr)) continue;
     if (!plugin.preCheck) continue;
     const result = plugin.preCheck(state, action, ctx);
-    if (result.handled) return result.state;
+    if (result.handled) return drainPenaltyQueue(result.state);
   }
 
   let next = applyAction(state, action);

--- a/packages/shared/tests/game-engine.test.ts
+++ b/packages/shared/tests/game-engine.test.ts
@@ -1098,3 +1098,52 @@ describe('PLAY_CARD - last draw_two triggers effect then ends round', () => {
     expect(afterPenalty.players[1]!.hand).toHaveLength(3);
   });
 });
+
+describe('CATCH_UNO during choosing_color phase', () => {
+  it('does not interrupt choosing_color - penalty queued until color is chosen', () => {
+    const wildCard = makeCard('wild', null, { id: 'w1' });
+    const state = makeState({
+      players: [
+        { id: 'p1', name: 'Alice', hand: [wildCard], score: 0, connected: true, calledUno: false },
+        { id: 'p2', name: 'Bob', hand: [makeCard('number', 'red', { value: 1, id: 'b1' })], score: 0, connected: true, calledUno: false },
+      ],
+      deckLeft: [makeCard('number', 'blue', { value: 3, id: 'd1' }), makeCard('number', 'green', { value: 4, id: 'd2' })],
+      currentPlayerIndex: 0,
+    });
+
+    // p1 plays wild -> choosing_color, p1 has 0 cards but just played so hand is empty
+    const afterPlay = applyAction(state, { type: 'PLAY_CARD', playerId: 'p1', cardId: 'w1' });
+    expect(afterPlay.phase).toBe('choosing_color');
+    expect(afterPlay.players[0]!.hand).toHaveLength(0);
+
+    // p2 catches p1's UNO (p1 didn't call)... but wait, p1 has 0 cards so can't be caught
+    // Actual scenario: p1 had 2 cards, plays wild, now has 1 card, didn't call UNO
+    const wildCard2 = makeCard('wild', null, { id: 'w2' });
+    const state2 = makeState({
+      players: [
+        { id: 'p1', name: 'Alice', hand: [wildCard2, makeCard('number', 'red', { value: 5, id: 'x1' })], score: 0, connected: true, calledUno: false },
+        { id: 'p2', name: 'Bob', hand: [makeCard('number', 'red', { value: 1, id: 'b1' })], score: 0, connected: true, calledUno: false },
+      ],
+      deckLeft: [makeCard('number', 'blue', { value: 3, id: 'd1' }), makeCard('number', 'green', { value: 4, id: 'd2' })],
+      currentPlayerIndex: 0,
+    });
+
+    const afterPlay2 = applyAction(state2, { type: 'PLAY_CARD', playerId: 'p1', cardId: 'w2' });
+    expect(afterPlay2.phase).toBe('choosing_color');
+    expect(afterPlay2.players[0]!.hand).toHaveLength(1);
+    expect(afterPlay2.players[0]!.calledUno).toBe(false);
+
+    // p2 catches p1 during choosing_color
+    const afterCatch = applyAction(afterPlay2, { type: 'CATCH_UNO', catcherId: 'p2', targetId: 'p1' });
+    // Phase should still be choosing_color - penalty is queued
+    expect(afterCatch.phase).toBe('choosing_color');
+    expect(afterCatch.players[0]!.unoCaught).toBe(true);
+    expect(afterCatch.pendingPenaltyQueue?.length).toBeGreaterThan(0);
+
+    // p1 chooses color -> penalty kicks in
+    const afterColor = applyAction(afterCatch, { type: 'CHOOSE_COLOR', playerId: 'p1', color: 'blue' });
+    expect(afterColor.phase).toBe('playing');
+    expect(afterColor.pendingPenaltyDraws).toBeGreaterThan(0);
+    expect(afterColor.players[afterColor.currentPlayerIndex]!.id).toBe('p1');
+  });
+});


### PR DESCRIPTION
## Summary

- 出 Wild 牌后进入选颜色阶段，此时被抓 UNO 会触发 `startPenaltyDraw`，将 phase 强制改为 `playing` 并中断选颜色流程
- 修复：当 phase 不是 `playing` 时，罚摸进入等待队列，等当前阶段完成后自动执行
- 同样适用于 `challenging`/`choosing_swap_target` 阶段被抓 UNO 的场景

## Test plan

- [ ] 出 Wild 牌（手里还剩 1 张），不喊 UNO，被抓后仍能正常选颜色
- [ ] 选完颜色后罚摸正常执行
- [ ] 出 Wild Draw Four 后被抓 UNO，质疑流程正常进行
- [ ] 7 换牌选目标时被抓 UNO，换牌正常完成后再罚摸
- [ ] 已有测试全部通过（219 tests）

🤖 Generated with [Claude Code](https://claude.com/claude-code)