### PR TITLE
fix: 使用 undici request API 修复 GitHub OAuth 代理不生效

### DIFF
--- a/packages/server/src/auth/github.ts
+++ b/packages/server/src/auth/github.ts
@@ -1,4 +1,4 @@
-import { ProxyAgent } from 'undici';
+import { request, ProxyAgent } from 'undici';
 import type { Config } from '../config';
 
 interface GitHubTokenResponse {
@@ -18,7 +18,7 @@ function getDispatcher(config: Config): ProxyAgent | undefined {
 }
 
 export async function exchangeCodeForToken(code: string, config: Config): Promise<string> {
-  const response = await fetch('https://github.com/login/oauth/access_token', {
+  const { statusCode, body } = await request('https://github.com/login/oauth/access_token', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
     body: JSON.stringify({
@@ -27,21 +27,21 @@ export async function exchangeCodeForToken(code: string, config: Config): Promis
       code,
     }),
     dispatcher: getDispatcher(config),
-  } as RequestInit);
-  const data = (await response.json()) as GitHubTokenResponse;
-  if (!data.access_token) {
+  });
+  const data = (await body.json()) as GitHubTokenResponse;
+  if (statusCode !== 200 || !data.access_token) {
     throw new Error('Failed to exchange code for GitHub token');
   }
   return data.access_token;
 }
 
 export async function fetchGitHubUser(accessToken: string, config: Config): Promise<GitHubUser> {
-  const response = await fetch('https://api.github.com/user', {
+  const { statusCode, body } = await request('https://api.github.com/user', {
     headers: { Authorization: `Bearer ${accessToken}` },
     dispatcher: getDispatcher(config),
-  } as RequestInit);
-  if (!response.ok) {
+  });
+  if (statusCode !== 200) {
     throw new Error('Failed to fetch GitHub user');
   }
-  return response.json() as Promise<GitHubUser>;
+  return body.json() as Promise<GitHubUser>;
 }


### PR DESCRIPTION
## Summary
- 全局 `fetch` 基于 Node.js 内置 undici 6.x，与项目依赖的 undici 8.x `ProxyAgent` 不兼容，`dispatcher` 被静默忽略，导致 `GITHUB_PROXY` 配置无效
- 改用 undici 自身的 `request` API，确保 HTTP 客户端和 `ProxyAgent` 来自同一版本

## Test plan
- [ ] 设置 `GITHUB_PROXY` 环境变量，验证 GitHub OAuth 登录请求走代理
- [ ] 不设置 `GITHUB_PROXY`，验证 OAuth 正常工作（无代理回退）

🤖 Generated with [Claude Code](https://claude.com/claude-code)