### PR TITLE
fix: 牌堆耗尽自动洗牌、抢出村规、托管与UI改进

### DIFF
--- a/packages/client/src/features/game/components/DrawPile.tsx
+++ b/packages/client/src/features/game/components/DrawPile.tsx
@@ -18,6 +18,7 @@ interface DrawPileProps {
 
 export default function DrawPile({ side, isPortrait, onDraw, drawTargetX, drawTargetY, drawAnimTrigger = 0, drawUntilCount = 0 }: DrawPileProps) {
   const deckCount = useGameStore((s) => side === 'left' ? s.deckLeftCount : s.deckRightCount);
+  const discardPileLength = useGameStore((s) => s.discardPile.length);
   const phase = useGameStore((s) => s.phase);
   const hasDrawnThisTurn = useGameStore((s) => s.hasDrawnThisTurn);
   const pendingPenaltyDraws = useGameStore((s) => s.pendingPenaltyDraws);
@@ -31,7 +32,8 @@ export default function DrawPile({ side, isPortrait, onDraw, drawTargetX, drawTa
   const mustDrawUntilPlayable = Boolean(settings?.houseRules?.drawUntilPlayable || settings?.houseRules?.deathDraw);
   const isDrawUntilTurn = mustDrawUntilPlayable && !isPenaltyDrawing;
   const canContinueDrawUntilPlayable = !isPenaltyDrawing && mustDrawUntilPlayable && hasDrawnThisTurn && playableIds.size === 0;
-  const canDraw = isMyTurn && phase === 'playing' && deckCount > 0 && (isPenaltyDrawing || !hasDrawnThisTurn || canContinueDrawUntilPlayable);
+  const hasCardsAvailable = deckCount > 0 || discardPileLength > 1;
+  const canDraw = isMyTurn && phase === 'playing' && hasCardsAvailable && (isPenaltyDrawing || !hasDrawnThisTurn || canContinueDrawUntilPlayable);
 
   const showNoPlayableHint = canDraw && !isDrawUntilTurn && !isPenaltyDrawing && drawStack === 0 && playableIds.size === 0 && !settings?.houseRules?.noHints;
   const emphasizeDraw = canDraw && !settings?.houseRules?.noHints;
@@ -79,7 +81,7 @@ export default function DrawPile({ side, isPortrait, onDraw, drawTargetX, drawTa
         )}
         style={{
           cursor: canDraw ? 'pointer' : 'default',
-          opacity: deckCount === 0 ? 0.25 : canDraw ? 1 : 0.5,
+          opacity: deckCount === 0 && !canDraw ? 0.25 : canDraw ? 1 : 0.5,
         }}
       />
       <span

--- a/packages/client/src/features/game/components/GameActions.tsx
+++ b/packages/client/src/features/game/components/GameActions.tsx
@@ -37,8 +37,13 @@ export default function GameActions({ onCallUno, onCatchUno, onChallenge, onAcce
   );
   const catchTargets = players.filter((p) => p.id !== userId && p.handCount === 1 && !p.calledUno && !p.unoCaught);
   const noChallengeWD4 = settings?.houseRules?.noChallengeWildFour ?? false;
+  const deckLeftCount = useGameStore((s) => s.deckLeftCount);
+  const deckRightCount = useGameStore((s) => s.deckRightCount);
+  const discardPileLength = useGameStore((s) => s.discardPile.length);
+  const noCardsAvailable = deckLeftCount === 0 && deckRightCount === 0 && discardPileLength <= 1;
   const mustDrawUntilPlayable = Boolean(settings?.houseRules?.drawUntilPlayable || settings?.houseRules?.deathDraw);
   const canPassAfterDraw = pendingPenaltyDraws === 0 && drawStack === 0 && hasDrawnThisTurn && (!mustDrawUntilPlayable || playableIds.size > 0);
+  const canPass = canPassAfterDraw || noCardsAvailable;
 
   const withCooldown = (fn: () => void) => () => {
     if (cooldown) return;
@@ -61,7 +66,7 @@ export default function GameActions({ onCallUno, onCatchUno, onChallenge, onAcce
           <Button variant="secondary" onClick={onAccept} sound="action">接受</Button>
         </>
       )}
-      {isMyTurn && canPassAfterDraw && phase === 'playing' && (
+      {isMyTurn && canPass && phase === 'playing' && (
         <Button variant="secondary" onClick={onPass} sound="click">跳过</Button>
       )}
       {phase === 'choosing_swap_target' && isMyTurn && (

--- a/packages/client/src/features/game/components/ScoreBoard.tsx
+++ b/packages/client/src/features/game/components/ScoreBoard.tsx
@@ -1,4 +1,4 @@
-import { Trophy, BarChart3, Crown } from 'lucide-react';
+import { Trophy, BarChart3, Crown, Check } from 'lucide-react';
 import { useGameStore } from '../stores/game-store';
 import { useEffectiveUserId } from '../hooks/useEffectiveUserId';
 import { useRoomStore } from '@/shared/stores/room-store';
@@ -51,16 +51,27 @@ export default function ScoreBoard({ onPlayAgain, onRematch, onBackToLobby }: Sc
           <thead>
             <tr className="text-muted-foreground text-xs">
               <th className="text-left px-2 py-1">玩家</th>
+              {!isGameOver && <th className="px-2 py-1">状态</th>}
               <th className="text-right px-2 py-1">分数</th>
             </tr>
           </thead>
           <tbody>
-            {sorted.map((p) => (
-              <tr key={p.id} className={cn(p.id === winnerId ? 'text-accent' : 'text-foreground')}>
-                <td className="px-2 py-1.5 text-left">{p.id === winnerId && <Crown size={14} className="inline align-middle mr-1" />}{p.name}</td>
-                <td className="px-2 py-1.5 text-right font-bold">{p.score}</td>
-              </tr>
-            ))}
+            {sorted.map((p) => {
+              const ready = !!vote?.voters.includes(p.id);
+              return (
+                <tr key={p.id} className={cn(p.id === winnerId ? 'text-accent' : 'text-foreground')}>
+                  <td className="px-2 py-1.5 text-left">{p.id === winnerId && <Crown size={14} className="inline align-middle mr-1" />}{p.name}</td>
+                  {!isGameOver && (
+                    <td className="px-2 py-1.5 text-center">
+                      {ready
+                        ? <Check size={14} className="inline text-green-400" />
+                        : <span className="text-xs text-muted-foreground">等待中</span>}
+                    </td>
+                  )}
+                  <td className="px-2 py-1.5 text-right font-bold">{p.score}</td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
         {!isGameOver && (

--- a/packages/client/src/features/game/components/TopBar.tsx
+++ b/packages/client/src/features/game/components/TopBar.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Eye, Volume2, VolumeX, Spade, DoorOpen, Bot, HelpCircle } from 'lucide-react';
 import TurnTimer from './TurnTimer';
 import { useSettingsStore } from '@/shared/stores/settings-store';
@@ -7,6 +8,8 @@ import { useEffectiveUserId } from '../hooks/useEffectiveUserId';
 import { getSocket } from '@/shared/socket';
 import { cn } from '@/shared/lib/utils';
 import { BUILD_VERSION } from '@/shared/build-info';
+
+const AUTOPILOT_COOLDOWN_MS = 3000;
 
 interface TopBarProps { roomCode: string; }
 
@@ -18,9 +21,13 @@ export default function TopBar({ roomCode }: TopBarProps) {
   const toggleInfoDrawer = useGameStore((s) => s.toggleInfoDrawer);
   const players = useGameStore((s) => s.players);
   const myAutopilot = players.find(p => p.id === userId)?.autopilot ?? false;
+  const [autopilotCooldown, setAutopilotCooldown] = useState(false);
 
   const handleToggleAutopilot = () => {
+    if (autopilotCooldown) return;
+    setAutopilotCooldown(true);
     getSocket().emit('player:toggle-autopilot', () => {});
+    setTimeout(() => setAutopilotCooldown(false), AUTOPILOT_COOLDOWN_MS);
   };
 
   const handleDissolve = () => {
@@ -45,11 +52,12 @@ export default function TopBar({ roomCode }: TopBarProps) {
         </button>
         <button
           onClick={handleToggleAutopilot}
+          disabled={autopilotCooldown}
           className={cn(
             'bg-transparent border-none text-sm cursor-pointer',
-            myAutopilot ? 'text-accent' : 'text-muted-foreground'
+            autopilotCooldown ? 'opacity-40 cursor-not-allowed' : myAutopilot ? 'text-accent' : 'text-muted-foreground'
           )}
-          title={myAutopilot ? '关闭自动托管' : '开启自动托管'}
+          title={autopilotCooldown ? '操作冷却中...' : myAutopilot ? '关闭自动托管' : '开启自动托管'}
         >
           <Bot size={16} />
         </button>

--- a/packages/client/src/features/game/hooks/usePlayableCardIds.ts
+++ b/packages/client/src/features/game/hooks/usePlayableCardIds.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 import { useGameStore } from '../stores/game-store';
 import { useEffectiveUserId } from './useEffectiveUserId';
 import { useIsMyTurn } from './useIsMyTurn';
-import { getPlayableCardIds } from '@/shared/utils/playable-cards';
+import { getPlayableCardIds, getJumpInCardIds } from '@/shared/utils/playable-cards';
 
 export function usePlayableCardIds(): Set<string> {
   const userId = useEffectiveUserId();
@@ -19,7 +19,11 @@ export function usePlayableCardIds(): Set<string> {
   const topCard = discardPile[discardPile.length - 1];
 
   return useMemo(() => {
-    if (!isMyTurn || phase !== 'playing') return new Set<string>();
+    if (phase !== 'playing') return new Set<string>();
+    if (!isMyTurn) {
+      if (!settings?.houseRules?.jumpIn) return new Set<string>();
+      return getJumpInCardIds(me?.hand ?? [], topCard);
+    }
     if (pendingPenaltyDraws > 0) return new Set<string>();
     return getPlayableCardIds({
       hand: me?.hand ?? [],

--- a/packages/client/src/shared/utils/playable-cards.ts
+++ b/packages/client/src/shared/utils/playable-cards.ts
@@ -38,3 +38,13 @@ export function getPlayableCardIds(params: {
 
   return new Set(playable.map((card) => card.id));
 }
+
+export function getJumpInCardIds(hand: Card[], topCard?: Card): Set<string> {
+  if (!topCard) return new Set();
+  const ids = hand.filter((card) =>
+    card.type === topCard.type &&
+    card.color === topCard.color &&
+    (card.type !== 'number' || (topCard.type === 'number' && card.value === topCard.value)),
+  ).map((card) => card.id);
+  return new Set(ids);
+}

--- a/packages/server/src/ws/game-events.ts
+++ b/packages/server/src/ws/game-events.ts
@@ -144,6 +144,7 @@ async function emitTerminalStateIfNeeded(
   turnTimer: TurnTimer,
   redis: KvStore,
   db: Kysely<Database>,
+  sessions: Map<string, GameSession>,
 ): Promise<boolean> {
   const state = session.getFullState();
   if (state.phase !== 'round_end' && state.phase !== 'game_over') return false;
@@ -158,8 +159,26 @@ async function emitTerminalStateIfNeeded(
   if (state.phase === 'round_end') {
     const scores = Object.fromEntries(state.players.map((p) => [p.id, p.score]));
     nextRoundVotes.delete(roomCode);
-    io.to(roomCode).emit('game:next_round_vote', getNextRoundVoteState(roomCode, session));
     session.recordEvent(GameEventType.ROUND_END, { winnerId: state.winnerId!, scores }, null);
+
+    const autopilotIds = state.players.filter((p) => p.autopilot).map((p) => p.id);
+    if (autopilotIds.length > 0) {
+      const votes = nextRoundVotes.get(roomCode) ?? new Set<string>();
+      for (const id of autopilotIds) votes.add(id);
+      nextRoundVotes.set(roomCode, votes);
+    }
+
+    const voteState = getNextRoundVoteState(roomCode, session);
+    io.to(roomCode).emit('game:next_round_vote', voteState);
+
+    if (voteState.votes >= voteState.required) {
+      const room = await getRoom(redis, roomCode);
+      const ownerIsAutopilot = state.players.some((p) => p.id === room?.ownerId && p.autopilot);
+      if (ownerIsAutopilot) {
+        await startNextRound(io, redis, roomCode, session, turnTimer, sessions);
+        return true;
+      }
+    }
   }
 
   if (state.phase === 'game_over') {
@@ -215,7 +234,7 @@ export function registerGameEvents(
     await touchRoomActivity(redis, roomCode);
     await saveGameState(redis, roomCode, session.getFullState());
     await emitGameUpdate(io, roomCode, session, redis);
-    if (!(await emitTerminalStateIfNeeded(io, roomCode, session, turnTimer, redis, db))) {
+    if (!(await emitTerminalStateIfNeeded(io, roomCode, session, turnTimer, redis, db, sessions))) {
       startTurnTimer(io, redis, roomCode, session, turnTimer, sessions);
     }
     callback?.({ success: true });
@@ -250,7 +269,7 @@ export function registerGameEvents(
     if (
       (beforeState.pendingPenaltyDraws ?? 0) > 0 &&
       (afterState.pendingPenaltyDraws ?? 0) === 0 &&
-      !(await emitTerminalStateIfNeeded(io, roomCode, session, turnTimer, redis, db))
+      !(await emitTerminalStateIfNeeded(io, roomCode, session, turnTimer, redis, db, sessions))
     ) {
       startTurnTimer(io, redis, roomCode, session, turnTimer, sessions);
     }
@@ -282,7 +301,7 @@ export function registerGameEvents(
     await touchRoomActivity(redis, roomCode);
     await saveGameState(redis, roomCode, session.getFullState());
     await emitGameUpdate(io, roomCode, session, redis);
-    if (await emitTerminalStateIfNeeded(io, roomCode, session, turnTimer, redis, db)) {
+    if (await emitTerminalStateIfNeeded(io, roomCode, session, turnTimer, redis, db, sessions)) {
       return callback?.({ success: true });
     }
     callback?.({ success: true });
@@ -316,7 +335,7 @@ export function registerGameEvents(
     await touchRoomActivity(redis, roomCode);
     await saveGameState(redis, roomCode, session.getFullState());
     await emitGameUpdate(io, roomCode, session, redis);
-    if (!(await emitTerminalStateIfNeeded(io, roomCode, session, turnTimer, redis, db))) {
+    if (!(await emitTerminalStateIfNeeded(io, roomCode, session, turnTimer, redis, db, sessions))) {
       startTurnTimer(io, redis, roomCode, session, turnTimer, sessions);
     }
     callback?.({ success: true });
@@ -333,7 +352,7 @@ export function registerGameEvents(
     await touchRoomActivity(redis, roomCode);
     await saveGameState(redis, roomCode, session.getFullState());
     await emitGameUpdate(io, roomCode, session, redis);
-    if (!(await emitTerminalStateIfNeeded(io, roomCode, session, turnTimer, redis, db))) {
+    if (!(await emitTerminalStateIfNeeded(io, roomCode, session, turnTimer, redis, db, sessions))) {
       startTurnTimer(io, redis, roomCode, session, turnTimer, sessions);
     }
     callback?.({ success: true });
@@ -354,7 +373,7 @@ export function registerGameEvents(
     await touchRoomActivity(redis, roomCode);
     await saveGameState(redis, roomCode, session.getFullState());
     await emitGameUpdate(io, roomCode, session, redis);
-    if (await emitTerminalStateIfNeeded(io, roomCode, session, turnTimer, redis, db)) {
+    if (await emitTerminalStateIfNeeded(io, roomCode, session, turnTimer, redis, db, sessions)) {
       // terminal state already emitted
     } else {
       startTurnTimer(io, redis, roomCode, session, turnTimer, sessions);

--- a/packages/server/src/ws/socket-handler.ts
+++ b/packages/server/src/ws/socket-handler.ts
@@ -18,6 +18,9 @@ import { registerVoicePresenceEvents, removeVoicePresence } from './voice-presen
 const RECONNECT_TIMEOUT_MS = 60_000;
 const AUTOPILOT_THINK_MS = 2_000;
 const ROOM_IDLE_SWEEP_MS = 60_000;
+const AUTOPILOT_TOGGLE_COOLDOWN_MS = 3_000;
+
+const autopilotToggleTimestamps = new Map<string, number>();
 
 export function setupSocketHandlers(io: SocketIOServer, redis: KvStore, jwtSecret: string, roomIdleTimeoutMs: number) {
   const roomManager = new RoomManager(redis);
@@ -191,6 +194,13 @@ export function setupSocketHandlers(io: SocketIOServer, redis: KvStore, jwtSecre
     registerVoicePresenceEvents(socket, io);
 
     socket.on('player:toggle-autopilot', async (callback) => {
+      const now = Date.now();
+      const lastToggle = autopilotToggleTimestamps.get(userId) ?? 0;
+      if (now - lastToggle < AUTOPILOT_TOGGLE_COOLDOWN_MS) {
+        return callback?.({ success: false, error: '操作太频繁，请稍后再试' });
+      }
+      autopilotToggleTimestamps.set(userId, now);
+
       const roomCode = socket.data.roomCode;
       if (!roomCode) return callback?.({ success: false, error: '不在房间中' });
       const session = sessions.get(roomCode);
@@ -216,6 +226,7 @@ export function setupSocketHandlers(io: SocketIOServer, redis: KvStore, jwtSecre
     socket.on('disconnect', async () => {
       clearRateLimit(socket.id);
       clearThrowTimestamp(userId);
+      autopilotToggleTimestamps.delete(userId);
       const roomCode = socket.data.roomCode;
       if (!roomCode) return;
       removeVoicePresence(io, roomCode, userId);

--- a/packages/shared/src/rules/autopilot-strategy.ts
+++ b/packages/shared/src/rules/autopilot-strategy.ts
@@ -63,12 +63,18 @@ export function chooseAutopilotAction(state: GameState, playerId: string): GameA
   const currentPlayer = state.players[state.currentPlayerIndex];
   if (!currentPlayer || currentPlayer.id !== playerId) return [];
 
+  const noCards = state.deckLeft.length === 0 && state.deckRight.length === 0 && state.discardPile.length <= 1;
+
   if ((state.pendingPenaltyDraws ?? 0) > 0) {
+    if (noCards) return [{ type: 'PASS', playerId }];
     return [{ type: 'DRAW_CARD', playerId, side: autopilotSide }];
   }
 
   const topCard = state.discardPile[state.discardPile.length - 1];
-  if (!topCard || !state.currentColor) return [{ type: 'DRAW_CARD', playerId, side: autopilotSide }];
+  if (!topCard || !state.currentColor) {
+    if (noCards) return [{ type: 'PASS', playerId }];
+    return [{ type: 'DRAW_CARD', playerId, side: autopilotSide }];
+  }
 
   const hasDrawnThisTurn =
     state.lastAction?.type === 'DRAW_CARD' &&
@@ -77,7 +83,7 @@ export function chooseAutopilotAction(state: GameState, playerId: string): GameA
   if (hasDrawnThisTurn && state.drawStack === 0) {
     const playableAfterDraw = getPlayableCards(player.hand, topCard, state.currentColor);
     if (playableAfterDraw.length === 0) {
-      if (state.settings.houseRules.drawUntilPlayable || state.settings.houseRules.deathDraw) {
+      if (!noCards && (state.settings.houseRules.drawUntilPlayable || state.settings.houseRules.deathDraw)) {
         return [{ type: 'DRAW_CARD', playerId, side: autopilotSide }];
       }
       return [{ type: 'PASS', playerId }];
@@ -117,11 +123,13 @@ export function chooseAutopilotAction(state: GameState, playerId: string): GameA
       }
     }
 
+    if (noCards) return [{ type: 'PASS', playerId }];
     return [{ type: 'DRAW_CARD', playerId, side: autopilotSide }];
   }
 
   const playable = getPlayableCards(player.hand, topCard, state.currentColor);
   if (playable.length === 0) {
+    if (noCards) return [{ type: 'PASS', playerId }];
     return [{ type: 'DRAW_CARD', playerId, side: autopilotSide }];
   }
 

--- a/packages/shared/src/rules/game-engine.ts
+++ b/packages/shared/src/rules/game-engine.ts
@@ -10,6 +10,10 @@ import { UNO_PENALTY_CARDS } from '../constants/scoring';
 // Helpers
 // -----------------------------------------------------------------------------
 
+function hasCardsAvailable(state: GameState): boolean {
+  return state.deckLeft.length > 0 || state.deckRight.length > 0 || state.discardPile.length > 1;
+}
+
 /**
  * Draw `count` cards from the specified side deck into the given player's hand.
  * Reshuffles from the discard pile into the side deck if it runs out mid-draw.
@@ -396,20 +400,21 @@ function handlePass(
   action: Extract<GameAction, { type: 'PASS' }>,
 ): GameState {
   if (state.phase !== 'playing') return state;
-
-  // Penalty draws from +2/+4 are not a normal draw-then-pass turn.
-  if ((state.pendingPenaltyDraws ?? 0) > 0 || state.drawStack > 0) return state;
-
   if (action.playerId !== currentPlayerId(state)) return state;
-  if ((state.pendingPenaltyDraws ?? 0) > 0 || state.drawStack > 0) return state;
 
-  // Can only pass after drawing
-  if (
-    !state.lastAction ||
-    state.lastAction.type !== 'DRAW_CARD' ||
-    state.lastAction.playerId !== action.playerId
-  ) {
-    return state;
+  const noCards = !hasCardsAvailable(state);
+
+  if (!noCards) {
+    if ((state.pendingPenaltyDraws ?? 0) > 0 || state.drawStack > 0) return state;
+
+    // Can only pass after drawing
+    if (
+      !state.lastAction ||
+      state.lastAction.type !== 'DRAW_CARD' ||
+      state.lastAction.playerId !== action.playerId
+    ) {
+      return state;
+    }
   }
 
   const newIndex = getNextPlayerIndex(
@@ -417,7 +422,18 @@ function handlePass(
     state.players.length,
     state.direction,
   );
-  return { ...state, currentPlayerIndex: newIndex, lastAction: action };
+  return {
+    ...state,
+    currentPlayerIndex: newIndex,
+    lastAction: action,
+    ...(noCards ? {
+      pendingPenaltyDraws: 0,
+      drawStack: 0,
+      pendingPenaltyNextPlayerIndex: null,
+      pendingPenaltySourcePlayerId: null,
+      pendingPenaltyQueue: [],
+    } : {}),
+  };
 }
 
 function handleChooseColor(

--- a/packages/shared/tests/autopilot-strategy.test.ts
+++ b/packages/shared/tests/autopilot-strategy.test.ts
@@ -101,6 +101,8 @@ describe('chooseAutopilotAction after drawing', () => {
         { id: 'p1', name: 'Alice', hand: [drawn], score: 0, connected: true, autopilot: true, calledUno: false },
         { id: 'p2', name: 'Bob', hand: [], score: 0, connected: true, autopilot: false, calledUno: false },
       ],
+      deckLeft: [makeCard('number', 'green', { value: 3, id: 'deck1' })],
+      deckLeftInitialCount: 1,
       lastAction: { type: 'DRAW_CARD', playerId: 'p1', side: 'left' as const },
       settings: {
         turnTimeLimit: 30,

--- a/packages/shared/tests/game-engine.test.ts
+++ b/packages/shared/tests/game-engine.test.ts
@@ -367,6 +367,8 @@ describe('PASS', () => {
         { id: 'p2', name: 'Bob', hand: [], score: 0, connected: true, calledUno: false },
         { id: 'p3', name: 'Carol', hand: [], score: 0, connected: true, calledUno: false },
       ],
+      deckLeft: [makeCard('number', 'blue', { value: 1, id: 'deck1' })],
+      deckLeftInitialCount: 1,
       lastAction: null,
     });
     const next = applyAction(state, { type: 'PASS', playerId: 'p1' });


### PR DESCRIPTION
## Summary
- **牌堆洗牌修复**: 客户端在牌堆为0时阻止点击摸牌，导致服务端洗牌逻辑无法触发。现在当弃牌堆有牌时允许摸牌，服务端自动从弃牌堆洗牌补充
- **无牌可摸时防卡死**: 所有牌堆和弃牌堆都耗尽时，允许直接过牌并清除罚摸状态，托管和超时也正确处理
- **抢出(jumpIn)村规修复**: 客户端在非自己回合时禁止所有出牌操作，导致抢出村规无法使用。现在开启抢出时，非当前玩家的完全相同手牌可点击出牌
- **托管自动投票下一局**: 回合结束时自动为托管玩家投票准备，若房主也是托管则直接开始下一局
- **托管切换限流**: 客户端按钮3秒冷却 + 服务端3秒时间戳校验，防止频繁切换
- **计分板准备状态**: 回合结束投票阶段在每个玩家名旁显示✓或"等待中"

## Test plan
- [x] shared 219 tests 全部通过
- [x] client 类型检查通过
- [x] server 类型检查通过
- [x] client 生产构建通过
- [ ] 手动测试：摸完一侧牌堆后点击该侧能正常洗牌摸牌
- [ ] 手动测试：两侧牌堆都摸完后弃牌堆有牌时仍可摸牌
- [ ] 手动测试：完全无牌时显示跳过按钮，点击后正常过牌
- [ ] 手动测试：开启抢出村规后，非当前玩家可出完全相同的牌
- [ ] 手动测试：托管玩家在回合结束后自动显示为已准备
- [ ] 手动测试：快速连点托管按钮被冷却拦截

🤖 Generated with [Claude Code](https://claude.com/claude-code)