### PR TITLE
fix: 修复罚摸期间可提前跳过的问题

### DIFF
--- a/packages/client/src/features/game/components/DrawPile.tsx
+++ b/packages/client/src/features/game/components/DrawPile.tsx
@@ -31,9 +31,10 @@ export default function DrawPile({ side, isPortrait, onDraw, drawTargetX, drawTa
   const playableIds = usePlayableCardIds();
   const mustDrawUntilPlayable = Boolean(settings?.houseRules?.drawUntilPlayable || settings?.houseRules?.deathDraw);
   const isDrawUntilTurn = mustDrawUntilPlayable && !isPenaltyDrawing;
+  const canStartDrawUntilPlayable = !mustDrawUntilPlayable || playableIds.size === 0;
   const canContinueDrawUntilPlayable = !isPenaltyDrawing && mustDrawUntilPlayable && hasDrawnThisTurn && playableIds.size === 0;
   const hasCardsAvailable = deckCount > 0 || discardPileLength > 1;
-  const canDraw = isMyTurn && phase === 'playing' && hasCardsAvailable && (isPenaltyDrawing || !hasDrawnThisTurn || canContinueDrawUntilPlayable);
+  const canDraw = isMyTurn && phase === 'playing' && hasCardsAvailable && (isPenaltyDrawing || (!hasDrawnThisTurn && canStartDrawUntilPlayable) || canContinueDrawUntilPlayable);
 
   const showNoPlayableHint = canDraw && !isDrawUntilTurn && !isPenaltyDrawing && drawStack === 0 && playableIds.size === 0 && !settings?.houseRules?.noHints;
   const emphasizeDraw = canDraw && !settings?.houseRules?.noHints;

--- a/packages/shared/src/rules/rules/death-draw.ts
+++ b/packages/shared/src/rules/rules/death-draw.ts
@@ -1,7 +1,7 @@
 import type { HouseRulePlugin } from '../house-rule-types';
 import type { GameState, GameAction } from '../../types/game';
 import type { RuleContext, PreCheckResult } from '../house-rule-types';
-import { hasPlayableCard } from '../house-rule-helpers';
+import { hasPendingDrawObligation, hasPlayableCard } from '../house-rule-helpers';
 
 export const deathDrawPass: HouseRulePlugin = {
   meta: {
@@ -34,6 +34,10 @@ export const deathDrawDraw: HouseRulePlugin = {
   isEnabled: (hr) => hr.deathDraw && !hr.drawUntilPlayable,
   preCheck: (state: GameState, action: GameAction, ctx: RuleContext): PreCheckResult => {
     if (action.type !== 'DRAW_CARD') return { handled: false };
+    if (hasPendingDrawObligation(state)) return { handled: false };
+    if (state.phase !== 'playing') return { handled: false };
+    const player = state.players[state.currentPlayerIndex];
+    if (player?.id !== action.playerId) return { handled: false };
     return { handled: true, state: ctx.handleDrawUntilPlayable(state, action) };
   },
 };

--- a/packages/shared/src/rules/rules/draw-until-playable.ts
+++ b/packages/shared/src/rules/rules/draw-until-playable.ts
@@ -14,6 +14,13 @@ export const drawUntilPlayable: HouseRulePlugin = {
   preCheck: (state: GameState, action: GameAction, ctx: RuleContext): PreCheckResult => {
     if (action.type === 'DRAW_CARD') {
       if (hasPendingDrawObligation(state)) return { handled: false };
+      if (state.phase !== 'playing') return { handled: false };
+      const player = state.players[state.currentPlayerIndex];
+      if (player?.id !== action.playerId) return { handled: false };
+      const topCard = state.discardPile[state.discardPile.length - 1];
+      if (topCard && state.currentColor && hasPlayableCard(player.hand, topCard, state.currentColor, ctx.canPlayCard)) {
+        return { handled: true, state };
+      }
       return { handled: true, state: ctx.handleDrawUntilPlayable(state, action) };
     }
     if (action.type !== 'PASS') return { handled: false };

--- a/packages/shared/tests/house-rules-batch1.test.ts
+++ b/packages/shared/tests/house-rules-batch1.test.ts
@@ -203,6 +203,47 @@ describe('deathDraw', () => {
     expect(next.currentPlayerIndex).toBe(1);
   });
 
+  it('does not intercept +2 penalty draws', () => {
+    const state = makeState({
+      currentPlayerIndex: 1,
+      pendingPenaltyDraws: 2,
+      pendingPenaltyNextPlayerIndex: 2,
+      pendingPenaltySourcePlayerId: 'p1',
+      deckLeft: [
+        makeCard('number', 'red', { value: 7, id: 'drawn_red' }),
+        makeCard('number', 'blue', { value: 1, id: 'drawn_blue' }),
+      ],
+      deckRight: [],
+      deckLeftInitialCount: 2,
+      deckRightInitialCount: 0,
+      currentColor: 'red',
+      discardPile: [makeCard('draw_two', 'red', { id: 'discard_d2' })],
+      players: [
+        { id: 'p1', name: 'Alice', hand: [], score: 0, connected: true, calledUno: false },
+        { id: 'p2', name: 'Bob', hand: [], score: 0, connected: true, calledUno: false },
+        { id: 'p3', name: 'Carol', hand: [], score: 0, connected: true, calledUno: false },
+      ],
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        houseRules: { ...DEFAULT_HOUSE_RULES, deathDraw: true },
+      },
+    });
+
+    const afterFirstDraw = applyActionWithHouseRules(state, { type: 'DRAW_CARD', playerId: 'p2', side: 'left' as const });
+    expect(afterFirstDraw.players[1]!.hand.map(c => c.id)).toEqual(['drawn_red']);
+    expect(afterFirstDraw.pendingPenaltyDraws).toBe(1);
+    expect(afterFirstDraw.currentPlayerIndex).toBe(1);
+
+    const passAttempt = applyActionWithHouseRules(afterFirstDraw, { type: 'PASS', playerId: 'p2' });
+    expect(passAttempt).toStrictEqual(afterFirstDraw);
+
+    const afterSecondDraw = applyActionWithHouseRules(afterFirstDraw, { type: 'DRAW_CARD', playerId: 'p2', side: 'left' as const });
+    expect(afterSecondDraw.players[1]!.hand.map(c => c.id)).toEqual(['drawn_red', 'drawn_blue']);
+    expect(afterSecondDraw.pendingPenaltyDraws).toBe(0);
+    expect(afterSecondDraw.currentPlayerIndex).toBe(2);
+  });
+
   it('does not activate draw-until-playable when drawUntilPlayable is already on', () => {
     // When both deathDraw and drawUntilPlayable are on, drawUntilPlayable takes priority
     const deck = [

--- a/packages/shared/tests/house-rules-engine.test.ts
+++ b/packages/shared/tests/house-rules-engine.test.ts
@@ -577,6 +577,75 @@ describe('drawUntilPlayable', () => {
     expect(next.players[0]!.hand[0]!.id).toBe('red7');
   });
 
+  it('rejects drawing when the player already has a playable card', () => {
+    const deck = [
+      makeCard('number', 'blue', { value: 1, id: 'blue1' }),
+    ];
+    const state = makeState({
+      players: [
+        { id: 'p1', name: 'Alice', hand: [makeCard('number', 'red', { value: 9, id: 'red9' })], score: 0, connected: true, calledUno: false },
+        { id: 'p2', name: 'Bob', hand: [makeCard('number', 'blue', { value: 1, id: 'p2c' })], score: 0, connected: true, calledUno: false },
+        { id: 'p3', name: 'Carol', hand: [], score: 0, connected: true, calledUno: false },
+      ],
+      deckLeft: deck,
+      deckRight: [],
+      deckLeftInitialCount: deck.length,
+      deckRightInitialCount: 0,
+      currentColor: 'red',
+      discardPile: [makeCard('number', 'red', { value: 5, id: 'discard_top' })],
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        houseRules: { ...DEFAULT_HOUSE_RULES, drawUntilPlayable: true },
+      },
+    });
+
+    const next = applyActionWithHouseRules(state, { type: 'DRAW_CARD', playerId: 'p1', side: 'left' as const });
+
+    expect(next).toStrictEqual(state);
+  });
+
+  it('keeps +2 penalty draws active until both cards are drawn', () => {
+    const state = makeState({
+      currentPlayerIndex: 1,
+      pendingPenaltyDraws: 2,
+      pendingPenaltyNextPlayerIndex: 2,
+      pendingPenaltySourcePlayerId: 'p1',
+      deckLeft: [
+        makeCard('number', 'red', { value: 7, id: 'drawn_red' }),
+        makeCard('number', 'blue', { value: 1, id: 'drawn_blue' }),
+      ],
+      deckRight: [],
+      deckLeftInitialCount: 2,
+      deckRightInitialCount: 0,
+      currentColor: 'red',
+      discardPile: [makeCard('draw_two', 'red', { id: 'discard_d2' })],
+      players: [
+        { id: 'p1', name: 'Alice', hand: [], score: 0, connected: true, calledUno: false },
+        { id: 'p2', name: 'Bob', hand: [], score: 0, connected: true, calledUno: false },
+        { id: 'p3', name: 'Carol', hand: [], score: 0, connected: true, calledUno: false },
+      ],
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        houseRules: { ...DEFAULT_HOUSE_RULES, drawUntilPlayable: true },
+      },
+    });
+
+    const afterFirstDraw = applyActionWithHouseRules(state, { type: 'DRAW_CARD', playerId: 'p2', side: 'left' as const });
+    expect(afterFirstDraw.players[1]!.hand.map(c => c.id)).toEqual(['drawn_red']);
+    expect(afterFirstDraw.pendingPenaltyDraws).toBe(1);
+    expect(afterFirstDraw.currentPlayerIndex).toBe(1);
+
+    const passAttempt = applyActionWithHouseRules(afterFirstDraw, { type: 'PASS', playerId: 'p2' });
+    expect(passAttempt).toStrictEqual(afterFirstDraw);
+
+    const afterSecondDraw = applyActionWithHouseRules(afterFirstDraw, { type: 'DRAW_CARD', playerId: 'p2', side: 'left' as const });
+    expect(afterSecondDraw.players[1]!.hand.map(c => c.id)).toEqual(['drawn_red', 'drawn_blue']);
+    expect(afterSecondDraw.pendingPenaltyDraws).toBe(0);
+    expect(afterSecondDraw.currentPlayerIndex).toBe(2);
+  });
+
   it('standard DRAW_CARD draws only 1 card without drawUntilPlayable', () => {
     const deck = [
       makeCard('number', 'blue', { value: 1, id: 'blue1' }),


### PR DESCRIPTION
摸到能出为止和死亡抽牌村规在玩家已有罚摸义务时不再拦截 DRAW_CARD，改由核心罚摸流程逐张扣减 pendingPenaltyDraws，避免 +2/+4 或 UNO 罚摸时摸一张后出现跳过。

前端摸牌按钮同步禁止在摸到能出为止规则下已有可出牌时继续起手摸牌，并保留牌堆耗尽时可洗弃牌堆继续摸的判断。

新增回归测试覆盖 drawUntilPlayable/deathDraw 开启时 +2 罚摸两张必须摸满，摸一张后 PASS 会被拒绝。