### PR TITLE
fix: 为 GitHub API 请求添加 User-Agent 头

### DIFF
--- a/packages/server/src/auth/github.ts
+++ b/packages/server/src/auth/github.ts
@@ -37,7 +37,7 @@ export async function exchangeCodeForToken(code: string, config: Config): Promis
 
 export async function fetchGitHubUser(accessToken: string, config: Config): Promise<GitHubUser> {
   const { statusCode, body } = await request('https://api.github.com/user', {
-    headers: { Authorization: `Bearer ${accessToken}` },
+    headers: { Authorization: `Bearer ${accessToken}`, 'User-Agent': 'UNO-Online' },
     dispatcher: getDispatcher(config),
   });
   if (statusCode !== 200) {


### PR DESCRIPTION
## Summary
- GitHub API 要求请求必须携带 `User-Agent` 头，为 `fetchGitHubUser` 请求补充 `User-Agent: UNO-Online`

## Test plan
- [ ] 验证 GitHub OAuth 登录流程正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)