### PR TITLE
feat: 回合结束踢出未准备玩家 + 退出/掉线鲁棒性优化

### DIFF
--- a/packages/client/src/features/game/components/ScoreBoard.tsx
+++ b/packages/client/src/features/game/components/ScoreBoard.tsx
@@ -1,21 +1,32 @@
-import { Trophy, BarChart3, Crown, Check } from 'lucide-react';
+import { useState, useEffect } from 'react';
+import { Trophy, BarChart3, Crown, Check, UserX } from 'lucide-react';
 import { useGameStore } from '../stores/game-store';
 import { useEffectiveUserId } from '../hooks/useEffectiveUserId';
 import { useRoomStore } from '@/shared/stores/room-store';
 import { cn } from '@/shared/lib/utils';
 import { Button } from '@/shared/components/ui/Button';
 
+const KICK_DELAY_MS = 30_000;
+
 interface ScoreBoardProps {
   onPlayAgain: () => void;
   onRematch: () => void;
   onBackToLobby: () => void;
+  onKickPlayer: (targetId: string) => void;
 }
 
-export default function ScoreBoard({ onPlayAgain, onRematch, onBackToLobby }: ScoreBoardProps) {
+export default function ScoreBoard({ onPlayAgain, onRematch, onBackToLobby, onKickPlayer }: ScoreBoardProps) {
   const players = useGameStore((s) => s.players);
   const winnerId = useGameStore((s) => s.winnerId);
   const phase = useGameStore((s) => s.phase);
   const vote = useGameStore((s) => s.nextRoundVote);
+  const [canKick, setCanKick] = useState(false);
+
+  useEffect(() => {
+    if (phase !== 'round_end') { setCanKick(false); return; }
+    const timer = setTimeout(() => setCanKick(true), KICK_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, [phase]);
   const ownerId = useRoomStore((s) => s.room?.ownerId);
   const userId = useEffectiveUserId();
   const sorted = [...players].sort((a, b) => b.score - a.score);
@@ -62,10 +73,12 @@ export default function ScoreBoard({ onPlayAgain, onRematch, onBackToLobby }: Sc
                 <tr key={p.id} className={cn(p.id === winnerId ? 'text-accent' : 'text-foreground')}>
                   <td className="px-2 py-1.5 text-left">{p.id === winnerId && <Crown size={14} className="inline align-middle mr-1" />}{p.name}</td>
                   {!isGameOver && (
-                    <td className="px-2 py-1.5 text-center">
+                    <td className="px-2 py-1.5 text-center whitespace-nowrap">
                       {ready
                         ? <Check size={14} className="inline text-green-400" />
-                        : <span className="text-xs text-muted-foreground">等待中</span>}
+                        : isHost && canKick && p.id !== userId
+                          ? <button onClick={() => onKickPlayer(p.id)} className="text-xs text-destructive hover:text-destructive/80 cursor-pointer bg-transparent border-none" title="踢出游戏"><UserX size={14} className="inline" /></button>
+                          : <span className="text-xs text-muted-foreground">等待中</span>}
                     </td>
                   )}
                   <td className="px-2 py-1.5 text-right font-bold">{p.score}</td>

--- a/packages/client/src/features/game/hooks/useGameActions.ts
+++ b/packages/client/src/features/game/hooks/useGameActions.ts
@@ -61,6 +61,14 @@ export function useGameActions() {
     getSocket().emit('game:rematch', () => {});
   }, []);
 
+  const kickPlayer = useCallback((targetId: string) => {
+    getSocket().emit('game:kick_player', { targetId }, (res: { success?: boolean; error?: string }) => {
+      if (!res?.success) {
+        useToastStore.getState().addToast(res?.error || '踢出失败', 'error');
+      }
+    });
+  }, []);
+
   return {
     playCard,
     drawCard,
@@ -73,5 +81,6 @@ export function useGameActions() {
     swapTarget,
     playAgain,
     rematch,
+    kickPlayer,
   };
 }

--- a/packages/client/src/features/game/pages/GamePage.tsx
+++ b/packages/client/src/features/game/pages/GamePage.tsx
@@ -75,6 +75,7 @@ export default function GamePage() {
     swapTarget,
     playAgain,
     rematch,
+    kickPlayer,
   } = useGameActions();
 
   useAutoPlay();
@@ -200,7 +201,7 @@ export default function GamePage() {
       {(phase === 'round_end' || phase === 'game_over') && <Confetti />}
       {needsColorPick && <ColorPicker onPick={chooseColor} />}
       {showScoreBoard && (
-        <ScoreBoard onPlayAgain={playAgain} onRematch={rematch} onBackToLobby={backToLobby} />
+        <ScoreBoard onPlayAgain={playAgain} onRematch={rematch} onBackToLobby={backToLobby} onKickPlayer={kickPlayer} />
       )}
     </div>
   );

--- a/packages/client/src/shared/socket.ts
+++ b/packages/client/src/shared/socket.ts
@@ -139,6 +139,16 @@ export function getSocket(): Socket {
       window.location.href = '/';
     });
 
+    socket.on('game:kicked', (data: { reason: string }) => {
+      useRoomStore.getState().clearRoom();
+      useGameStore.getState().clearGame();
+      leaveVoiceSession();
+      useToastStore.getState().addToast(data.reason || '你已被移出游戏', 'error');
+      if (window.location.pathname !== '/lobby') {
+        window.location.assign('/lobby');
+      }
+    });
+
     socket.on('room:dissolved', (data?: { reason?: string }) => {
       useRoomStore.getState().clearRoom();
       useGameStore.getState().clearGame();

--- a/packages/server/src/plugins/core/game/session.ts
+++ b/packages/server/src/plugins/core/game/session.ts
@@ -166,6 +166,17 @@ export class GameSession {
     };
   }
 
+  removePlayer(playerId: string): void {
+    this.state = {
+      ...this.state,
+      players: this.state.players.filter((p) => p.id !== playerId),
+    };
+  }
+
+  getPlayerCount(): number {
+    return this.state.players.length;
+  }
+
   getCurrentPlayerId(): string {
     return this.state.players[this.state.currentPlayerIndex]!.id;
   }

--- a/packages/server/src/ws/game-events.ts
+++ b/packages/server/src/ws/game-events.ts
@@ -10,7 +10,7 @@ import { emitGameUpdate, startTurnTimer, resetPlayerTimeout, clearRoomTimeouts }
 import type { TurnTimer } from '../plugins/core/game/turn-timer';
 import { recordGameResult } from '../db/user-repo';
 import { saveGameEvents, saveDeckInfo } from '../plugins/core/game-history/service';
-import { getRoom, setRoomStatus, touchRoomActivity } from '../plugins/core/room/store';
+import { getRoom, setRoomStatus, touchRoomActivity, removePlayerFromRoom } from '../plugins/core/room/store';
 import type { SocketData } from './types';
 
 function getSession(socket: Socket, sessions: Map<string, GameSession>): { session: GameSession; roomCode: string } | null {
@@ -104,6 +104,24 @@ export async function persistGameOnDissolve(roomCode: string, session: GameSessi
   const startTime = gameStartTimes.get(roomCode) ?? Date.now();
   await persistGameResult(roomCode, session, startTime, db);
   gameStartTimes.delete(roomCode);
+}
+
+export function addAutopilotVote(roomCode: string, playerId: string, session: GameSession, io: SocketIOServer): void {
+  if (!session.isRoundEnd()) return;
+  const votes = nextRoundVotes.get(roomCode) ?? new Set<string>();
+  votes.add(playerId);
+  nextRoundVotes.set(roomCode, votes);
+  const voteState = getNextRoundVoteState(roomCode, session);
+  io.to(roomCode).emit('game:next_round_vote', voteState);
+}
+
+export function removePlayerVote(roomCode: string, playerId: string, session: GameSession, io: SocketIOServer): void {
+  const votes = nextRoundVotes.get(roomCode);
+  if (votes) votes.delete(playerId);
+  if (session.isRoundEnd()) {
+    const voteState = getNextRoundVoteState(roomCode, session);
+    io.to(roomCode).emit('game:next_round_vote', voteState);
+  }
 }
 
 function getNextRoundVoteState(roomCode: string, session: GameSession): NextRoundVoteState {
@@ -442,6 +460,60 @@ export function registerGameEvents(
     }
 
     callback?.({ success: true, started: false, vote: voteState });
+  });
+
+  socket.on('game:kick_player', async (payload: { targetId?: string }, callback) => {
+    const targetId = payload?.targetId;
+    if (!targetId) return callback?.({ success: false, error: '缺少目标玩家' });
+
+    const ctx = getSession(socket, sessions);
+    if (!ctx) return callback?.({ success: false, error: 'No active game' });
+    const { session, roomCode } = ctx;
+
+    if (!session.isRoundEnd()) {
+      return callback?.({ success: false, error: '只能在回合结束阶段踢人' });
+    }
+
+    const room = await getRoom(redis, roomCode);
+    if (room?.ownerId !== data.user.userId) {
+      return callback?.({ success: false, error: '只有房主可以踢人' });
+    }
+
+    if (targetId === data.user.userId) {
+      return callback?.({ success: false, error: '不能踢自己' });
+    }
+
+    const voters = nextRoundVotes.get(roomCode) ?? new Set<string>();
+    if (voters.has(targetId)) {
+      return callback?.({ success: false, error: '该玩家已准备，无法踢出' });
+    }
+
+    const state = session.getFullState();
+    if (!state.players.some((p) => p.id === targetId)) {
+      return callback?.({ success: false, error: '玩家不在游戏中' });
+    }
+
+    session.removePlayer(targetId);
+    await removePlayerFromRoom(redis, roomCode, targetId);
+
+    const targetSockets = await io.in(roomCode).fetchSockets();
+    for (const s of targetSockets) {
+      if ((s.data as SocketData).user.userId === targetId) {
+        s.emit('game:kicked', { reason: '你已被房主移出游戏' });
+        s.leave(roomCode);
+        (s.data as SocketData).roomCode = null;
+      }
+    }
+
+    voters.delete(targetId);
+    const voteState = getNextRoundVoteState(roomCode, session);
+    io.to(roomCode).emit('game:next_round_vote', voteState);
+
+    await saveGameState(redis, roomCode, session.getFullState());
+    await emitGameUpdate(io, roomCode, session, redis);
+    io.to(roomCode).emit('room:updated', { players: state.players.filter((p) => p.id !== targetId).map((p) => ({ userId: p.id, name: p.name })) });
+
+    callback?.({ success: true });
   });
 
   socket.on('game:rematch', async (callback) => {

--- a/packages/server/src/ws/room-events.ts
+++ b/packages/server/src/ws/room-events.ts
@@ -9,7 +9,7 @@ import { getRoom, getRoomPlayers, setRoomSettings, setRoomStatus, touchRoomActiv
 import { GameSession } from '../plugins/core/game/session';
 import { saveGameState } from '../plugins/core/game/state-store';
 import type { TurnTimer } from '../plugins/core/game/turn-timer';
-import { setGameStartTime } from './game-events';
+import { setGameStartTime, removePlayerVote } from './game-events';
 import type { SocketData } from './types';
 import { dissolveRoom } from './room-lifecycle';
 import { removeVoicePresence } from './voice-presence';
@@ -128,10 +128,31 @@ export function registerRoomEvents(
     removeVoicePresence(io, roomCode, data.user.userId);
     socket.leave(roomCode);
     data.roomCode = null;
+
+    const session = sessions.get(roomCode);
+    if (session && !deleted) {
+      session.removePlayer(data.user.userId);
+      removePlayerVote(roomCode, data.user.userId, session, io);
+
+      if (session.getPlayerCount() < MIN_PLAYERS) {
+        const st = session.getFullState();
+        const lastPlayer = st.players[0];
+        if (lastPlayer) session.forceGameOver(lastPlayer.id);
+        turnTimer.stop(roomCode);
+        io.to(roomCode).emit('game:over', {
+          winnerId: lastPlayer?.id ?? null,
+          scores: Object.fromEntries(st.players.map((p) => [p.id, p.score])),
+        });
+      }
+
+      await saveGameState(redis, roomCode, session.getFullState());
+      await emitGameUpdate(io, roomCode, session, redis);
+    }
+
     if (!deleted) {
-      const room = await getRoom(redis, roomCode);
+      const updatedRoom = await getRoom(redis, roomCode);
       const players = await getRoomPlayers(redis, roomCode);
-      io.to(roomCode).emit('room:updated', { players, room });
+      io.to(roomCode).emit('room:updated', { players, room: updatedRoom });
     } else {
       sessions.delete(roomCode);
       turnTimer.stop(roomCode);

--- a/packages/server/src/ws/socket-handler.ts
+++ b/packages/server/src/ws/socket-handler.ts
@@ -5,7 +5,7 @@ import { RoomManager } from '../plugins/core/room/manager';
 import { TurnTimer } from '../plugins/core/game/turn-timer';
 import { GameSession } from '../plugins/core/game/session';
 import { registerRoomEvents, emitGameUpdate, startTurnTimer, executeAutopilot, resetPlayerTimeout } from './room-events';
-import { registerGameEvents } from './game-events';
+import { registerGameEvents, addAutopilotVote } from './game-events';
 import { getRoom, getRoomPlayers, setRoomOwner } from '../plugins/core/room/store';
 import { saveGameState, loadGameState } from '../plugins/core/game/state-store';
 import { checkRateLimit, clearRateLimit } from './rate-limiter';
@@ -268,6 +268,7 @@ export function setupSocketHandlers(io: SocketIOServer, redis: KvStore, jwtSecre
             await saveGameState(redis, roomCode, s.getFullState());
             await emitGameUpdate(io, roomCode, s, redis);
             io.to(roomCode).emit('player:autopilot', { playerId: userId, enabled: true });
+            addAutopilotVote(roomCode, userId, s, io);
             startAutoPlay(userId, roomCode);
           }
         }, RECONNECT_TIMEOUT_MS);


### PR DESCRIPTION
## Summary
- **踢出功能**: 房主在回合结束30秒后可踢出未准备的玩家，被踢玩家收到通知并返回大厅
- **主动退出修复**: 玩家 `room:leave` 时同步从游戏会话移除，清理投票状态，不再导致游戏卡死
- **人数不足处理**: 退出后剩余玩家不足 MIN_PLAYERS 时自动判定游戏结束
- **断线投票修复**: 断线超时启用托管时，若处于 round_end 阶段自动补投票，避免投票卡死

## Test plan
- [x] shared 220 tests 全部通过
- [x] client 类型检查通过
- [x] server 类型检查通过
- [ ] 手动测试：回合结束30秒后房主可看到踢出按钮并踢出未准备玩家
- [ ] 手动测试：玩家主动退出后游戏正常继续
- [ ] 手动测试：只剩1人时游戏自动结束
- [ ] 手动测试：断线60秒后托管自动投票

🤖 Generated with [Claude Code](https://claude.com/claude-code)