### PR TITLE
fix: 修复托管抢出与抢出结算

### DIFF
--- a/packages/server/src/ws/game-events.ts
+++ b/packages/server/src/ws/game-events.ts
@@ -1,12 +1,12 @@
 import type { Socket, Server as SocketIOServer } from 'socket.io';
 import type { KvStore } from '../kv/types.js';
-import type { ChatMessage, Color } from '@uno-online/shared';
-import { GameEventType } from '@uno-online/shared';
+import type { ChatMessage, Color, GameAction } from '@uno-online/shared';
+import { chooseAutopilotJumpInAction, GameEventType } from '@uno-online/shared';
 import type { Kysely } from 'kysely';
 import type { Database } from '../db/database';
 import { GameSession } from '../plugins/core/game/session';
 import { saveGameState } from '../plugins/core/game/state-store';
-import { emitGameUpdate, startTurnTimer, resetPlayerTimeout, clearRoomTimeouts } from './room-events';
+import { emitGameUpdate, setAutopilotActionHandler, startTurnTimer, resetPlayerTimeout, clearRoomTimeouts } from './room-events';
 import type { TurnTimer } from '../plugins/core/game/turn-timer';
 import { recordGameResult } from '../db/user-repo';
 import { saveGameEvents, saveDeckInfo } from '../plugins/core/game-history/service';
