### PR TITLE
fix: 修复对局记录不保存、rematch 无权限检查及断线处理逻辑

### DIFF
--- a/packages/client/src/features/game/components/ScoreBoard.tsx
+++ b/packages/client/src/features/game/components/ScoreBoard.tsx
@@ -92,9 +92,12 @@ export default function ScoreBoard({ onPlayAgain, onRematch, onBackToLobby, onKi
             {allAgreed ? '所有玩家已同意，等待房主开始下一轮' : `已有 ${votes}/${required} 人同意继续下一轮`}
           </p>
         )}
+        {isGameOver && !isHost && (
+          <p className="mb-3 text-xs text-muted-foreground">等待房主发起再来一局</p>
+        )}
         <div className="flex gap-3 justify-center">
           {!isGameOver && <Button variant="primary" onClick={onPlayAgain} disabled={isNextRoundDisabled} sound="ready">{nextRoundButtonText}</Button>}
-          {isGameOver && <Button variant="primary" onClick={onRematch} sound="ready">再来一局</Button>}
+          {isGameOver && isHost && <Button variant="primary" onClick={onRematch} sound="ready">再来一局</Button>}
           <Button variant="secondary" onClick={onBackToLobby} sound="click">返回大厅</Button>
         </div>
       </div>

--- a/packages/client/src/features/game/hooks/useGameActions.ts
+++ b/packages/client/src/features/game/hooks/useGameActions.ts
@@ -58,7 +58,11 @@ export function useGameActions() {
   }, []);
 
   const rematch = useCallback(() => {
-    getSocket().emit('game:rematch', () => {});
+    getSocket().emit('game:rematch', (res: { success?: boolean; error?: string }) => {
+      if (res && !res.success) {
+        useToastStore.getState().addToast(res.error || '无法发起再来一局', 'error');
+      }
+    });
   }, []);
 
   const kickPlayer = useCallback((targetId: string) => {

--- a/packages/server/src/ws/game-events.ts
+++ b/packages/server/src/ws/game-events.ts
@@ -53,7 +53,8 @@ async function persistGameResult(roomCode: string, session: GameSession, startTi
     await saveDeckInfo(db, gameId, state.deckHash, session.getInitialDeckSerialized());
     session.clearEvents();
     setTimeout(() => persistedGames.delete(key), 60_000);
-  } catch {
+  } catch (err) {
+    console.error(`[persistGameResult] Failed to persist game ${key}:`, err);
     persistedGames.delete(key);
   }
 }
@@ -293,10 +294,10 @@ async function emitTerminalStateIfNeeded(
     nextRoundVotes.delete(roomCode);
     session.recordEvent(GameEventType.ROUND_END, { winnerId: state.winnerId!, scores }, null);
 
-    const autopilotIds = state.players.filter((p) => p.autopilot).map((p) => p.id);
-    if (autopilotIds.length > 0) {
+    const connectedAutopilotIds = state.players.filter((p) => p.autopilot && p.connected).map((p) => p.id);
+    if (connectedAutopilotIds.length > 0) {
       const votes = nextRoundVotes.get(roomCode) ?? new Set<string>();
-      for (const id of autopilotIds) votes.add(id);
+      for (const id of connectedAutopilotIds) votes.add(id);
       nextRoundVotes.set(roomCode, votes);
     }
 
@@ -672,6 +673,10 @@ export function registerGameEvents(
     const { session, roomCode } = ctx;
     if (!session.isGameOver()) {
       return callback?.({ success: false, error: 'Game is not over' });
+    }
+    const room = await getRoom(redis, roomCode);
+    if (room?.ownerId !== data.user.userId) {
+      return callback?.({ success: false, error: '只有房主可以发起再来一局' });
     }
     nextRoundVotes.delete(roomCode);
     session.resetForRematch();

--- a/packages/server/src/ws/room-events.ts
+++ b/packages/server/src/ws/room-events.ts
@@ -9,7 +9,7 @@ import { getRoom, getRoomPlayers, setRoomSettings, setRoomStatus, touchRoomActiv
 import { GameSession } from '../plugins/core/game/session';
 import type { GameStatePersister } from '../plugins/core/game/state-store';
 import type { TurnTimer } from '../plugins/core/game/turn-timer';
-import { setGameStartTime, removePlayerVote } from './game-events';
+import { setGameStartTime, removePlayerVote, persistGameOnDissolve } from './game-events';
 import type { SocketData } from './types';
 import { dissolveRoom } from './room-lifecycle';
 import { removeVoicePresence } from './voice-presence';
@@ -153,18 +153,28 @@ export function registerRoomEvents(
 
     const session = sessions.get(roomCode);
     if (session && !deleted) {
-      session.removePlayer(data.user.userId);
-      removePlayerVote(roomCode, data.user.userId, session, io);
+      const willEndGame = session.getPlayerCount() - 1 < MIN_PLAYERS;
 
-      if (session.getPlayerCount() < MIN_PLAYERS) {
+      if (willEndGame) {
         const st = session.getFullState();
-        const lastPlayer = st.players[0];
-        if (lastPlayer) session.forceGameOver(lastPlayer.id);
-        turnTimer.stop(roomCode);
-        io.to(roomCode).emit('game:over', {
-          winnerId: lastPlayer?.id ?? null,
-          scores: Object.fromEntries(st.players.map((p) => [p.id, p.score])),
-        });
+        const lastPlayer = st.players.find(p => p.id !== data.user.userId);
+        if (lastPlayer) {
+          session.forceGameOver(lastPlayer.id);
+          turnTimer.stop(roomCode);
+          // Persist before removing — game history needs the full player list
+          await persistGameOnDissolve(roomCode, session, db);
+          session.removePlayer(data.user.userId);
+          io.to(roomCode).emit('game:over', {
+            winnerId: lastPlayer.id,
+            scores: Object.fromEntries(st.players.map((p) => [p.id, p.score])),
+          });
+        } else {
+          turnTimer.stop(roomCode);
+          session.removePlayer(data.user.userId);
+        }
+      } else {
+        session.removePlayer(data.user.userId);
+        removePlayerVote(roomCode, data.user.userId, session, io);
       }
 
       persister.markDirty(roomCode, session.getFullState());
@@ -299,6 +309,7 @@ export function registerRoomEvents(
         const winner = state.players.find(p => p.hand.length === minCards);
         if (winner) {
           s.forceGameOver(winner.id);
+          await persistGameOnDissolve(roomCode, s, db);
           persister.markDirty(roomCode, s.getFullState());
           await persister.flushNow(roomCode);
           await emitGameUpdate(io, roomCode, s, redis);

--- a/packages/server/src/ws/socket-handler.ts
+++ b/packages/server/src/ws/socket-handler.ts
@@ -20,6 +20,7 @@ const RECONNECT_TIMEOUT_MS = 60_000;
 const AUTOPILOT_THINK_MS = 2_000;
 const ROOM_IDLE_SWEEP_MS = 60_000;
 const AUTOPILOT_TOGGLE_COOLDOWN_MS = 3_000;
+const ALL_DISCONNECT_TIMEOUT_MS = 5 * 60_000;
 
 const autopilotToggleTimestamps = new Map<string, number>();
 
@@ -28,6 +29,7 @@ export function setupSocketHandlers(io: SocketIOServer, redis: KvStore, jwtSecre
   const turnTimer = new TurnTimer();
   const sessions = new Map<string, GameSession>();
   const disconnectTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  const allDisconnectTimers = new Map<string, ReturnType<typeof setTimeout>>();
   const autoPlayIntervals = new Map<string, ReturnType<typeof setInterval>>();
   const userSocketMap = new Map<string, string>();
   const persister = new GameStatePersister(redis);
@@ -86,6 +88,14 @@ export function setupSocketHandlers(io: SocketIOServer, redis: KvStore, jwtSecre
     autoPlayIntervals.set(userId, interval);
   }
 
+  function cancelDissolutionTimer(roomCode: string) {
+    const timer = allDisconnectTimers.get(roomCode);
+    if (timer) {
+      clearTimeout(timer);
+      allDisconnectTimers.delete(roomCode);
+    }
+  }
+
   function stopAutoPlayForRoom(roomCode: string) {
     const session = sessions.get(roomCode);
     if (!session) return;
@@ -97,6 +107,7 @@ export function setupSocketHandlers(io: SocketIOServer, redis: KvStore, jwtSecre
         disconnectTimers.delete(player.id);
       }
     }
+    cancelDissolutionTimer(roomCode);
   }
 
   async function cleanupIdleRooms() {
@@ -158,6 +169,7 @@ export function setupSocketHandlers(io: SocketIOServer, redis: KvStore, jwtSecre
       }
 
       if (session) {
+        cancelDissolutionTimer(roomCode);
         session.setPlayerConnected(userId, true);
         session.setPlayerAutopilot(userId, false);
         resetPlayerTimeout(roomCode, userId);
@@ -214,6 +226,7 @@ export function setupSocketHandlers(io: SocketIOServer, redis: KvStore, jwtSecre
       const nextAutopilot = !player.autopilot;
       session.setPlayerAutopilot(userId, nextAutopilot);
       if (nextAutopilot) {
+        addAutopilotVote(roomCode, userId, session, io);
         startAutoPlay(userId, roomCode);
       } else {
         stopAutoPlay(userId);
@@ -250,6 +263,20 @@ export function setupSocketHandlers(io: SocketIOServer, redis: KvStore, jwtSecre
         if (connectedCount < 2) {
           turnTimer.stop(roomCode);
         }
+        if (connectedCount === 0 && !allDisconnectTimers.has(roomCode)) {
+          const dissolutionTimer = setTimeout(async () => {
+            allDisconnectTimers.delete(roomCode);
+            if (!sessions.has(roomCode)) return;
+            try {
+              stopAutoPlayForRoom(roomCode);
+              await dissolveRoom(io, redis, roomCode, sessions, turnTimer, persister, 'idle_timeout', getDb());
+            } catch (err) {
+              console.error(`[allDisconnect] Failed to dissolve room ${roomCode}:`, err);
+            }
+          }, ALL_DISCONNECT_TIMEOUT_MS);
+          dissolutionTimer.unref?.();
+          allDisconnectTimers.set(roomCode, dissolutionTimer);
+        }
 
         // Host transfer: if disconnected player is room owner, transfer
         const room = await getRoom(redis, roomCode);
@@ -275,7 +302,6 @@ export function setupSocketHandlers(io: SocketIOServer, redis: KvStore, jwtSecre
             persister.markDirty(roomCode, s.getFullState());
             await emitGameUpdate(io, roomCode, s, redis);
             io.to(roomCode).emit('player:autopilot', { playerId: userId, enabled: true });
-            addAutopilotVote(roomCode, userId, s, io);
             startAutoPlay(userId, roomCode);
           }
         }, RECONNECT_TIMEOUT_MS);


### PR DESCRIPTION
## Summary

- **对局记录为空**：`forceGameOver` 路径（玩家退出导致人数不足、blitz 超时）未调用 `persistGameResult`，且 catch 块静默吞错误无日志
- **rematch 无权限**：任何玩家都能触发"再来一局"直接重开游戏，绕过房主控制
- **断线自动投票**：断线玩家不应在 round_end 阶段被自动投票同意继续
- **全员断线无处理**：所有人断线后房间依赖 2 小时闲置超时才清理

## Changes

- `persistGameResult` catch 块添加 `console.error` 输出
- 玩家退出 / blitz 超时的 `forceGameOver` 后调用 `persistGameOnDissolve`
- 调整 `removePlayer` 顺序，持久化时包含完整玩家列表
- `game:rematch` 添加房主权限校验
- 前端 ScoreBoard 仅对房主显示"再来一局"按钮，非房主显示等待提示
- `emitTerminalStateIfNeeded` 中自动投票仅限 `connected + autopilot` 玩家
- 断线 60s 超时回调不再调用 `addAutopilotVote`
- 在线手动开启 autopilot 时补加投票
- 全员断线 5 分钟自动解散房间（含 try/catch 防护）
- 提取 `cancelDissolutionTimer` 辅助函数消除重复代码

## Test plan

- [ ] 正常对局达到目标分数后，检查数据库是否有对局记录
- [ ] 2 人对局中一人退出，检查对局记录是否包含双方数据
- [ ] 非房主点击"再来一局"应看不到按钮/收到错误提示
- [ ] round_end 阶段断线玩家不自动投票，房主可在 30s 后踢出
- [ ] 全员断线后 5 分钟内房间自动解散
- [ ] 重连后解散计时器正确取消

🤖 Generated with [Claude Code](https://claude.com/claude-code)