### PR TITLE
fix: 托管模式 +4 卡死 + 最后一张功能牌不结算胜利

### DIFF
--- a/packages/shared/src/rules/autopilot-strategy.ts
+++ b/packages/shared/src/rules/autopilot-strategy.ts
@@ -55,6 +55,7 @@ export function chooseAutopilotAction(state: GameState, playerId: string): GameA
   if (!player) return [];
 
   const autopilotSide: DrawSide = state.deckLeft.length >= state.deckRight.length ? 'left' : 'right';
+  const hr = state.settings.houseRules;
 
   if (state.phase === 'challenging') {
     if (state.pendingDrawPlayerId === playerId) {
@@ -105,11 +106,11 @@ export function chooseAutopilotAction(state: GameState, playerId: string): GameA
       return [{ type: 'PASS', playerId }];
     }
     const pick = pickPlayableCard(playableAfterDraw, state.currentColor);
-    return playCardActions(playerId, pick, player.hand);
+    const needsColorOnPlay = pick.type === 'wild_draw_four' && (hr.stackDrawFour || hr.crossStack);
+    return playCardActions(playerId, pick, player.hand, needsColorOnPlay);
   }
 
   if (state.drawStack > 0) {
-    const hr = state.settings.houseRules;
     const stackingEnabled = hr.stackDrawTwo || hr.stackDrawFour || hr.crossStack;
 
     if (stackingEnabled) {
@@ -149,7 +150,7 @@ export function chooseAutopilotAction(state: GameState, playerId: string): GameA
     return [{ type: 'DRAW_CARD', playerId, side: autopilotSide }];
   }
 
-  // Priority: same-color non-wild > any non-wild > wild as last resort
   const pick = pickPlayableCard(playable, state.currentColor);
-  return playCardActions(playerId, pick, player.hand);
+  const needsColorOnPlay = pick.type === 'wild_draw_four' && (hr.stackDrawFour || hr.crossStack);
+  return playCardActions(playerId, pick, player.hand, needsColorOnPlay);
 }