@@ -85,6 +85,8 @@ function buildChatMessage(user: SocketData['user'], text: string): ChatMessage {
 
 const gameStartTimes = new Map<string, number>();
 const nextRoundVotes = new Map<string, Set<string>>();
+const AUTOPILOT_JUMP_IN_DELAY_MS = 2_000;
+const autopilotJumpInTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
 interface NextRoundVoteState {
   votes: number;
@@ -122,6 +124,98 @@ export function removePlayerVote(roomCode: string, playerId: string, session: Ga
     const voteState = getNextRoundVoteState(roomCode, session);
     io.to(roomCode).emit('game:next_round_vote', voteState);
   }
+}
+
+function clearAutopilotJumpIn(roomCode: string): void {
+  const timer = autopilotJumpInTimers.get(roomCode);
+  if (!timer) return;
+  clearTimeout(timer);
+  autopilotJumpInTimers.delete(roomCode);
+}
+
+function recordAutopilotAction(session: GameSession, action: GameAction): void {
+  if (action.type === 'PLAY_CARD') {
+    const playedCard = session.getFullState().discardPile.at(-1);
+    if (playedCard) {
+      session.recordEvent(GameEventType.PLAY_CARD, { cardId: action.cardId, card: playedCard, chosenColor: action.chosenColor }, action.playerId);
+    }
+    return;
+  }
+
+  if (action.type === 'CHOOSE_COLOR') {
+    session.recordEvent(GameEventType.CHOOSE_COLOR, { color: action.color }, action.playerId);
+  }
+}
+
+function handleAutopilotAction(
+  io: SocketIOServer,
+  redis: KvStore,
+  roomCode: string,
+  session: GameSession,
+  turnTimer: TurnTimer,
+  db: Kysely<Database>,
+  sessions: Map<string, GameSession>,
+  action: GameAction,
+): void {
+  recordAutopilotAction(session, action);
+  if (action.type === 'PLAY_CARD') {
+    scheduleAutopilotJumpIn(io, redis, roomCode, session, turnTimer, db, sessions);
+  }
+}
+
+function scheduleAutopilotJumpIn(
+  io: SocketIOServer,
+  redis: KvStore,
+  roomCode: string,
+  session: GameSession,
+  turnTimer: TurnTimer,
+  db: Kysely<Database>,
+  sessions: Map<string, GameSession>,
+): void {
+  clearAutopilotJumpIn(roomCode);
+
+  const snapshot = session.getFullState();
+  if (!snapshot.settings.houseRules.jumpIn || snapshot.phase !== 'playing') return;
+  const topCardId = snapshot.discardPile.at(-1)?.id;
+  if (!topCardId) return;
+
+  const timer = setTimeout(async () => {
+    autopilotJumpInTimers.delete(roomCode);
+    const currentSession = sessions.get(roomCode);
+    if (!currentSession) return;
+
+    const state = currentSession.getFullState();
+    if (state.phase !== 'playing' || state.discardPile.at(-1)?.id !== topCardId) return;
+
+    const jumper = state.players.find((player) =>
+      player.autopilot &&
+      !player.eliminated &&
+      chooseAutopilotJumpInAction(state, player.id).length > 0
+    );
+    if (!jumper) return;
+
+    let acted = false;
+    for (const action of chooseAutopilotJumpInAction(state, jumper.id)) {
+      const result = currentSession.applyAction(action);
+      if (result.success) {
+        acted = true;
+        recordAutopilotAction(currentSession, action);
+      }
+    }
+    if (!acted) return;
+
+    await touchRoomActivity(redis, roomCode);
+    await saveGameState(redis, roomCode, currentSession.getFullState());
+    await emitGameUpdate(io, roomCode, currentSession, redis);
+
+    if (!(await emitTerminalStateIfNeeded(io, roomCode, currentSession, turnTimer, redis, db, sessions))) {
+      scheduleAutopilotJumpIn(io, redis, roomCode, currentSession, turnTimer, db, sessions);
+      startTurnTimer(io, redis, roomCode, currentSession, turnTimer, sessions);
+    }
+  }, AUTOPILOT_JUMP_IN_DELAY_MS);
+
+  timer.unref?.();
+  autopilotJumpInTimers.set(roomCode, timer);
 }
 
 function getNextRoundVoteState(roomCode: string, session: GameSession): NextRoundVoteState {
@@ -214,6 +308,10 @@ export function registerGameEvents(
   sessions: Map<string, GameSession>,
   db: Kysely<Database>,
 ) {
+  setAutopilotActionHandler((roomCode, session, action) => {
+    handleAutopilotAction(io, redis, roomCode, session, turnTimer, db, sessions, action);
+  });
+
   const data = socket.data as SocketData;
   const initialSession = data.roomCode ? sessions.get(data.roomCode) : null;
   if (initialSession) {
@@ -245,6 +343,7 @@ export function registerGameEvents(
     await saveGameState(redis, roomCode, session.getFullState());
     await emitGameUpdate(io, roomCode, session, redis);
     if (!(await emitTerminalStateIfNeeded(io, roomCode, session, turnTimer, redis, db, sessions))) {
+      scheduleAutopilotJumpIn(io, redis, roomCode, session, turnTimer, db, sessions);
       startTurnTimer(io, redis, roomCode, session, turnTimer, sessions);
     }
     callback?.({ success: true });
@@ -386,6 +485,7 @@ export function registerGameEvents(
     if (await emitTerminalStateIfNeeded(io, roomCode, session, turnTimer, redis, db, sessions)) {
       // terminal state already emitted
     } else {
+      scheduleAutopilotJumpIn(io, redis, roomCode, session, turnTimer, db, sessions);
       startTurnTimer(io, redis, roomCode, session, turnTimer, sessions);
     }
     callback?.({ success: true });

--- a/packages/server/src/ws/room-events.ts
+++ b/packages/server/src/ws/room-events.ts
@@ -17,9 +17,19 @@ import { getAutopilotActionPlayerId } from './autopilot-action-player';
 
 const DRAW_PENALTY_PAUSE_MS = 500;
 const AUTO_AUTOPILOT_THRESHOLD = 2;
+type AutopilotActionHandler = (roomCode: string, session: GameSession, action: GameAction) => void;
 
 // Track consecutive timeouts per player per room
 const timeoutCounts = new Map<string, Map<string, number>>();
+let autopilotActionHandler: AutopilotActionHandler | null = null;
+
+export function setAutopilotActionHandler(handler: AutopilotActionHandler | null): void {
+  autopilotActionHandler = handler;
+}
+
+export function notifyAutopilotAction(roomCode: string, session: GameSession, action: GameAction): void {
+  autopilotActionHandler?.(roomCode, session, action);
+}
 
 export function getTimeoutCounts(): Map<string, Map<string, number>> {
   return timeoutCounts;
@@ -299,6 +309,7 @@ export async function executeAutopilot(
   session: GameSession,
   playerId: string,
   onPenaltyPause?: () => void | Promise<void>,
+  onActionSuccess?: (action: GameAction) => void | Promise<void>,
 ): Promise<boolean> {
   let acted = false;
   for (let round = 0; round < 5; round++) {
@@ -313,6 +324,7 @@ export async function executeAutopilot(
       const result = session.applyAction(action);
       if (result.success) {
         anySuccess = true;
+        await onActionSuccess?.(action);
         if (shouldPauseAfterAction(beforeAction, session, action)) {
           await onPenaltyPause?.();
           await sleep(DRAW_PENALTY_PAUSE_MS);
@@ -356,7 +368,7 @@ export function startTurnTimer(
       await executeAutopilot(s, pid, async () => {
         await saveGameState(redis, code, s.getFullState());
         await emitGameUpdate(io, code, s, redis);
-      });
+      }, (action) => notifyAutopilotAction(code, s, action));
       await saveGameState(redis, code, s.getFullState());
       await emitGameUpdate(io, code, s, redis);
       startTurnTimer(io, redis, code, s, turnTimer, sessions);
@@ -379,7 +391,7 @@ export function startTurnTimer(
       await executeAutopilot(s, pid, async () => {
         await saveGameState(redis, code, s.getFullState());
         await emitGameUpdate(io, code, s, redis);
-      });
+      }, (action) => notifyAutopilotAction(code, s, action));
       await saveGameState(redis, code, s.getFullState());
       await emitGameUpdate(io, code, s, redis);
       io.to(code).emit('player:timeout', { playerId: pid });
@@ -407,7 +419,7 @@ export function startTurnTimer(
     await executeAutopilot(s, pid, async () => {
       await saveGameState(redis, code, s.getFullState());
       await emitGameUpdate(io, code, s, redis);
-    });
+    }, (action) => notifyAutopilotAction(code, s, action));
     await saveGameState(redis, code, s.getFullState());
     await emitGameUpdate(io, code, s, redis);
     io.to(code).emit('player:timeout', { playerId: pid });

--- a/packages/server/src/ws/socket-handler.ts
+++ b/packages/server/src/ws/socket-handler.ts
@@ -4,7 +4,7 @@ import { authenticateSocket } from '../auth/middleware';
 import { RoomManager } from '../plugins/core/room/manager';
 import { TurnTimer } from '../plugins/core/game/turn-timer';
 import { GameSession } from '../plugins/core/game/session';
-import { registerRoomEvents, emitGameUpdate, startTurnTimer, executeAutopilot, resetPlayerTimeout } from './room-events';
+import { registerRoomEvents, emitGameUpdate, startTurnTimer, executeAutopilot, notifyAutopilotAction, resetPlayerTimeout } from './room-events';
 import { getAutopilotActionPlayerId } from './autopilot-action-player';
 import { registerGameEvents, addAutopilotVote } from './game-events';
 import { getRoom, getRoomPlayers, setRoomOwner } from '../plugins/core/room/store';
@@ -72,7 +72,7 @@ export function setupSocketHandlers(io: SocketIOServer, redis: KvStore, jwtSecre
       const acted = await executeAutopilot(session, userId, async () => {
         await saveGameState(redis, roomCode, session.getFullState());
         await emitGameUpdate(io, roomCode, session, redis);
-      });
+      }, (action) => notifyAutopilotAction(roomCode, session, action));
 
       if (acted) {
         await saveGameState(redis, roomCode, session.getFullState());

--- a/packages/shared/src/rules/autopilot-strategy.ts
+++ b/packages/shared/src/rules/autopilot-strategy.ts
@@ -34,6 +34,30 @@ function pickPlayableCard(playable: Card[], currentColor: Color): Card {
   );
 }
 
+function isExactJumpInMatch(card: Card, topCard: Card): boolean {
+  return (
+    card.type === topCard.type &&
+    card.color === topCard.color &&
+    (card.type !== 'number' || (topCard.type === 'number' && card.value === topCard.value))
+  );
+}
+
+export function chooseAutopilotJumpInAction(state: GameState, playerId: string): GameAction[] {
+  if (!state.settings.houseRules.jumpIn || state.phase !== 'playing') return [];
+
+  const currentPlayer = state.players[state.currentPlayerIndex];
+  if (!currentPlayer || currentPlayer.id === playerId) return [];
+
+  const player = state.players.find(p => p.id === playerId);
+  const topCard = state.discardPile[state.discardPile.length - 1];
+  if (!player?.autopilot || !topCard) return [];
+
+  const card = player.hand.find(c => isExactJumpInMatch(c, topCard));
+  if (!card) return [];
+
+  return playCardActions(playerId, card, player.hand);
+}
+
 export function chooseAutopilotAction(state: GameState, playerId: string): GameAction[] {
   const player = state.players.find(p => p.id === playerId);
   if (!player) return [];

--- a/packages/shared/src/rules/index.ts
+++ b/packages/shared/src/rules/index.ts
@@ -11,4 +11,4 @@ export type { HouseRulePlugin, RuleMetadata, RuleContext, PreCheckResult } from 
 export { buildRuleContext } from './house-rule-helpers';
 export { getAllRuleMetadata } from './house-rule-registry';
 export { PRE_CHECK_PLUGINS, POST_PROCESS_PLUGINS } from './rules/index';
-export { chooseAutopilotAction } from './autopilot-strategy';
+export { chooseAutopilotAction, chooseAutopilotJumpInAction } from './autopilot-strategy';

--- a/packages/shared/src/rules/rules/jump-in.ts
+++ b/packages/shared/src/rules/rules/jump-in.ts
@@ -35,16 +35,43 @@ export const jumpIn: HouseRulePlugin = {
         i === jumperIdx ? { ...p, hand: newHand } : p,
       );
       const nextIdx = ctx.getNextPlayerIndex(jumperIdx, players.length, state.direction);
+      const baseState: GameState = {
+        ...state,
+        players,
+        discardPile: [...state.discardPile, card],
+        currentPlayerIndex: nextIdx,
+        lastAction: action,
+      };
+
+      if (card.type === 'wild') {
+        return {
+          handled: true,
+          state: {
+            ...baseState,
+            phase: 'choosing_color',
+            currentPlayerIndex: jumperIdx,
+          },
+        };
+      }
+
+      if (card.type === 'wild_draw_four') {
+        return {
+          handled: true,
+          state: {
+            ...baseState,
+            phase: 'choosing_color',
+            currentPlayerIndex: jumperIdx,
+            pendingDrawPlayerId: players[nextIdx]?.id ?? null,
+          },
+        };
+      }
+
       return {
         handled: true,
-        state: {
-          ...state,
-          players,
-          discardPile: [...state.discardPile, card],
+        state: ctx.checkRoundEnd({
+          ...baseState,
           currentColor: card.color ?? state.currentColor,
-          currentPlayerIndex: nextIdx,
-          lastAction: action,
-        },
+        }, action.playerId),
       };
     }
     return { handled: true, state };

--- a/packages/shared/tests/autopilot-strategy.test.ts
+++ b/packages/shared/tests/autopilot-strategy.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { DEFAULT_HOUSE_RULES, chooseAutopilotAction } from '../src';
+import { DEFAULT_HOUSE_RULES, chooseAutopilotAction, chooseAutopilotJumpInAction } from '../src';
 import type { Card, Color, GameState } from '../src';
 
 function makeCard(type: Card['type'], color: Color | null, extra?: { value?: number; id?: string }): Card {
@@ -160,6 +160,82 @@ describe('chooseAutopilotAction for seven swap', () => {
 
     expect(chooseAutopilotAction(state, 'p1')).toEqual([
       { type: 'CHOOSE_SWAP_TARGET', playerId: 'p1', targetId: 'p3' },
+    ]);
+  });
+});
+
+describe('chooseAutopilotJumpInAction', () => {
+  it('plays an exact matching card while another player has the turn', () => {
+    const jumpCard = makeCard('number', 'red', { value: 5, id: 'jump_red_5' });
+    const state = makeState({
+      currentPlayerIndex: 0,
+      players: [
+        { id: 'p1', name: 'Alice', hand: [], score: 0, connected: true, autopilot: false, calledUno: false },
+        { id: 'p2', name: 'Bot', hand: [jumpCard], score: 0, connected: true, autopilot: true, calledUno: false },
+      ],
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        allowSpectators: true,
+        spectatorMode: 'hidden',
+        houseRules: { ...DEFAULT_HOUSE_RULES, jumpIn: true },
+      },
+    });
+
+    expect(chooseAutopilotJumpInAction(state, 'p2')).toEqual([
+      { type: 'PLAY_CARD', playerId: 'p2', cardId: 'jump_red_5' },
+    ]);
+  });
+
+  it('does not jump in without an exact match', () => {
+    const state = makeState({
+      currentPlayerIndex: 0,
+      players: [
+        { id: 'p1', name: 'Alice', hand: [], score: 0, connected: true, autopilot: false, calledUno: false },
+        {
+          id: 'p2',
+          name: 'Bot',
+          hand: [makeCard('number', 'red', { value: 6, id: 'red_6' })],
+          score: 0,
+          connected: true,
+          autopilot: true,
+          calledUno: false,
+        },
+      ],
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        allowSpectators: true,
+        spectatorMode: 'hidden',
+        houseRules: { ...DEFAULT_HOUSE_RULES, jumpIn: true },
+      },
+    });
+
+    expect(chooseAutopilotJumpInAction(state, 'p2')).toEqual([]);
+  });
+
+  it('chooses a color after jumping in with a wild card', () => {
+    const jumpWild = makeCard('wild', null, { id: 'jump_wild' });
+    const blue = makeCard('number', 'blue', { value: 2, id: 'blue_2' });
+    const state = makeState({
+      currentPlayerIndex: 0,
+      discardPile: [makeCard('wild', null, { id: 'top_wild' })],
+      players: [
+        { id: 'p1', name: 'Alice', hand: [], score: 0, connected: true, autopilot: false, calledUno: false },
+        { id: 'p2', name: 'Bot', hand: [jumpWild, blue], score: 0, connected: true, autopilot: true, calledUno: false },
+      ],
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        allowSpectators: true,
+        spectatorMode: 'hidden',
+        houseRules: { ...DEFAULT_HOUSE_RULES, jumpIn: true },
+      },
+    });
+
+    expect(chooseAutopilotJumpInAction(state, 'p2')).toEqual([
+      { type: 'PLAY_CARD', playerId: 'p2', cardId: 'jump_wild' },
+      { type: 'CHOOSE_COLOR', playerId: 'p2', color: 'blue' },
     ]);
   });
 });

--- a/packages/shared/tests/house-rules-batch-fix.test.ts
+++ b/packages/shared/tests/house-rules-batch-fix.test.ts
@@ -151,6 +151,45 @@ describe('jumpIn', () => {
     expect(next.players[1]!.hand).toHaveLength(1);
   });
 
+  it('enters color choosing when jumping in with a wild card', () => {
+    const topWild = makeCard('wild', null, { id: 'top_wild' });
+    const jumpWild = makeCard('wild', null, { id: 'jump_wild' });
+    const state = makeState({
+      currentPlayerIndex: 0,
+      currentColor: 'red',
+      discardPile: [topWild],
+      players: [
+        { id: 'p1', name: 'Alice', hand: [makeCard('number', 'red', { value: 1 })], score: 0, connected: true, calledUno: false },
+        { id: 'p2', name: 'Bob', hand: [jumpWild, makeCard('number', 'blue', { value: 3 })], score: 0, connected: true, calledUno: false },
+        { id: 'p3', name: 'Carol', hand: [makeCard('number', 'yellow', { value: 1 })], score: 0, connected: true, calledUno: false },
+      ],
+      settings: { turnTimeLimit: 30, targetScore: 500, houseRules: { ...DEFAULT_HOUSE_RULES, jumpIn: true } },
+    });
+
+    const next = applyActionWithHouseRules(state, { type: 'PLAY_CARD', playerId: 'p2', cardId: 'jump_wild' });
+
+    expect(next.phase).toBe('choosing_color');
+    expect(next.currentPlayerIndex).toBe(1);
+    expect(next.discardPile.at(-1)?.id).toBe('jump_wild');
+  });
+
+  it('ends the round immediately when jump-in empties a hand', () => {
+    const matchCard = makeCard('number', 'red', { value: 5, id: 'last_jump' });
+    const state = makeState({
+      players: [
+        { id: 'p1', name: 'Alice', hand: [makeCard('number', 'blue', { value: 1 })], score: 0, connected: true, calledUno: false },
+        { id: 'p2', name: 'Bob', hand: [matchCard], score: 0, connected: true, calledUno: false },
+        { id: 'p3', name: 'Carol', hand: [makeCard('number', 'yellow', { value: 1 })], score: 0, connected: true, calledUno: false },
+      ],
+      settings: { turnTimeLimit: 30, targetScore: 500, houseRules: { ...DEFAULT_HOUSE_RULES, jumpIn: true } },
+    });
+
+    const next = applyActionWithHouseRules(state, { type: 'PLAY_CARD', playerId: 'p2', cardId: 'last_jump' });
+
+    expect(next.phase).toBe('round_end');
+    expect(next.winnerId).toBe('p2');
+  });
+
   it('rejects out-of-turn play without exact match', () => {
     const noMatch = makeCard('number', 'red', { value: 3, id: 'nope' });
     const state = makeState({


### PR DESCRIPTION
托管玩家现在会在其他玩家成功出牌后延迟 2 秒检查同牌抢出，手动托管、断线托管和回合计时托管都会走同一套动作通知。

抢出万能牌不再绕过选色：真人抢出会进入 choosing_color，托管抢出会自动追加 CHOOSE_COLOR。

修复抢出最后一张牌不会立即结算的问题，普通牌抢出清空手牌后会立刻进入 round_end/game_over，避免下一位玩家继续出牌并抢先结算。

补充托管抢出策略、抢出万能选色、抢出最后一张立即结算的回归测试。