### PR TITLE
fix: 房主投票和开始下一轮分离为两步操作

### DIFF
--- a/packages/server/src/ws/game-events.ts
+++ b/packages/server/src/ws/game-events.ts
@@ -171,14 +171,6 @@ async function emitTerminalStateIfNeeded(
     const voteState = getNextRoundVoteState(roomCode, session);
     io.to(roomCode).emit('game:next_round_vote', voteState);
 
-    if (voteState.votes >= voteState.required) {
-      const room = await getRoom(redis, roomCode);
-      const ownerIsAutopilot = state.players.some((p) => p.id === room?.ownerId && p.autopilot);
-      if (ownerIsAutopilot) {
-        await startNextRound(io, redis, roomCode, session, turnTimer, sessions);
-        return true;
-      }
-    }
   }
 
   if (state.phase === 'game_over') {
@@ -437,13 +429,14 @@ export function registerGameEvents(
     const room = await getRoom(redis, roomCode);
     const isOwner = room?.ownerId === data.user.userId;
     const votes = nextRoundVotes.get(roomCode) ?? new Set<string>();
+    const hadAlreadyVoted = votes.has(data.user.userId);
     votes.add(data.user.userId);
     nextRoundVotes.set(roomCode, votes);
 
     const voteState = getNextRoundVoteState(roomCode, session);
     io.to(roomCode).emit('game:next_round_vote', voteState);
 
-    if (isOwner && voteState.votes >= voteState.required) {
+    if (isOwner && hadAlreadyVoted && voteState.votes >= voteState.required) {
       await startNextRound(io, redis, roomCode, session, turnTimer, sessions);
       return callback?.({ success: true, started: true, vote: voteState });
     }


### PR DESCRIPTION
## Summary
- 托管自动投票后，房主点"同意继续"会同时完成投票+开始下一轮，跳过了确认步骤
- 现在房主第一次点击只投票，全票通过后按钮变为"开始下一轮"，再次点击才真正开始
- 同时移除了全员托管时的自动开始逻辑，下一轮必须由房主手动触发

## Test plan
- [x] server 类型检查通过
- [ ] 手动测试：有托管玩家时，房主点"同意继续"只投票不开始
- [ ] 手动测试：全票通过后房主点"开始下一轮"正常开始

🤖 Generated with [Claude Code](https://claude.com/claude-code)