--- a/packages/shared/src/rules/house-rule-helpers.ts
+++ b/packages/shared/src/rules/house-rule-helpers.ts
@@ -75,7 +75,7 @@ export function putAttackCardOnStack(
   const nextIdx = getNextPlayerIndex(state.currentPlayerIndex, players.length, state.direction);
   const newColor = card.type === 'draw_two' ? card.color : (action.chosenColor ?? state.currentColor);
 
-  return {
+  return checkRoundEnd({
     ...state,
     players,
     discardPile: [...state.discardPile, playedCard],
@@ -83,7 +83,7 @@ export function putAttackCardOnStack(
     drawStack: state.drawStack + stackAdd,
     currentPlayerIndex: nextIdx,
     lastAction: action,
-  };
+  }, action.playerId);
 }
 
 export function applyDoubleScore(before: GameState, after: GameState): GameState {

--- a/packages/shared/src/rules/rules/deflection.ts
+++ b/packages/shared/src/rules/rules/deflection.ts
@@ -1,6 +1,7 @@
 import type { HouseRulePlugin } from '../house-rule-types';
 import type { GameState, GameAction } from '../../types/game';
 import type { RuleContext, PreCheckResult } from '../house-rule-types';
+import { checkRoundEnd } from '../game-engine';
 
 export const deflection: HouseRulePlugin = {
   meta: {
@@ -32,7 +33,7 @@ export const deflection: HouseRulePlugin = {
       const nextIdx = ctx.getNextPlayerIndex(state.currentPlayerIndex, players.length, newDirection);
       return {
         handled: true,
-        state: {
+        state: checkRoundEnd({
           ...state,
           players,
           discardPile: [...state.discardPile, card],
@@ -40,7 +41,7 @@ export const deflection: HouseRulePlugin = {
           direction: newDirection,
           currentPlayerIndex: nextIdx,
           lastAction: action,
-        },
+        }, action.playerId),
       };
     }
 
@@ -52,14 +53,14 @@ export const deflection: HouseRulePlugin = {
       const nextIdx = ctx.getNextPlayerIndex(state.currentPlayerIndex, players.length, state.direction);
       return {
         handled: true,
-        state: {
+        state: checkRoundEnd({
           ...state,
           players,
           discardPile: [...state.discardPile, card],
           currentColor: card.color ?? state.currentColor,
           currentPlayerIndex: nextIdx,
           lastAction: action,
-        },
+        }, action.playerId),
       };
     }
 

--- a/packages/shared/src/rules/rules/jump-in.ts
+++ b/packages/shared/src/rules/rules/jump-in.ts
@@ -42,23 +42,23 @@ export const jumpIn: HouseRulePlugin = {
       if (card.type === 'wild') {
         return {
           handled: true,
-          state: {
+          state: ctx.checkRoundEnd({
             ...baseState,
             phase: 'choosing_color',
             currentPlayerIndex: jumperIdx,
-          },
+          }, action.playerId),
         };
       }
 
       if (card.type === 'wild_draw_four') {
         return {
           handled: true,
-          state: {
+          state: ctx.checkRoundEnd({
             ...baseState,
             phase: 'choosing_color',
             currentPlayerIndex: jumperIdx,
             pendingDrawPlayerId: players[nextIdx]?.id ?? null,
-          },
+          }, action.playerId),
         };
       }
 

--- a/packages/shared/src/rules/rules/seven-swap.ts
+++ b/packages/shared/src/rules/rules/seven-swap.ts
@@ -15,6 +15,7 @@ export const sevenSwapPost: HouseRulePlugin = {
     if (after === before) return after;
     const playedCard = before.players[before.currentPlayerIndex]?.hand.find(c => c.id === action.cardId);
     if (playedCard?.type !== 'number' || playedCard.value !== 7) return after;
+    if (after.phase === 'round_end' || after.phase === 'game_over') return after;
     return { ...after, phase: 'choosing_swap_target', currentPlayerIndex: before.currentPlayerIndex };
   },
 };

--- a/packages/shared/tests/autopilot-strategy.test.ts
+++ b/packages/shared/tests/autopilot-strategy.test.ts
@@ -120,6 +120,51 @@ describe('chooseAutopilotAction for seven swap', () => {
   });
 });
 
+describe('chooseAutopilotAction with wild_draw_four and stacking', () => {
+  it('includes chosenColor when stacking is enabled so the stacking plugin accepts the card', () => {
+    const wd4 = makeCard('wild_draw_four', null, { id: 'wd4' });
+    const state = makeState({
+      players: [
+        { id: 'p1', name: 'Alice', hand: [wd4], score: 0, connected: true, autopilot: true, calledUno: false },
+        { id: 'p2', name: 'Bob', hand: [makeCard('number', 'red', { value: 1, id: 'r1' })], score: 0, connected: true, autopilot: false, calledUno: false },
+      ],
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        allowSpectators: true,
+        spectatorMode: 'hidden',
+        houseRules: { ...DEFAULT_HOUSE_RULES, stackDrawFour: true },
+      },
+    });
+
+    const actions = chooseAutopilotAction(state, 'p1');
+    expect(actions).toHaveLength(1);
+    expect(actions[0]).toMatchObject({
+      type: 'PLAY_CARD',
+      playerId: 'p1',
+      cardId: 'wd4',
+      chosenColor: expect.any(String),
+    });
+  });
+
+  it('uses two-step PLAY_CARD + CHOOSE_COLOR when stacking is disabled', () => {
+    const wd4 = makeCard('wild_draw_four', null, { id: 'wd4' });
+    const blue = makeCard('number', 'blue', { value: 3, id: 'blue_3' });
+    const state = makeState({
+      players: [
+        { id: 'p1', name: 'Alice', hand: [wd4, blue], score: 0, connected: true, autopilot: true, calledUno: false },
+        { id: 'p2', name: 'Bob', hand: [makeCard('number', 'red', { value: 1, id: 'r1' })], score: 0, connected: true, autopilot: false, calledUno: false },
+      ],
+    });
+
+    const actions = chooseAutopilotAction(state, 'p1');
+    expect(actions).toHaveLength(2);
+    expect(actions[0]).toMatchObject({ type: 'PLAY_CARD', playerId: 'p1', cardId: 'wd4' });
+    expect(actions[0]).not.toHaveProperty('chosenColor');
+    expect(actions[1]).toMatchObject({ type: 'CHOOSE_COLOR', playerId: 'p1', color: 'blue' });
+  });
+});
+
 describe('chooseAutopilotJumpInAction', () => {
   it('plays an exact matching card while another player has the turn', () => {
     const jumpCard = makeCard('number', 'red', { value: 5, id: 'jump_red_5' });

--- a/packages/shared/tests/house-rules-batch-fix.test.ts
+++ b/packages/shared/tests/house-rules-batch-fix.test.ts
@@ -95,6 +95,126 @@ describe('skipDeflect', () => {
   });
 });
 
+describe('stacking last card round end', () => {
+  it('wins immediately when playing last +2 with stacking enabled', () => {
+    const dt = makeCard('draw_two', 'red', { id: 'last_dt' });
+    const state = makeState({
+      currentPlayerIndex: 0,
+      discardPile: [makeCard('number', 'red', { value: 1 })],
+      currentColor: 'red',
+      players: [
+        { id: 'p1', name: 'Alice', hand: [dt], score: 0, connected: true, calledUno: false },
+        { id: 'p2', name: 'Bob', hand: [makeCard('draw_two', 'blue', { id: 'bob_dt' }), makeCard('number', 'green', { value: 3 })], score: 0, connected: true, calledUno: false },
+      ],
+      settings: { turnTimeLimit: 30, targetScore: 500, houseRules: { ...DEFAULT_HOUSE_RULES, stackDrawTwo: true } },
+    });
+
+    const next = applyActionWithHouseRules(state, { type: 'PLAY_CARD', playerId: 'p1', cardId: 'last_dt' });
+    expect(next.phase).toBe('round_end');
+    expect(next.winnerId).toBe('p1');
+    expect(next.drawStack).toBe(0);
+  });
+
+  it('wins immediately when playing last +4 with stacking enabled', () => {
+    const wd4 = makeCard('wild_draw_four', null, { id: 'last_wd4' });
+    const state = makeState({
+      currentPlayerIndex: 0,
+      discardPile: [makeCard('number', 'red', { value: 1 })],
+      currentColor: 'red',
+      players: [
+        { id: 'p1', name: 'Alice', hand: [wd4], score: 0, connected: true, calledUno: false },
+        { id: 'p2', name: 'Bob', hand: [makeCard('number', 'green', { value: 3 }), makeCard('number', 'blue', { value: 5 })], score: 0, connected: true, calledUno: false },
+      ],
+      settings: { turnTimeLimit: 30, targetScore: 500, houseRules: { ...DEFAULT_HOUSE_RULES, stackDrawFour: true } },
+    });
+
+    const next = applyActionWithHouseRules(state, { type: 'PLAY_CARD', playerId: 'p1', cardId: 'last_wd4', chosenColor: 'red' });
+    expect(next.phase).toBe('round_end');
+    expect(next.winnerId).toBe('p1');
+    expect(next.drawStack).toBe(0);
+  });
+});
+
+describe('deflection last card round end', () => {
+  it('wins immediately when deflecting with last reverse card', () => {
+    const rev = makeCard('reverse', 'red', { id: 'last_rev' });
+    const dt = makeCard('draw_two', 'red', { id: 'dt_top' });
+    const state = makeState({
+      drawStack: 2,
+      currentPlayerIndex: 1,
+      discardPile: [makeCard('number', 'blue', { value: 1 }), dt],
+      currentColor: 'red',
+      players: [
+        { id: 'p1', name: 'Alice', hand: [makeCard('number', 'green', { value: 1 })], score: 0, connected: true, calledUno: false },
+        { id: 'p2', name: 'Bob', hand: [rev], score: 0, connected: true, calledUno: false },
+        { id: 'p3', name: 'Carol', hand: [makeCard('number', 'yellow', { value: 1 })], score: 0, connected: true, calledUno: false },
+      ],
+      settings: { turnTimeLimit: 30, targetScore: 500, houseRules: { ...DEFAULT_HOUSE_RULES, reverseDeflectDrawTwo: true } },
+    });
+
+    const next = applyActionWithHouseRules(state, { type: 'PLAY_CARD', playerId: 'p2', cardId: 'last_rev' });
+    expect(next.phase).toBe('round_end');
+    expect(next.winnerId).toBe('p2');
+  });
+});
+
+describe('jumpIn last card round end', () => {
+  it('wins immediately when jumping in with last wild card', () => {
+    const topWild = makeCard('wild', null, { id: 'top_wild' });
+    const jumpWild = makeCard('wild', null, { id: 'jump_wild' });
+    const state = makeState({
+      currentPlayerIndex: 0,
+      currentColor: 'red',
+      discardPile: [topWild],
+      players: [
+        { id: 'p1', name: 'Alice', hand: [makeCard('number', 'red', { value: 1 })], score: 0, connected: true, calledUno: false },
+        { id: 'p2', name: 'Bob', hand: [jumpWild], score: 0, connected: true, calledUno: false },
+      ],
+      settings: { turnTimeLimit: 30, targetScore: 500, houseRules: { ...DEFAULT_HOUSE_RULES, jumpIn: true } },
+    });
+
+    const next = applyActionWithHouseRules(state, { type: 'PLAY_CARD', playerId: 'p2', cardId: 'jump_wild' });
+    expect(next.phase).toBe('round_end');
+    expect(next.winnerId).toBe('p2');
+  });
+
+  it('wins immediately when jumping in with last wild_draw_four', () => {
+    const topWd4 = makeCard('wild_draw_four', null, { id: 'top_wd4' });
+    const jumpWd4 = makeCard('wild_draw_four', null, { id: 'jump_wd4' });
+    const state = makeState({
+      currentPlayerIndex: 0,
+      currentColor: 'red',
+      discardPile: [topWd4],
+      players: [
+        { id: 'p1', name: 'Alice', hand: [makeCard('number', 'red', { value: 1 })], score: 0, connected: true, calledUno: false },
+        { id: 'p2', name: 'Bob', hand: [jumpWd4], score: 0, connected: true, calledUno: false },
+      ],
+      settings: { turnTimeLimit: 30, targetScore: 500, houseRules: { ...DEFAULT_HOUSE_RULES, jumpIn: true } },
+    });
+
+    const next = applyActionWithHouseRules(state, { type: 'PLAY_CARD', playerId: 'p2', cardId: 'jump_wd4' });
+    expect(next.phase).toBe('round_end');
+    expect(next.winnerId).toBe('p2');
+  });
+});
+
+describe('sevenSwap last card round end', () => {
+  it('wins immediately when playing last 7 instead of entering swap phase', () => {
+    const seven = makeCard('number', 'red', { value: 7, id: 'last_seven' });
+    const state = makeState({
+      players: [
+        { id: 'p1', name: 'Alice', hand: [seven], score: 0, connected: true, calledUno: false },
+        { id: 'p2', name: 'Bob', hand: [makeCard('number', 'green', { value: 2 }), makeCard('number', 'blue', { value: 3 })], score: 0, connected: true, calledUno: false },
+      ],
+      settings: { turnTimeLimit: 30, targetScore: 500, houseRules: { ...DEFAULT_HOUSE_RULES, sevenSwapHands: true } },
+    });
+
+    const next = applyActionWithHouseRules(state, { type: 'PLAY_CARD', playerId: 'p1', cardId: 'last_seven' });
+    expect(next.phase).toBe('round_end');
+    expect(next.winnerId).toBe('p1');
+  });
+});
+
 describe('jumpIn', () => {
   it('allows out-of-turn play with exact matching card', () => {
     const matchCard = makeCard('number', 'red', { value: 5, id: 'jump1' });


### PR DESCRIPTION
## Summary
- **托管 +4 卡死**：叠加规则开启时，托管出 wild_draw_four 不带 chosenColor，被叠加插件拒绝后无限重试定时器。修复托管策略在叠加场景下附带 chosenColor
- **最后一张功能牌不结算**：叠加、偏转、抢出等村规插件移除手牌后未调用 checkRoundEnd，导致最后一张 +2/+4/reverse/skip/wild 不能直接胜利。统一补上 checkRoundEnd
- **sevenSwapPost 覆盖终态**：打出最后一张 7 时，postProcess 把 round_end 覆盖为 choosing_swap_target。加终态守卫

## Test plan
- [x] 237 项单元测试全部通过（新增 6 项覆盖所有修复路径）
- [x] 服务端类型检查通过
- [ ] 开启 party/crazy 预设，托管模式出 +4 不再卡死
- [ ] 最后一张 +2/+4 直接结算胜利，不进入叠加流程

🤖 Generated with [Claude Code](https://claude.com/claude-code)