### PR TITLE
fix: 添加 GitHub OAuth 回调错误日志

### DIFF
--- a/packages/server/src/plugins/core/auth/routes.ts
+++ b/packages/server/src/plugins/core/auth/routes.ts
@@ -140,6 +140,7 @@ function registerProductionRoutes(fastify: FastifyInstance, ctx: PluginContext) 
       const token = makeToken(user, config.jwtSecret);
       return { token, user: userResponse(user), isNewUser: user.isNewUser };
     } catch (err) {
+      request.log.error(err, 'GitHub OAuth callback failed');
       return reply.code(500).send({ error: 'Authentication failed' });
     }
   });


### PR DESCRIPTION
## Summary
- `/api/auth/callback` 的 catch 块吞掉了异常，返回 500 时日志无任何错误信息，无法排查问题
- 添加 `request.log.error` 输出实际异常

🤖 Generated with [Claude Code](https://claude.com/claude-code)