### PR TITLE
feat: 游戏规则修复、观众席弹幕及 UX 改进

### DIFF
--- a/packages/client/src/features/game/components/DanmakuLayer.tsx
+++ b/packages/client/src/features/game/components/DanmakuLayer.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useRef, useState } from 'react';
+import { useChatStore } from '../stores/chat-store';
+import type { ChatMessage } from '@uno-online/shared';
+
+interface DanmakuItem {
+  id: string;
+  message: ChatMessage;
+  track: number;
+}
+
+const TRACK_COUNT = 5;
+const DURATION = 8000;
+
+export default function DanmakuLayer() {
+  const latestMessage = useChatStore((s) => s.latestLiveMessage);
+  const [items, setItems] = useState<DanmakuItem[]>([]);
+  const nextTrackRef = useRef(0);
+
+  useEffect(() => {
+    if (!latestMessage) return;
+    const track = nextTrackRef.current % TRACK_COUNT;
+    nextTrackRef.current = track + 1;
+    const item: DanmakuItem = { id: latestMessage.id, message: latestMessage, track };
+    setItems((prev) => [...prev, item]);
+    const timer = setTimeout(() => {
+      setItems((prev) => prev.filter((i) => i.id !== item.id));
+    }, DURATION);
+    return () => clearTimeout(timer);
+  }, [latestMessage]);
+
+  if (items.length === 0) return null;
+
+  return (
+    <div className="absolute inset-0 overflow-hidden pointer-events-none" style={{ zIndex: 15 }}>
+      {items.map((item) => (
+        <div
+          key={item.id}
+          className="danmaku-item absolute whitespace-nowrap text-sm font-bold"
+          style={{
+            top: `${item.track * 28 + 8}px`,
+            textShadow: '1px 1px 2px rgba(0,0,0,0.8), -1px -1px 2px rgba(0,0,0,0.8)',
+          }}
+        >
+          {item.message.isSpectator && (
+            <span className="text-2xs bg-white/20 rounded px-1 py-0.5 mr-1 align-middle">观众</span>
+          )}
+          <span className="text-white/60 mr-1">{item.message.nickname}</span>
+          <span className="text-white">{item.message.text}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/client/src/features/game/components/PlayerHand.tsx
+++ b/packages/client/src/features/game/components/PlayerHand.tsx
@@ -146,13 +146,11 @@ export default function PlayerHand({ onPlayCard }: PlayerHandProps) {
   const houseRules = settings?.houseRules;
   const shouldPickColorBeforePlay = (card: CardType) => {
     if (card.type !== 'wild_draw_four' || !houseRules || !topCard) return false;
-    if (topCard.type !== 'draw_two' && topCard.type !== 'wild_draw_four') {
-      return houseRules.stackDrawFour || houseRules.crossStack;
-    }
-    return (
-      drawStack > 0 ||
-      (drawStack === 0 && (houseRules.stackDrawFour || houseRules.crossStack))
-    );
+    if (drawStack <= 0) return false;
+    const canStack =
+      (houseRules.stackDrawFour && topCard.type === 'wild_draw_four') ||
+      (houseRules.crossStack && (topCard.type === 'draw_two' || topCard.type === 'wild_draw_four'));
+    return canStack;
   };
 
   const setActiveFromPointer = (clientX: number) => {

--- a/packages/client/src/features/game/components/PlayerListPanel.tsx
+++ b/packages/client/src/features/game/components/PlayerListPanel.tsx
@@ -1,4 +1,6 @@
+import { Eye } from 'lucide-react';
 import { useGameStore } from '../stores/game-store';
+import { useSpectatorStore } from '../stores/spectator-store';
 import { useEffectiveUserId } from '../hooks/useEffectiveUserId';
 import { AVATAR_COLORS, AVATAR_EMOJIS } from '../constants/avatars';
 import GoogleRing from '@/shared/components/ui/GoogleRing';
@@ -9,6 +11,7 @@ import { AiBadge } from '@/shared/components/ui/AiBadge';
 export default function PlayerListPanel() {
   const players = useGameStore((s) => s.players);
   const currentPlayerIndex = useGameStore((s) => s.currentPlayerIndex);
+  const spectators = useSpectatorStore((s) => s.spectators);
   const userId = useEffectiveUserId();
 
   if (players.length === 0) return null;
@@ -20,7 +23,7 @@ export default function PlayerListPanel() {
           玩家 ({players.length})
         </div>
         <div className="py-1">
-          {players.map((p, i) => {
+          {players.map((p, i: number) => {
             const isActive = i === currentPlayerIndex;
             const isMe = p.id === userId;
             const roleColor = getRoleColor(p.role);
@@ -71,6 +74,21 @@ export default function PlayerListPanel() {
             );
           })}
         </div>
+        {spectators.length > 0 && (
+          <>
+            <div className="px-3 py-2 border-t border-white/10 text-xs text-muted-foreground font-bold">
+              观众 ({spectators.length})
+            </div>
+            <div className="py-1">
+              {spectators.map((name) => (
+                <div key={name} className="flex items-center gap-2 px-3 py-1 text-xs text-muted-foreground">
+                  <Eye size={12} className="shrink-0" />
+                  <span className="truncate">{name}</span>
+                </div>
+              ))}
+            </div>
+          </>
+        )}
       </div>
     </div>
   );

--- a/packages/client/src/features/game/components/ScoreBoard.tsx
+++ b/packages/client/src/features/game/components/ScoreBoard.tsx
@@ -22,11 +22,20 @@ export default function ScoreBoard({ onPlayAgain, onRematch, onBackToLobby, onKi
   const phase = useGameStore((s) => s.phase);
   const vote = useGameStore((s) => s.nextRoundVote);
   const [canKick, setCanKick] = useState(false);
+  const [leaveCountdown, setLeaveCountdown] = useState(5);
 
   useEffect(() => {
     if (phase !== 'round_end') { setCanKick(false); return; }
     const timer = setTimeout(() => setCanKick(true), KICK_DELAY_MS);
     return () => clearTimeout(timer);
+  }, [phase]);
+
+  useEffect(() => {
+    setLeaveCountdown(5);
+    const interval = setInterval(() => {
+      setLeaveCountdown((c) => { if (c <= 1) { clearInterval(interval); return 0; } return c - 1; });
+    }, 1000);
+    return () => clearInterval(interval);
   }, [phase]);
   const ownerId = useRoomStore((s) => s.room?.ownerId);
   const userId = useEffectiveUserId();
@@ -93,13 +102,11 @@ export default function ScoreBoard({ onPlayAgain, onRematch, onBackToLobby, onKi
             {allAgreed ? '所有玩家已同意，等待房主开始下一轮' : `已有 ${votes}/${required} 人同意继续下一轮`}
           </p>
         )}
-        {isGameOver && !isHost && (
-          <p className="mb-3 text-xs text-muted-foreground">等待房主发起再来一局</p>
-        )}
         <div className="flex gap-3 justify-center">
           {!isGameOver && <Button variant="primary" onClick={onPlayAgain} disabled={isNextRoundDisabled} sound="ready">{nextRoundButtonText}</Button>}
           {isGameOver && isHost && <Button variant="primary" onClick={onRematch} sound="ready">再来一局</Button>}
-          <Button variant="secondary" onClick={onBackToLobby} sound="click">返回大厅</Button>
+          {isGameOver && !isHost && <Button variant="primary" disabled>等待房主再来一局…</Button>}
+          <Button variant="secondary" onClick={onBackToLobby} sound="click" disabled={leaveCountdown > 0}>{leaveCountdown > 0 ? `返回大厅 (${leaveCountdown}s)` : '返回大厅'}</Button>
         </div>
       </div>
     </div>

--- a/packages/client/src/features/game/hooks/useGameSocket.ts
+++ b/packages/client/src/features/game/hooks/useGameSocket.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useGameStore } from '../stores/game-store';
 import { useChatStore } from '../stores/chat-store';
+import { useSpectatorStore } from '../stores/spectator-store';
 import { useRoomStore } from '@/shared/stores/room-store';
 import { getSocket, connectSocket, onConnectionStatus, refreshVoicePresence } from '@/shared/socket';
 
@@ -11,6 +12,7 @@ export function useGameSocket(roomCode: string | undefined) {
   const setChatHistory = useChatStore((s) => s.setHistory);
   const addChatMessage = useChatStore((s) => s.addMessage);
   const clearChatMessages = useChatStore((s) => s.clearMessages);
+  const setSpectators = useSpectatorStore((s) => s.setSpectators);
   const setRoom = useRoomStore((s) => s.setRoom);
   const navigate = useNavigate();
   const [connectionStatus, setConnectionStatus] = useState<
@@ -42,12 +44,22 @@ export function useGameSocket(roomCode: string | undefined) {
     socket.on('chat:message', addChatMessage);
     socket.on('chat:cleared', clearChatMessages);
 
+    const onSpectatorList = (data: { spectators: string[] }) => setSpectators(data.spectators);
+    const onSpectatorJoined = (data: { spectators: string[] }) => setSpectators(data.spectators);
+    const onSpectatorLeft = (data: { spectators: string[] }) => setSpectators(data.spectators);
+    socket.on('room:spectator_list', onSpectatorList);
+    socket.on('room:spectator_joined', onSpectatorJoined);
+    socket.on('room:spectator_left', onSpectatorLeft);
+
     return () => {
       socket.off('chat:history', setChatHistory);
       socket.off('chat:message', addChatMessage);
       socket.off('chat:cleared', clearChatMessages);
+      socket.off('room:spectator_list', onSpectatorList);
+      socket.off('room:spectator_joined', onSpectatorJoined);
+      socket.off('room:spectator_left', onSpectatorLeft);
     };
-  }, [setChatHistory, addChatMessage, clearChatMessages]);
+  }, [setChatHistory, addChatMessage, clearChatMessages, setSpectators]);
 
   // Reconnection status tracking + auto-rejoin on reconnect
   useEffect(() => {

--- a/packages/client/src/features/game/hooks/usePlayableCardIds.ts
+++ b/packages/client/src/features/game/hooks/usePlayableCardIds.ts
@@ -19,6 +19,7 @@ export function usePlayableCardIds(): Set<string> {
     if (phase !== 'playing') return new Set<string>();
     if (!isMyTurn) {
       if (!settings?.houseRules?.jumpIn) return new Set<string>();
+      if (pendingPenaltyDraws > 0 || drawStack > 0) return new Set<string>();
       return getJumpInCardIds(myHand ?? [], topCard);
     }
     if (pendingPenaltyDraws > 0) return new Set<string>();

--- a/packages/client/src/features/game/pages/GamePage.tsx
+++ b/packages/client/src/features/game/pages/GamePage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import type { MouseEvent } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
-import { Loader2, Eye, LogOut } from 'lucide-react';
+import { Loader2, Eye, LogOut, UserPlus } from 'lucide-react';
 import { motion, AnimatePresence, LayoutGroup } from 'framer-motion';
 import { useGameStore } from '../stores/game-store';
 import { useIsMyTurn } from '../hooks/useIsMyTurn';
@@ -14,6 +14,7 @@ import { playSound } from '@/shared/sound/sound-manager';
 import { getSocket, refreshVoicePresence } from '@/shared/socket';
 import { leaveVoiceSession } from '@/shared/voice/voice-runtime';
 import { useRoomStore } from '@/shared/stores/room-store';
+import { useToastStore } from '@/shared/stores/toast-store';
 import TopBar from '../components/TopBar';
 import GameTable from '../components/GameTable';
 import GameActions from '../components/GameActions';
@@ -26,6 +27,8 @@ import Confetti from '../components/Confetti';
 import MobileFAB from '../components/MobileFAB';
 import InfoDrawer from '../components/InfoDrawer';
 import PlayerListPanel from '../components/PlayerListPanel';
+import DanmakuLayer from '../components/DanmakuLayer';
+import { useSpectatorStore } from '../stores/spectator-store';
 import GameStartRulesModal from '../components/GameStartRulesModal';
 
 export default function GamePage() {
@@ -37,6 +40,7 @@ export default function GamePage() {
   const openInfoDrawer = useGameStore((s) => s.openInfoDrawer);
   const clearGame = useGameStore((s) => s.clearGame);
   const clearRoom = useRoomStore((s) => s.clearRoom);
+  const clearSpectators = useSpectatorStore((s) => s.clearSpectators);
 
   const isMyTurn = useIsMyTurn();
   const playableIds = usePlayableCardIds();
@@ -121,6 +125,7 @@ export default function GamePage() {
     getSocket().emit('room:leave', () => {
       clearRoom();
       clearGame();
+      clearSpectators();
       navigate('/lobby');
     });
   };
@@ -152,7 +157,10 @@ export default function GamePage() {
       <TopBar roomCode={roomCode ?? ''} />
       <PlayerListPanel />
       <LayoutGroup>
+      <div className="relative flex flex-col flex-1 min-h-0">
       <GameTable onDraw={drawCard} />
+      <DanmakuLayer />
+      </div>
       <AnimatePresence>
         {showTurnBanner && isMyTurn && phase === 'playing' && (
           <motion.div
@@ -181,6 +189,23 @@ export default function GamePage() {
       {isSpectator && (
         <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-actions bg-card/90 backdrop-blur-sm rounded-full px-3 py-2 text-sm text-muted-foreground flex items-center gap-2">
           <Eye size={16} /> 观战中
+          {phase === 'round_end' && (
+            <button
+              onClick={() => {
+                getSocket().emit('game:spectator_join', (res: { success?: boolean; error?: string }) => {
+                  if (res?.success) {
+                    setSpectator(false);
+                    clearSpectators();
+                  } else {
+                    useToastStore.getState().addToast(res?.error ?? '加入失败', 'error');
+                  }
+                });
+              }}
+              className="ml-1 inline-flex items-center gap-1 rounded-full bg-primary/80 px-2 py-1 text-xs text-white transition-colors hover:bg-primary"
+            >
+              <UserPlus size={12} /> 加入游戏
+            </button>
+          )}
           <button
             onClick={backToLobby}
             className="ml-1 inline-flex items-center gap-1 rounded-full bg-white/10 px-2 py-1 text-xs text-foreground transition-colors hover:bg-white/20"

--- a/packages/client/src/features/game/pages/RoomPage.tsx
+++ b/packages/client/src/features/game/pages/RoomPage.tsx
@@ -96,7 +96,7 @@ export default function RoomPage() {
         <button
           onClick={() => {
             const url = `${window.location.origin}/room/${roomCode}`;
-            navigator.clipboard.writeText(url);
+            navigator.clipboard.writeText(`来玩 UNO 吧！房间号：${roomCode}\n${url}`);
             useToastStore.getState().addToast('房间链接已复制', 'success');
           }}
           className="bg-white/10 hover:bg-white/20 rounded-lg p-1.5 cursor-pointer transition-colors"

--- a/packages/client/src/features/game/stores/spectator-store.ts
+++ b/packages/client/src/features/game/stores/spectator-store.ts
@@ -1,0 +1,19 @@
+import { create } from 'zustand';
+
+interface SpectatorState {
+  spectators: string[];
+  setSpectators: (list: string[]) => void;
+  addSpectator: (nickname: string) => void;
+  removeSpectator: (nickname: string) => void;
+  clearSpectators: () => void;
+}
+
+export const useSpectatorStore = create<SpectatorState>((set) => ({
+  spectators: [],
+  setSpectators: (list) => set({ spectators: list }),
+  addSpectator: (nickname) =>
+    set((s) => s.spectators.includes(nickname) ? s : { spectators: [...s.spectators, nickname] }),
+  removeSpectator: (nickname) =>
+    set((s) => ({ spectators: s.spectators.filter((n) => n !== nickname) })),
+  clearSpectators: () => set({ spectators: [] }),
+}));

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -357,3 +357,11 @@
 @utility shadow-tech {
   box-shadow: var(--border-glow);
 }
+
+@keyframes danmaku-scroll {
+  from { transform: translateX(100vw); }
+  to { transform: translateX(-100%); }
+}
+.danmaku-item {
+  animation: danmaku-scroll 8s linear forwards;
+}

--- a/packages/server/src/plugins/core/game/session.ts
+++ b/packages/server/src/plugins/core/game/session.ts
@@ -152,6 +152,31 @@ export class GameSession {
     };
   }
 
+  addPlayer(data: { id: string; name: string; avatarUrl?: string | null; role?: UserRole; isBot?: boolean }): void {
+    if (this.state.players.some((p) => p.id === data.id)) return;
+    this.state = {
+      ...this.state,
+      players: [
+        ...this.state.players,
+        {
+          id: data.id,
+          name: data.name,
+          hand: [],
+          score: 0,
+          roundWins: 0,
+          connected: true,
+          autopilot: false,
+          calledUno: false,
+          unoCaught: false,
+          eliminated: false,
+          avatarUrl: data.avatarUrl ?? null,
+          role: data.role,
+          isBot: data.isBot ?? false,
+        },
+      ],
+    };
+  }
+
   removePlayer(playerId: string): void {
     this.state = {
       ...this.state,

--- a/packages/server/src/plugins/core/spectate/ws.ts
+++ b/packages/server/src/plugins/core/spectate/ws.ts
@@ -5,6 +5,16 @@ import { deleteRoom, getRoom } from '../room/store';
 import { GameSession } from '../game/session';
 import { loadGameState } from '../game/state-store';
 
+const roomSpectators = new Map<string, Set<string>>();
+
+function getSpectatorNames(roomCode: string): string[] {
+  return [...(roomSpectators.get(roomCode) ?? [])];
+}
+
+export function clearRoomSpectators(roomCode: string): void {
+  roomSpectators.delete(roomCode);
+}
+
 export function setupSpectateHandlers(
   io: SocketIOServer,
   kv: KvStore,
@@ -48,12 +58,17 @@ export function setupSpectateHandlers(
       data.isSpectator = true;
       await socket.join(roomCode);
 
+      if (!roomSpectators.has(roomCode)) roomSpectators.set(roomCode, new Set());
+      roomSpectators.get(roomCode)!.add(data.user.nickname);
+
       const view = session.getSpectatorView(room.settings.spectatorMode);
       socket.emit('game:state', view);
       socket.emit('chat:history', session.getChatHistory());
+      socket.emit('room:spectator_list', { spectators: getSpectatorNames(roomCode) });
 
       socket.to(roomCode).emit('room:spectator_joined', {
         nickname: data.user.nickname,
+        spectators: getSpectatorNames(roomCode),
       });
 
       callback?.({ success: true });
@@ -62,8 +77,13 @@ export function setupSpectateHandlers(
     socket.on('disconnect', () => {
       const data = socket.data as SocketData;
       if (data.isSpectator && data.roomCode) {
+        const nickname = data.user?.nickname;
+        if (nickname) {
+          roomSpectators.get(data.roomCode)?.delete(nickname);
+        }
         socket.to(data.roomCode).emit('room:spectator_left', {
-          nickname: data.user?.nickname,
+          nickname: nickname ?? '',
+          spectators: getSpectatorNames(data.roomCode),
         });
       }
     });

--- a/packages/server/src/ws/game-events.ts
+++ b/packages/server/src/ws/game-events.ts
@@ -10,7 +10,8 @@ import { emitGameUpdate, setAutopilotActionHandler, startTurnTimer, resetPlayerT
 import type { TurnTimer } from '../plugins/core/game/turn-timer';
 import { recordGameResult } from '../db/user-repo';
 import { saveGameEvents, saveDeckInfo } from '../plugins/core/game-history/service';
-import { getRoom, setRoomStatus, touchRoomActivity, removePlayerFromRoom } from '../plugins/core/room/store';
+import { getRoom, setRoomStatus, touchRoomActivity, removePlayerFromRoom, addPlayerToRoom } from '../plugins/core/room/store';
+import { MAX_PLAYERS } from '@uno-online/shared';
 import type { SocketData } from './types';
 
 function getSession(socket: Socket, sessions: Map<string, GameSession>): { session: GameSession; roomCode: string } | null {
@@ -77,7 +78,7 @@ function checkChatRateLimit(userId: string): boolean {
   return true;
 }
 
-function buildChatMessage(user: SocketData['user'], text: string): ChatMessage {
+function buildChatMessage(user: SocketData['user'], text: string, isSpectator = false): ChatMessage {
   return {
     id: `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
     userId: user.userId,
@@ -85,6 +86,7 @@ function buildChatMessage(user: SocketData['user'], text: string): ChatMessage {
     text,
     timestamp: Date.now(),
     role: user.role ?? 'normal',
+    isSpectator: isSpectator || undefined,
   };
 }
 
@@ -572,7 +574,7 @@ export function registerGameEvents(
     const text = payload.text.trim().slice(0, 500);
     if (!text) return;
 
-    const message = buildChatMessage(data.user, text);
+    const message = buildChatMessage(data.user, text, data.isSpectator);
     session.addChatMessage(message);
     touchRoomActivity(redis, roomCode).catch(() => {});
     persister.markDirty(roomCode, session.getFullState());
@@ -608,6 +610,40 @@ export function registerGameEvents(
     }
 
     callback?.({ success: true, started: false, vote: voteState });
+  });
+
+  socket.on('game:spectator_join', async (callback) => {
+    const roomCode = data.roomCode;
+    if (!roomCode || !data.isSpectator) return callback?.({ success: false, error: '非观众' });
+    const session = sessions.get(roomCode);
+    if (!session) return callback?.({ success: false, error: '游戏会话不存在' });
+    if (!session.isRoundEnd()) return callback?.({ success: false, error: '只能在回合结束时加入' });
+    if (session.getPlayerCount() >= MAX_PLAYERS) return callback?.({ success: false, error: '玩家已满' });
+    if (session.getFullState().players.some((p) => p.id === data.user.userId)) {
+      return callback?.({ success: false, error: '已在游戏中' });
+    }
+
+    data.isSpectator = false;
+    session.addPlayer({
+      id: data.user.userId,
+      name: data.user.nickname,
+      avatarUrl: data.user.avatarUrl,
+      role: data.user.role as any,
+      isBot: data.user.isBot,
+    });
+    await addPlayerToRoom(redis, roomCode, {
+      userId: data.user.userId,
+      nickname: data.user.nickname,
+      avatarUrl: data.user.avatarUrl,
+      role: data.user.role,
+      isBot: data.user.isBot,
+    });
+    persister.markDirty(roomCode, session.getFullState());
+
+    const voteState = getNextRoundVoteState(roomCode, session);
+    io.to(roomCode).emit('game:next_round_vote', voteState);
+    await emitGameUpdate(io, roomCode, session, redis);
+    callback?.({ success: true });
   });
 
   socket.on('game:kick_player', async (payload: { targetId?: string }, callback) => {

--- a/packages/server/src/ws/room-events.ts
+++ b/packages/server/src/ws/room-events.ts
@@ -17,6 +17,7 @@ import { getAutopilotActionPlayerId } from './autopilot-action-player';
 
 const DRAW_PENALTY_PAUSE_MS = 500;
 const AUTO_AUTOPILOT_THRESHOLD = 2;
+const BOT_TURN_TIME_LIMIT = 120;
 type AutopilotActionHandler = (roomCode: string, session: GameSession, action: GameAction) => void;
 
 // Track consecutive timeouts per player per room
@@ -379,6 +380,29 @@ export function startTurnTimer(
 ) {
   const state = session.getFullState();
   const phase = state.phase;
+
+  const actingPlayerId = getAutopilotActionPlayerId(state);
+  const actingPlayer = actingPlayerId ? state.players.find(p => p.id === actingPlayerId) : null;
+  if (actingPlayer?.isBot && !actingPlayer.autopilot) {
+    turnTimer.start(roomCode, BOT_TURN_TIME_LIMIT, async (code) => {
+      const s = sessions.get(code);
+      if (!s) return;
+      const pid = getAutopilotActionPlayerId(s.getFullState());
+      if (!pid) {
+        startTurnTimer(io, redis, code, s, turnTimer, sessions, persister);
+        return;
+      }
+      await executeAutopilot(s, pid, async () => {
+        persister.markDirty(code, s.getFullState());
+        await emitGameUpdate(io, code, s, redis);
+      }, (action) => notifyAutopilotAction(code, s, action));
+      persister.markDirty(code, s.getFullState());
+      await emitGameUpdate(io, code, s, redis);
+      startTurnTimer(io, redis, code, s, turnTimer, sessions, persister);
+    });
+    return;
+  }
+
   const immediateAutopilotPlayerId = getImmediateAutopilotPlayerId(state);
 
   if (immediateAutopilotPlayerId) {

--- a/packages/shared/src/rules/autopilot-strategy.ts
+++ b/packages/shared/src/rules/autopilot-strategy.ts
@@ -106,7 +106,7 @@ export function chooseAutopilotAction(state: GameState, playerId: string): GameA
       return [{ type: 'PASS', playerId }];
     }
     const pick = pickPlayableCard(playableAfterDraw, state.currentColor);
-    const needsColorOnPlay = pick.type === 'wild_draw_four' && (hr.stackDrawFour || hr.crossStack);
+    const needsColorOnPlay = pick.type === 'wild_draw_four' && state.drawStack > 0 && (hr.stackDrawFour || hr.crossStack);
     return playCardActions(playerId, pick, player.hand, needsColorOnPlay);
   }
 
@@ -151,6 +151,6 @@ export function chooseAutopilotAction(state: GameState, playerId: string): GameA
   }
 
   const pick = pickPlayableCard(playable, state.currentColor);
-  const needsColorOnPlay = pick.type === 'wild_draw_four' && (hr.stackDrawFour || hr.crossStack);
+  const needsColorOnPlay = pick.type === 'wild_draw_four' && state.drawStack > 0 && (hr.stackDrawFour || hr.crossStack);
   return playCardActions(playerId, pick, player.hand, needsColorOnPlay);
 }

--- a/packages/shared/src/rules/house-rule-types.ts
+++ b/packages/shared/src/rules/house-rule-types.ts
@@ -39,7 +39,7 @@ export interface RuleContext {
   handleForcedPlayAfterDraw: (state: GameState, action: Extract<GameAction, { type: 'DRAW_CARD' }>) => GameState;
   applyDoubleScore: (before: GameState, after: GameState) => GameState;
   canPlayCard: (card: Card, topCard: Card, currentColor: Color) => boolean;
-  getNextPlayerIndex: (current: number, total: number, direction: Direction) => number;
+  getNextPlayerIndex: (current: number, total: number, direction: Direction, skip?: number) => number;
 }
 
 export interface HouseRulePlugin {

--- a/packages/shared/src/rules/house-rules-engine.ts
+++ b/packages/shared/src/rules/house-rules-engine.ts
@@ -5,6 +5,17 @@ import { PRE_CHECK_PLUGINS, POST_PROCESS_PLUGINS } from './rules/index';
 
 const ctx = buildRuleContext();
 
+function runPostProcess(state: GameState, next: GameState, action: GameAction, hr: GameState['settings']['houseRules']): GameState {
+  for (const plugin of POST_PROCESS_PLUGINS) {
+    if (!plugin.isEnabled(hr)) continue;
+    if (!plugin.postProcess) continue;
+    next = plugin.postProcess(state, next, action, ctx);
+  }
+  return next;
+}
+
+const TERMINAL_PHASES = new Set(['round_end', 'game_over']);
+
 export function applyActionWithHouseRules(state: GameState, action: GameAction): GameState {
   const hr = state.settings.houseRules;
 
@@ -12,16 +23,15 @@ export function applyActionWithHouseRules(state: GameState, action: GameAction):
     if (!plugin.isEnabled(hr)) continue;
     if (!plugin.preCheck) continue;
     const result = plugin.preCheck(state, action, ctx);
-    if (result.handled) return drainPenaltyQueue(result.state);
+    if (result.handled) {
+      let next = drainPenaltyQueue(result.state);
+      if (next !== state && TERMINAL_PHASES.has(next.phase) && !TERMINAL_PHASES.has(state.phase)) {
+        next = runPostProcess(state, next, action, hr);
+      }
+      return next;
+    }
   }
 
   let next = applyAction(state, action);
-
-  for (const plugin of POST_PROCESS_PLUGINS) {
-    if (!plugin.isEnabled(hr)) continue;
-    if (!plugin.postProcess) continue;
-    next = plugin.postProcess(state, next, action, ctx);
-  }
-
-  return next;
+  return runPostProcess(state, next, action, hr);
 }

--- a/packages/shared/src/rules/rules/jump-in.ts
+++ b/packages/shared/src/rules/rules/jump-in.ts
@@ -2,6 +2,7 @@ import type { HouseRulePlugin } from '../house-rule-types';
 import type { GameState, GameAction } from '../../types/game';
 import type { RuleContext, PreCheckResult } from '../house-rule-types';
 import { isExactJumpInMatch } from '../validation';
+import { reverseDirection } from '../turn';
 
 export const jumpIn: HouseRulePlugin = {
   meta: {
@@ -14,6 +15,7 @@ export const jumpIn: HouseRulePlugin = {
   preCheck: (state: GameState, action: GameAction, ctx: RuleContext): PreCheckResult => {
     if (action.type !== 'PLAY_CARD') return { handled: false };
     if (state.phase !== 'playing') return { handled: false };
+    if ((state.pendingPenaltyDraws ?? 0) > 0 || state.drawStack > 0) return { handled: false };
     const currentPlayer = state.players[state.currentPlayerIndex];
     if (!currentPlayer || currentPlayer.id === action.playerId) return { handled: false };
 
@@ -39,27 +41,139 @@ export const jumpIn: HouseRulePlugin = {
         lastAction: action,
       };
 
-      if (card.type === 'wild') {
-        return {
-          handled: true,
-          state: ctx.checkRoundEnd({
-            ...baseState,
-            phase: 'choosing_color',
-            currentPlayerIndex: jumperIdx,
-          }, action.playerId),
-        };
-      }
+      switch (card.type) {
+        case 'skip': {
+          return {
+            handled: true,
+            state: ctx.checkRoundEnd({
+              ...baseState,
+              currentColor: card.color,
+              currentPlayerIndex: ctx.getNextPlayerIndex(jumperIdx, players.length, state.direction, 1),
+            }, action.playerId),
+          };
+        }
 
-      if (card.type === 'wild_draw_four') {
-        return {
-          handled: true,
-          state: ctx.checkRoundEnd({
-            ...baseState,
-            phase: 'choosing_color',
-            currentPlayerIndex: jumperIdx,
-            pendingDrawPlayerId: players[nextIdx]?.id ?? null,
-          }, action.playerId),
-        };
+        case 'reverse': {
+          const newDirection = reverseDirection(state.direction);
+          const newIdx = players.length === 2
+            ? jumperIdx
+            : ctx.getNextPlayerIndex(jumperIdx, players.length, newDirection);
+          return {
+            handled: true,
+            state: ctx.checkRoundEnd({
+              ...baseState,
+              currentColor: card.color,
+              direction: newDirection,
+              currentPlayerIndex: newIdx,
+            }, action.playerId),
+          };
+        }
+
+        case 'draw_two': {
+          const drawTarget = players[nextIdx]?.id;
+          if (!drawTarget) break;
+          const skipNext = ctx.getNextPlayerIndex(jumperIdx, players.length, state.direction, 1);
+          let penaltyState = ctx.startPenaltyDraw(
+            { ...baseState, currentColor: card.color },
+            drawTarget, 2, skipNext, action.playerId,
+          );
+          if (state.settings.houseRules.revengeMode && (topCard.type === 'draw_two' || topCard.type === 'wild_draw_four')) {
+            penaltyState = ctx.startPenaltyDraw(penaltyState, drawTarget, 2, skipNext);
+          }
+          return {
+            handled: true,
+            state: ctx.checkRoundEnd(penaltyState, action.playerId),
+          };
+        }
+
+        case 'wild': {
+          if (action.chosenColor) {
+            const discardPile = [...baseState.discardPile];
+            discardPile[discardPile.length - 1] = { ...card, chosenColor: action.chosenColor };
+            return {
+              handled: true,
+              state: ctx.checkRoundEnd({
+                ...baseState,
+                discardPile,
+                currentColor: action.chosenColor,
+              }, action.playerId),
+            };
+          }
+          return {
+            handled: true,
+            state: ctx.checkRoundEnd({
+              ...baseState,
+              phase: 'choosing_color',
+              currentPlayerIndex: jumperIdx,
+            }, action.playerId),
+          };
+        }
+
+        case 'wild_draw_four': {
+          if (action.chosenColor) {
+            const discardPile = [...baseState.discardPile];
+            discardPile[discardPile.length - 1] = { ...card, chosenColor: action.chosenColor };
+            return {
+              handled: true,
+              state: ctx.checkRoundEnd({
+                ...baseState,
+                discardPile,
+                currentColor: action.chosenColor,
+                phase: 'challenging',
+                currentPlayerIndex: jumperIdx,
+                pendingDrawPlayerId: players[nextIdx]?.id ?? null,
+              }, action.playerId),
+            };
+          }
+          return {
+            handled: true,
+            state: ctx.checkRoundEnd({
+              ...baseState,
+              phase: 'choosing_color',
+              currentPlayerIndex: jumperIdx,
+              pendingDrawPlayerId: players[nextIdx]?.id ?? null,
+            }, action.playerId),
+          };
+        }
+
+        case 'number': {
+          const hr = state.settings.houseRules;
+          if (hr.sevenSwapHands && card.value === 7) {
+            return {
+              handled: true,
+              state: ctx.checkRoundEnd({
+                ...baseState,
+                currentColor: card.color,
+                phase: 'choosing_swap_target',
+                currentPlayerIndex: jumperIdx,
+              }, action.playerId),
+            };
+          }
+          if (hr.zeroRotateHands && card.value === 0) {
+            const hands = players.map(p => [...p.hand]);
+            const rotatedPlayers = players.map((p, i) => {
+              const sourceIdx = state.direction === 'clockwise'
+                ? (i - 1 + players.length) % players.length
+                : (i + 1) % players.length;
+              return { ...p, hand: hands[sourceIdx]! };
+            });
+            return {
+              handled: true,
+              state: ctx.checkRoundEnd({
+                ...baseState,
+                players: rotatedPlayers,
+                currentColor: card.color,
+              }, action.playerId),
+            };
+          }
+          return {
+            handled: true,
+            state: ctx.checkRoundEnd({
+              ...baseState,
+              currentColor: card.color,
+            }, action.playerId),
+          };
+        }
       }
 
       return {

--- a/packages/shared/src/rules/rules/misplay-penalty.ts
+++ b/packages/shared/src/rules/rules/misplay-penalty.ts
@@ -13,7 +13,9 @@ export const misplayPenalty: HouseRulePlugin = {
   preCheck: (state: GameState, action: GameAction, ctx: RuleContext): PreCheckResult => {
     if (action.type !== 'PLAY_CARD') return { handled: false };
     const currentPlayer = state.players[state.currentPlayerIndex];
-    if (state.phase !== 'playing' || currentPlayer?.id !== action.playerId) {
+    if (state.phase !== 'playing') return { handled: true, state };
+    if (currentPlayer?.id !== action.playerId) {
+      if (state.settings.houseRules.jumpIn) return { handled: false };
       return { handled: true, state };
     }
     const standardResult = ctx.applyAction(state, action);

--- a/packages/shared/src/rules/rules/stacking.ts
+++ b/packages/shared/src/rules/rules/stacking.ts
@@ -35,10 +35,12 @@ export const stacking: HouseRulePlugin = {
     }
 
     // Case (b): PLAY_CARD when drawStack === 0 — start new stack
+    // Skip wild_draw_four here so it goes through the normal choosing_color → challenging flow
     if (action.type === 'PLAY_CARD' && state.drawStack === 0 && state.phase === 'playing') {
       const player = state.players[state.currentPlayerIndex];
       if (player?.id !== action.playerId) return { handled: false };
       const card = player.hand.find(c => c.id === action.cardId);
+      if (card?.type === 'wild_draw_four') return { handled: false };
       const topCard = state.discardPile[state.discardPile.length - 1];
       if (
         card &&

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -5,4 +5,5 @@ export interface ChatMessage {
   text: string;
   timestamp: number;
   role?: string;
+  isSpectator?: boolean;
 }

--- a/packages/shared/src/types/socket-events.ts
+++ b/packages/shared/src/types/socket-events.ts
@@ -42,8 +42,9 @@ export interface ServerToClientEvents {
   'room:updated': (data: Record<string, unknown>) => void;
   'room:dissolved': (data?: { reason?: string }) => void;
   'room:rejoin_redirect': (data: { roomCode: string }) => void;
-  'room:spectator_joined': (data: { nickname: string }) => void;
-  'room:spectator_left': (data: { nickname: string }) => void;
+  'room:spectator_joined': (data: { nickname: string; spectators: string[] }) => void;
+  'room:spectator_left': (data: { nickname: string; spectators: string[] }) => void;
+  'room:spectator_list': (data: { spectators: string[] }) => void;
   'voice:presence': (presence: Record<string, unknown>) => void;
 }
 
@@ -74,4 +75,5 @@ export interface ClientToServerEvents {
   'voice:presence': (data: Record<string, unknown>, callback?: (res: SocketCallbackResult) => void) => void;
   'throw:item': (payload: { targetId: string; item: string }, callback?: (res: SocketCallbackResult) => void) => void;
   'player:toggle-autopilot': (callback?: (res: SocketCallbackResult & { autopilot?: boolean }) => void) => void;
+  'game:spectator_join': (callback?: (res: SocketCallbackResult) => void) => void;
 }

--- a/packages/shared/tests/autopilot-strategy.test.ts
+++ b/packages/shared/tests/autopilot-strategy.test.ts
@@ -121,9 +121,11 @@ describe('chooseAutopilotAction for seven swap', () => {
 });
 
 describe('chooseAutopilotAction with wild_draw_four and stacking', () => {
-  it('includes chosenColor when stacking is enabled so the stacking plugin accepts the card', () => {
+  it('includes chosenColor when stacking on existing drawStack', () => {
     const wd4 = makeCard('wild_draw_four', null, { id: 'wd4' });
     const state = makeState({
+      drawStack: 4,
+      discardPile: [makeCard('number', 'red', { value: 1, id: 'base' }), makeCard('wild_draw_four', null, { id: 'top_wd4' })],
       players: [
         { id: 'p1', name: 'Alice', hand: [wd4], score: 0, connected: true, autopilot: true, calledUno: false },
         { id: 'p2', name: 'Bob', hand: [makeCard('number', 'red', { value: 1, id: 'r1' })], score: 0, connected: true, autopilot: false, calledUno: false },
@@ -145,6 +147,30 @@ describe('chooseAutopilotAction with wild_draw_four and stacking', () => {
       cardId: 'wd4',
       chosenColor: expect.any(String),
     });
+  });
+
+  it('uses two-step flow for first +4 even when stacking is enabled', () => {
+    const wd4 = makeCard('wild_draw_four', null, { id: 'wd4' });
+    const state = makeState({
+      drawStack: 0,
+      players: [
+        { id: 'p1', name: 'Alice', hand: [wd4], score: 0, connected: true, autopilot: true, calledUno: false },
+        { id: 'p2', name: 'Bob', hand: [makeCard('number', 'red', { value: 1, id: 'r1' })], score: 0, connected: true, autopilot: false, calledUno: false },
+      ],
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        allowSpectators: true,
+        spectatorMode: 'hidden',
+        houseRules: { ...DEFAULT_HOUSE_RULES, stackDrawFour: true },
+      },
+    });
+
+    const actions = chooseAutopilotAction(state, 'p1');
+    expect(actions).toHaveLength(2);
+    expect(actions[0]).toMatchObject({ type: 'PLAY_CARD', playerId: 'p1', cardId: 'wd4' });
+    expect(actions[0]).not.toHaveProperty('chosenColor');
+    expect(actions[1]).toMatchObject({ type: 'CHOOSE_COLOR', playerId: 'p1' });
   });
 
   it('uses two-step PLAY_CARD + CHOOSE_COLOR when stacking is disabled', () => {

--- a/packages/shared/tests/house-rules-remaining.test.ts
+++ b/packages/shared/tests/house-rules-remaining.test.ts
@@ -214,7 +214,7 @@ describe('stackDrawTwo', () => {
 // ──────────────────────────────────────────────────────────────────────────────
 
 describe('stackDrawFour', () => {
-  it('starts a draw stack when the first +4 is played', () => {
+  it('first +4 goes through choosing_color phase (challenge flow)', () => {
     const wd4Play = makeCard('wild_draw_four', null, { id: 'wd4play' });
     const extra = makeCard('number', 'blue', { value: 1, id: 'extra' });
     const state = makeState({
@@ -235,17 +235,13 @@ describe('stackDrawFour', () => {
       type: 'PLAY_CARD',
       playerId: 'p1',
       cardId: 'wd4play',
-      chosenColor: 'blue',
     });
 
-    expect(next.drawStack).toBe(4);
-    expect(next.currentColor).toBe('blue');
-    expect(next.players[1]!.hand).toHaveLength(1);
-    expect(next.currentPlayerIndex).toBe(1);
-    expect(next.discardPile[next.discardPile.length - 1]).toMatchObject({
-      id: 'wd4play',
-      chosenColor: 'blue',
-    });
+    expect(next.phase).toBe('choosing_color');
+    expect(next.drawStack).toBe(0);
+    expect(next.pendingDrawPlayerId).toBe('p2');
+    expect(next.currentPlayerIndex).toBe(0);
+    expect(next.discardPile[next.discardPile.length - 1]!.id).toBe('wd4play');
   });
 
   it('+4 stacks on +4: drawStack increases by 4', () => {
@@ -348,9 +344,8 @@ describe('stackDrawFour', () => {
     expect(next).toStrictEqual(state);
   });
 
-  it('lets the third player draw 8 after two +4 cards are stacked', () => {
-    const firstWd4 = makeCard('wild_draw_four', null, { id: 'first_wd4' });
-    const secondWd4 = makeCard('wild_draw_four', null, { id: 'second_wd4' });
+  it('first +4 goes through challenge flow, accept applies penalty', () => {
+    const wd4Play = makeCard('wild_draw_four', null, { id: 'first_wd4' });
     const deck = Array.from({ length: 12 }, (_, i) => makeCard('number', 'blue', { value: i % 10, id: `wd4d${i}` }));
     const state = makeState({
       discardPile: [makeCard('number', 'red', { value: 1, id: 'base' })],
@@ -360,8 +355,8 @@ describe('stackDrawFour', () => {
       deckLeftInitialCount: deck.length,
       deckRightInitialCount: 0,
       players: [
-        { id: 'p1', name: 'Alice', hand: [firstWd4, makeCard('number', 'blue', { value: 1, id: 'p1c' })], score: 0, connected: true, calledUno: false },
-        { id: 'p2', name: 'Bob', hand: [secondWd4, makeCard('number', 'blue', { value: 2, id: 'p2c' })], score: 0, connected: true, calledUno: false },
+        { id: 'p1', name: 'Alice', hand: [wd4Play, makeCard('number', 'blue', { value: 1, id: 'p1c' })], score: 0, connected: true, calledUno: false },
+        { id: 'p2', name: 'Bob', hand: [makeCard('number', 'blue', { value: 2, id: 'p2c' })], score: 0, connected: true, calledUno: false },
         { id: 'p3', name: 'Carol', hand: [makeCard('number', 'green', { value: 3, id: 'p3c' })], score: 0, connected: true, calledUno: false },
       ],
       settings: {
@@ -371,42 +366,22 @@ describe('stackDrawFour', () => {
       },
     });
 
-    const afterFirstWd4 = applyActionWithHouseRules(state, {
-      type: 'PLAY_CARD',
-      playerId: 'p1',
-      cardId: 'first_wd4',
-      chosenColor: 'red',
+    const afterPlay = applyActionWithHouseRules(state, {
+      type: 'PLAY_CARD', playerId: 'p1', cardId: 'first_wd4',
     });
-    expect(afterFirstWd4.drawStack).toBe(4);
-    expect(afterFirstWd4.currentPlayerIndex).toBe(1);
+    expect(afterPlay.phase).toBe('choosing_color');
 
-    const afterSecondWd4 = applyActionWithHouseRules(afterFirstWd4, {
-      type: 'PLAY_CARD',
-      playerId: 'p2',
-      cardId: 'second_wd4',
-      chosenColor: 'red',
+    const afterColor = applyActionWithHouseRules(afterPlay, {
+      type: 'CHOOSE_COLOR', playerId: 'p1', color: 'red',
     });
-    expect(afterSecondWd4.drawStack).toBe(8);
-    expect(afterSecondWd4.currentPlayerIndex).toBe(2);
+    expect(afterColor.phase).toBe('challenging');
+    expect(afterColor.pendingDrawPlayerId).toBe('p2');
 
-    const next = applyActionWithHouseRules(afterSecondWd4, { type: 'DRAW_CARD', playerId: 'p3', side: 'left' as const });
-
-    expect(next).not.toBe(afterSecondWd4);
-    expect(next.pendingPenaltyDraws).toBe(7);
-    const paid = drawPendingPenalty(next);
-    expect(paid.players[2]!.hand.map(c => c.id)).toEqual([
-      'p3c',
-      'wd4d0',
-      'wd4d1',
-      'wd4d2',
-      'wd4d3',
-      'wd4d4',
-      'wd4d5',
-      'wd4d6',
-      'wd4d7',
-    ]);
-    expect(paid.drawStack).toBe(0);
-    expect(paid.currentPlayerIndex).toBe(0);
+    const afterAccept = applyActionWithHouseRules(afterColor, {
+      type: 'ACCEPT', playerId: 'p2',
+    });
+    expect(afterAccept.phase).toBe('playing');
+    expect(afterAccept.pendingPenaltyDraws).toBe(4);
   });
 });
 


### PR DESCRIPTION
## Summary

- **同牌抢出（jump-in）全面修复**：变色牌不再双重选色、功能牌（skip/reverse/draw_two/7/0）正确触发效果、罚摸期间禁止抢出
- **+4 质疑修复**：首张 +4 不再被 stacking 规则跳过质疑流程
- **村规交互修复**：misplayPenalty 不再阻断 jumpIn、preCheck 导致回合结束时补跑 postProcess（doubleScore/teamMode/elimination）、revengeMode + jumpIn 正确翻倍
- **Bot 思考时间**：AI 玩家 120 秒思考上限，不触发超时惩罚
- **观众席**：PlayerListPanel 显示观众列表，服务端同步观众 join/leave
- **弹幕聊天**：所有聊天消息以弹幕形式飘过牌桌区域，观众消息带「观众」标签
- **观众加入游戏**：回合结束时观众可点击加入，下轮自动发牌
- **游戏结束 UX**：非房主显示「等待房主再来一局」主按钮，返回大厅 5 秒冷却防误触
- **邀请链接**：复制时附带说明文本

## Test plan

- [ ] 同牌抢出：开启 jumpIn，验证 skip/reverse/draw_two/wild/wild_draw_four/7(七换手)/0(零轮转) 抢出效果正确
- [ ] +4 质疑：开启 stackDrawFour，出 +4 应进入质疑流程
- [ ] 罚摸期间抢出：+2 罚摸未完成时不应能抢出
- [ ] Bot 思考：AI 玩家不应在 30 秒超时，应有 120 秒
- [ ] 观众列表：观众加入/离开时右上角列表实时更新
- [ ] 弹幕：发送聊天消息后弹幕从右向左飘过牌桌
- [ ] 观众加入：回合结束时观众栏出现「加入游戏」按钮，点击后成为玩家
- [ ] 返回大厅：计分板出现后返回大厅按钮 5 秒后才可点击

🤖 Generated with [Claude Code](https://claude.com/claude-code)