### PR TITLE
feat: 随机座位村规 + Enter键打开聊天框

### DIFF
--- a/packages/client/src/features/game/components/ChatBox.tsx
+++ b/packages/client/src/features/game/components/ChatBox.tsx
@@ -16,6 +16,11 @@ export default function ChatBox({ embedded = false }: ChatBoxProps) {
   const [input, setInput] = useState('');
   const [open, setOpen] = useState(false);
   const bottomRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (embedded) inputRef.current?.focus();
+  }, [embedded]);
 
   useEffect(() => {
     const socket = getSocket();
@@ -70,7 +75,7 @@ export default function ChatBox({ embedded = false }: ChatBoxProps) {
           ))}
         </div>
         <div className="flex gap-1">
-          <input value={input} onChange={(e) => setInput(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && send()}
+          <input ref={inputRef} value={input} onChange={(e) => setInput(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && send()}
             placeholder="发送消息..."
             className="flex-1 px-2.5 py-1.5 rounded-lg border border-white/20 bg-muted text-foreground text-xs"
           />

--- a/packages/client/src/features/game/components/InfoDrawer.tsx
+++ b/packages/client/src/features/game/components/InfoDrawer.tsx
@@ -22,6 +22,8 @@ export default function InfoDrawer() {
   const toggleInfoDrawer = useGameStore((s) => s.toggleInfoDrawer);
   const setInfoDrawerTab = useGameStore((s) => s.setInfoDrawerTab);
 
+  const openInfoDrawer = useGameStore((s) => s.openInfoDrawer);
+
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       const target = e.target as HTMLElement;
@@ -30,10 +32,14 @@ export default function InfoDrawer() {
         e.preventDefault();
         toggleInfoDrawer();
       }
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        openInfoDrawer('chat');
+      }
     };
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [toggleInfoDrawer]);
+  }, [toggleInfoDrawer, openInfoDrawer]);
 
   return (
     <AnimatePresence>

--- a/packages/shared/src/constants/house-rules.ts
+++ b/packages/shared/src/constants/house-rules.ts
@@ -40,4 +40,5 @@ export const HOUSE_RULE_DEFINITIONS: HouseRuleDefinition[] = [
   { key: 'handLimit', label: '手牌上限', description: '超过数量时不能摸牌' },
   { key: 'handRevealThreshold', label: '手牌透明', description: '手牌低于此数对所有人可见' },
   { key: 'blitzTimeLimit', label: '闪电战', description: '总时间限制（秒），超时手牌最少者赢' },
+  { key: 'shuffleSeats', label: '随机座位', description: '每轮开始时随机打乱玩家座位顺序' },
 ];

--- a/packages/shared/src/rules/setup.ts
+++ b/packages/shared/src/rules/setup.ts
@@ -171,7 +171,7 @@ export function initializeNextRound(prevState: GameState): GameState {
   const skipWild = !hr.wildFirstTurn;
   const { topCard, remainingDeck: deckAfterDiscard, effect } = handleFirstDiscard(deckAfterDeal, skipWild);
 
-  const players: Player[] = prevState.players.map(p => ({
+  let players: Player[] = prevState.players.map(p => ({
     ...p,
     hand: hands[p.id] ?? [],
     calledUno: false,
@@ -180,6 +180,13 @@ export function initializeNextRound(prevState: GameState): GameState {
     connected: p.connected,
     autopilot: p.autopilot,
   }));
+
+  if (hr.shuffleSeats) {
+    for (let i = players.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [players[i], players[j]] = [players[j]!, players[i]!];
+    }
+  }
 
   let direction: GameState['direction'] = 'clockwise';
   let currentPlayerIndex = prevState.currentPlayerIndex;

--- a/packages/shared/src/types/house-rules.ts
+++ b/packages/shared/src/types/house-rules.ts
@@ -32,6 +32,7 @@ export interface HouseRules {
   noChallengeWildFour: boolean;
   blindDraw: boolean;
   bombCard: boolean;
+  shuffleSeats: boolean;
 }
 
 export const DEFAULT_HOUSE_RULES: HouseRules = {
@@ -68,6 +69,7 @@ export const DEFAULT_HOUSE_RULES: HouseRules = {
   noChallengeWildFour: false,
   blindDraw: false,
   bombCard: false,
+  shuffleSeats: false,
 };
 
 export const HOUSE_RULES_PRESETS: Record<string, Partial<HouseRules>> = {


### PR DESCRIPTION
## Summary
- 新增 `shuffleSeats` 村规：每轮开始时 Fisher-Yates 随机打乱玩家座位顺序
- Enter 键快捷打开聊天面板并自动聚焦输入框

## Test plan
- [x] 223 tests 通过，client/server 类型检查通过
- [ ] 手动测试：开启随机座位后每轮玩家顺序变化
- [ ] 手动测试：按 Enter 打开聊天并可直接输入

🤖 Generated with [Claude Code](https://claude.com/claude-code)