### PR TITLE
fix: 将 GITHUB_PROXY 环境变量传递到 Docker 容器

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       DOMAIN: ${DOMAIN:-localhost}
       DEV_MODE: ${DEV_MODE:-true}
       ROOM_IDLE_TIMEOUT_MS: ${ROOM_IDLE_TIMEOUT_MS:-7200000}
+      GITHUB_PROXY: ${GITHUB_PROXY:-}
       PORT: "3001"
     volumes:
       - ./data/sqlite:/data


### PR DESCRIPTION
## Summary
- docker-compose.yml 缺少 `GITHUB_PROXY` 环境变量映射，导致 `.env` 中配置的 GitHub OAuth 代理无法传递到容器内，代理不生效
- 添加 `GITHUB_PROXY: ${GITHUB_PROXY:-}` 到 server 服务的 environment 中

## Test plan
- [ ] 在 `.env` 中设置 `GITHUB_PROXY`，`docker compose up -d` 后确认容器内环境变量存在
- [ ] 验证 GitHub OAuth 登录请求走代理

🤖 Generated with [Claude Code](https://claude.com/claude-code)