### PR TITLE
feat: 反作弊 UI 及管理员作弊检测功能

### DIFF
--- a/packages/admin/src/pages/RoomsPage.tsx
+++ b/packages/admin/src/pages/RoomsPage.tsx
@@ -38,7 +38,9 @@ export default function RoomsPage() {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [dissolvingCode, setDissolvingCode] = useState<string | null>(null);
+  const [cheatingCode, setCheatingCode] = useState<string | null>(null);
   const [confirmCode, setConfirmCode] = useState<string | null>(null);
+  const [confirmCheatCode, setConfirmCheatCode] = useState<string | null>(null);
 
   const fetchRooms = useCallback(async () => {
     try {
@@ -66,6 +68,19 @@ export default function RoomsPage() {
       setError(err instanceof Error ? err.message : 'Failed to dissolve room');
     } finally {
       setDissolvingCode(null);
+    }
+  };
+
+  const handleCheat = async (code: string) => {
+    setConfirmCheatCode(null);
+    setCheatingCode(code);
+    try {
+      await apiFetch(`/admin/rooms/${code}/cheat`, { method: 'POST' });
+      await fetchRooms();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to trigger cheat');
+    } finally {
+      setCheatingCode(null);
     }
   };
 
@@ -116,7 +131,17 @@ export default function RoomsPage() {
                 <TableCell className="text-slate-400">
                   {new Date(room.createdAt).toLocaleString()}
                 </TableCell>
-                <TableCell>
+                <TableCell className="space-x-2">
+                  {room.status === 'playing' && (
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      onClick={() => setConfirmCheatCode(room.code)}
+                      disabled={cheatingCode === room.code}
+                    >
+                      {cheatingCode === room.code ? 'Sending...' : 'Cheat'}
+                    </Button>
+                  )}
                   <Button
                     variant="destructive"
                     size="sm"
@@ -156,6 +181,28 @@ export default function RoomsPage() {
               onClick={() => confirmCode && handleDissolve(confirmCode)}
             >
               Dissolve
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={confirmCheatCode !== null} onOpenChange={(open) => !open && setConfirmCheatCode(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Trigger Cheat Detection</DialogTitle>
+            <DialogDescription>
+              This will show a &quot;cheater detected&quot; screen to ALL players in room {confirmCheatCode} and dissolve the game. Are you sure?
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmCheatCode(null)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => confirmCheatCode && handleCheat(confirmCheatCode)}
+            >
+              Confirm Cheat
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/packages/client/src/features/game/components/AntiCheatToast.tsx
+++ b/packages/client/src/features/game/components/AntiCheatToast.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from 'react';
+
+type Phase = 'loading' | 'running' | 'done';
+
+export default function AntiCheatToast() {
+  const [phase, setPhase] = useState<Phase>('loading');
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    const steps = [
+      { delay: 0, value: 12 },
+      { delay: 300, value: 25 },
+      { delay: 800, value: 38 },
+      { delay: 1400, value: 41 },
+      { delay: 2200, value: 56 },
+      { delay: 2600, value: 64 },
+      { delay: 3400, value: 67 },
+      { delay: 4200, value: 83 },
+      { delay: 4600, value: 91 },
+      { delay: 5200, value: 100 },
+    ];
+    const timers = steps.map(({ delay, value }) =>
+      setTimeout(() => setProgress(value), delay),
+    );
+    const switchTimer = setTimeout(() => setPhase('running'), 5600);
+    const doneTimer = setTimeout(() => setPhase('done'), 9600);
+    return () => {
+      timers.forEach(clearTimeout);
+      clearTimeout(switchTimer);
+      clearTimeout(doneTimer);
+    };
+  }, []);
+
+  if (phase === 'done') return null;
+
+  return (
+    <div className={`ace-container ${phase === 'running' ? '' : ''}`}>
+      {phase === 'loading' && (
+        <div className="ace-loading">
+          <div className="ace-loading-shimmer" />
+          <div className="ace-header">
+            <div className="ace-logo-icon">U</div>
+            <div className="ace-header-text">
+              <span className="ace-title">UNO Anti-Cheat</span>
+              <span className="ace-subtitle">公平竞技守护系统</span>
+            </div>
+          </div>
+          <div className="ace-desc">正在加载反作弊模块…</div>
+          <div className="ace-progress">
+            <div className="ace-progress-bar" style={{ width: `${progress}%` }} />
+          </div>
+        </div>
+      )}
+      {phase === 'running' && (
+        <div className="ace-running">
+          <div className="ace-scan-line" />
+          <div className="ace-running-body">
+            <div className="ace-logo-icon">U</div>
+            <div className="ace-running-content">
+              <div className="ace-status-row">
+                <span className="ace-status-label">反作弊系统已加载</span>
+                <span className="ace-status-badge"><span className="ace-status-dot" />运行中</span>
+              </div>
+              <div className="ace-desc">请遵守游戏规则，享受公平对局</div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/client/src/features/game/components/CheatOverlay.tsx
+++ b/packages/client/src/features/game/components/CheatOverlay.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useRoomStore } from '@/shared/stores/room-store';
+import { useGameStore } from '../stores/game-store';
+import { leaveVoiceSession } from '@/shared/voice/voice-runtime';
+
+const SLICE_COUNT = 5;
+const DURATION = 500;
+const TICK = 35;
+const MAX_OFFSET = 80;
+
+export default function CheatOverlay() {
+  const navigate = useNavigate();
+  const clearRoom = useRoomStore((s) => s.clearRoom);
+  const clearGame = useGameStore((s) => s.clearGame);
+  const canvasRef = useRef<HTMLDivElement>(null);
+  const realRef = useRef<HTMLDivElement>(null);
+  const [showBtn, setShowBtn] = useState(false);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const real = realRef.current;
+    if (!canvas || !real) return;
+
+    const cuts = [0];
+    for (let i = 1; i < SLICE_COUNT; i++) {
+      cuts.push(Math.round((i / SLICE_COUNT) * 100 + (Math.random() * 8 - 4)));
+    }
+    cuts.push(100);
+
+    const slices: HTMLDivElement[] = [];
+    for (let i = 0; i < SLICE_COUNT; i++) {
+      const el = document.createElement('div');
+      el.className = 'cheat-gs';
+      el.innerHTML = real.innerHTML;
+      const tl = cuts[i]!;
+      const tr = cuts[i]! + Math.round(Math.random() * 6 - 3);
+      const br = cuts[i + 1]! + Math.round(Math.random() * 6 - 3);
+      const bl = cuts[i + 1]!;
+      el.style.clipPath = `polygon(0 ${tl}%, 100% ${tr}%, 100% ${br}%, 0 ${bl}%)`;
+      canvas.appendChild(el);
+      slices.push(el);
+    }
+
+    let elapsed = 0;
+    const interval = setInterval(() => {
+      elapsed += TICK;
+      const progress = elapsed / DURATION;
+      if (progress >= 1) {
+        clearInterval(interval);
+        canvas.style.visibility = 'hidden';
+        setShowBtn(true);
+        return;
+      }
+      const strength = Math.pow(1 - progress, 2.5);
+      for (const el of slices) {
+        const roll = Math.random();
+        let offset: number;
+        if (roll < 0.25) offset = 0;
+        else if (roll < 0.5) offset = (Math.random() - 0.5) * MAX_OFFSET * 0.3 * strength;
+        else offset = (Math.random() - 0.5) * MAX_OFFSET * 2 * strength;
+        el.style.transform = `translateX(${Math.round(offset)}px)`;
+      }
+    }, TICK);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  const handleContinue = () => {
+    clearRoom();
+    clearGame();
+    leaveVoiceSession();
+    navigate('/lobby');
+  };
+
+  return (
+    <div className="cheat-overlay">
+      <div className="cheat-real" ref={realRef}>
+        <div className="cheat-title" data-text="检测到作弊者">检测到作弊者</div>
+        <div className="cheat-subtitle">比赛终止</div>
+        <div className="cheat-desc">作弊者已受到惩罚，游戏取消，所有玩家的输赢均不计入。</div>
+        <div className="cheat-divider" />
+        {showBtn && (
+          <button className="cheat-btn cheat-btn-visible" onClick={handleContinue}>继 续</button>
+        )}
+      </div>
+      <div className="cheat-glitch-canvas" ref={canvasRef} />
+      <div className="cheat-flash" />
+    </div>
+  );
+}

--- a/packages/client/src/features/game/pages/GamePage.tsx
+++ b/packages/client/src/features/game/pages/GamePage.tsx
@@ -28,6 +28,8 @@ import MobileFAB from '../components/MobileFAB';
 import InfoDrawer from '../components/InfoDrawer';
 import PlayerListPanel from '../components/PlayerListPanel';
 import DanmakuLayer from '../components/DanmakuLayer';
+import AntiCheatToast from '../components/AntiCheatToast';
+import CheatOverlay from '../components/CheatOverlay';
 import { useSpectatorStore } from '../stores/spectator-store';
 import GameStartRulesModal from '../components/GameStartRulesModal';
 
@@ -41,6 +43,7 @@ export default function GamePage() {
   const clearGame = useGameStore((s) => s.clearGame);
   const clearRoom = useRoomStore((s) => s.clearRoom);
   const clearSpectators = useSpectatorStore((s) => s.clearSpectators);
+  const cheatDetected = useGameStore((s) => s.cheatDetected);
 
   const isMyTurn = useIsMyTurn();
   const playableIds = usePlayableCardIds();
@@ -51,6 +54,8 @@ export default function GamePage() {
   useGameLogTracker();
   const [showStartRules, setShowStartRules] = useState(false);
   const shownStartRulesRef = useRef<string | null>(null);
+  const [antiCheatKey, setAntiCheatKey] = useState<string | null>(null);
+  const shownAntiCheatRef = useRef<string | null>(null);
 
   useEffect(() => {
     refreshVoicePresence();
@@ -66,6 +71,15 @@ export default function GamePage() {
     openInfoDrawer('rules');
     setShowStartRules(true);
   }, [roomCode, settings, roundNumber, phase, openInfoDrawer]);
+
+  useEffect(() => {
+    if (!roomCode || roundNumber !== 1) return;
+    if (phase !== 'playing' && phase !== 'challenging' && phase !== 'choosing_color' && phase !== 'choosing_swap_target') return;
+    const key = `${roomCode}:ac`;
+    if (shownAntiCheatRef.current === key) return;
+    shownAntiCheatRef.current = key;
+    setAntiCheatKey(key);
+  }, [roomCode, roundNumber, phase]);
 
   const {
     playCard,
@@ -223,11 +237,13 @@ export default function GamePage() {
         onClose={() => setShowStartRules(false)}
       />
       <GameEffects />
+      {antiCheatKey && <AntiCheatToast key={antiCheatKey} />}
       {(phase === 'round_end' || phase === 'game_over') && <Confetti />}
       {needsColorPick && <ColorPicker onPick={chooseColor} />}
       {showScoreBoard && (
         <ScoreBoard onPlayAgain={playAgain} onRematch={rematch} onBackToLobby={backToLobby} onKickPlayer={kickPlayer} />
       )}
+      {cheatDetected && <CheatOverlay />}
     </div>
   );
 }

--- a/packages/client/src/features/game/stores/game-store.ts
+++ b/packages/client/src/features/game/stores/game-store.ts
@@ -34,6 +34,8 @@ interface GameState {
   isSpectator: boolean;
   deckHash: string | null;
   nextRoundVote: NextRoundVoteState | null;
+  cheatDetected: boolean;
+  setCheatDetected: (value: boolean) => void;
   setSpectator: (value: boolean) => void;
   infoDrawerOpen: boolean;
   infoDrawerTab: InfoDrawerTab;
@@ -70,6 +72,8 @@ export const useGameStore = create<GameState>((set) => ({
   isSpectator: false,
   deckHash: null,
   nextRoundVote: null,
+  cheatDetected: false,
+  setCheatDetected: (value) => set({ cheatDetected: value }),
   setSpectator: (value) => set({ isSpectator: value }),
   infoDrawerOpen: false,
   infoDrawerTab: 'rules' as InfoDrawerTab,

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -365,3 +365,324 @@
 .danmaku-item {
   animation: danmaku-scroll 8s linear forwards;
 }
+
+/* ---- Anti-Cheat Toast ---- */
+.ace-container {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  width: 300px;
+  z-index: 9999;
+  animation: ace-slide-in 0.5s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+@keyframes ace-slide-in {
+  from { transform: translateY(30px) translateX(20px); opacity: 0; }
+  to { transform: translateY(0) translateX(0); opacity: 1; }
+}
+
+.ace-loading {
+  background: linear-gradient(135deg, #ef4444 0%, #dc2626 50%, #b91c1c 100%);
+  border-radius: 8px;
+  padding: 14px 16px;
+  color: #fff;
+  position: relative;
+  overflow: hidden;
+  box-shadow: 0 4px 24px rgba(239, 68, 68, 0.3);
+}
+.ace-loading-shimmer {
+  position: absolute;
+  inset: -50%;
+  width: 200%;
+  height: 200%;
+  background: linear-gradient(45deg, transparent 30%, rgba(255,255,255,0.1) 50%, transparent 70%);
+  animation: ace-shimmer 2s ease-in-out infinite;
+}
+@keyframes ace-shimmer {
+  0% { transform: translateX(-100%); }
+  100% { transform: translateX(100%); }
+}
+
+.ace-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 8px;
+  position: relative;
+  z-index: 1;
+}
+.ace-logo-icon {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  font-weight: 900;
+  color: #fff;
+  background: rgba(255,255,255,0.2);
+  backdrop-filter: blur(4px);
+  flex-shrink: 0;
+}
+.ace-header-text {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.ace-title {
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+}
+.ace-subtitle {
+  font-size: 10.5px;
+  opacity: 0.75;
+}
+.ace-desc {
+  font-size: 11px;
+  opacity: 0.8;
+  position: relative;
+  z-index: 1;
+  line-height: 1.5;
+}
+
+.ace-progress {
+  height: 2px;
+  background: rgba(255,255,255,0.2);
+  border-radius: 1px;
+  margin-top: 10px;
+  overflow: hidden;
+  position: relative;
+  z-index: 1;
+}
+.ace-progress-bar {
+  height: 100%;
+  border-radius: 1px;
+  background: linear-gradient(90deg, #fbbf24, #fff);
+  transition: width 0.4s ease-out;
+}
+
+.ace-running {
+  background: linear-gradient(135deg, #18181b 0%, #1f1f26 100%);
+  border: 1px solid rgba(239, 68, 68, 0.2);
+  border-radius: 8px;
+  padding: 14px 16px;
+  color: #fff;
+  position: relative;
+  overflow: hidden;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+  animation: ace-slide-in 0.4s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+.ace-running .ace-logo-icon {
+  background: rgba(239, 68, 68, 0.15);
+  color: #ef4444;
+  border: 1px solid rgba(239, 68, 68, 0.3);
+}
+.ace-running .ace-desc {
+  color: rgba(255,255,255,0.4);
+  font-size: 10.5px;
+  margin-top: 4px;
+}
+
+.ace-scan-line {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(239, 68, 68, 0.35), transparent);
+  animation: ace-scan 3s ease-in-out infinite;
+}
+@keyframes ace-scan {
+  0% { top: 0; opacity: 0; }
+  10% { opacity: 1; }
+  90% { opacity: 1; }
+  100% { top: 100%; opacity: 0; }
+}
+
+.ace-running-body {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  position: relative;
+  z-index: 1;
+}
+.ace-running-content {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.ace-status-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.ace-status-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: #f0f0f0;
+}
+.ace-status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  color: #4ade80;
+  background: rgba(74, 222, 128, 0.1);
+  border: 1px solid rgba(74, 222, 128, 0.2);
+  border-radius: 10px;
+  padding: 1px 8px;
+}
+.ace-status-dot {
+  width: 5px;
+  height: 5px;
+  background: #4ade80;
+  border-radius: 50%;
+  animation: ace-pulse 1.5s ease-in-out infinite;
+}
+@keyframes ace-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.4; transform: scale(0.7); }
+}
+
+/* ---- Cheat Overlay ---- */
+.cheat-overlay {
+  position: fixed;
+  inset: 0;
+  background: #c0392b;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 99999;
+  animation: cheat-bg-flicker 0.35s steps(1) forwards;
+}
+@keyframes cheat-bg-flicker {
+  0%{opacity:0}14%{opacity:1}22%{opacity:0}36%{opacity:1}44%{opacity:0}52%{opacity:1}100%{opacity:1}
+}
+.cheat-overlay::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(ellipse at center, transparent 40%, rgba(0,0,0,0.3) 100%);
+  pointer-events: none;
+  z-index: 3;
+}
+.cheat-overlay::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(0deg, transparent, transparent 2px, rgba(0,0,0,0.03) 2px, rgba(0,0,0,0.03) 4px);
+  pointer-events: none;
+  z-index: 3;
+}
+.cheat-real {
+  position: relative;
+  z-index: 2;
+  text-align: center;
+  color: #fff;
+  padding: 0 32px;
+  max-width: 680px;
+}
+.cheat-glitch-canvas {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 4;
+  pointer-events: none;
+}
+.cheat-gs {
+  position: absolute;
+  text-align: center;
+  color: #fff;
+  padding: 0 32px;
+  max-width: 680px;
+  width: 100%;
+  will-change: transform, clip-path;
+}
+.cheat-title {
+  font-size: clamp(48px, 9vw, 72px);
+  font-weight: 900;
+  letter-spacing: 8px;
+  line-height: 1.15;
+  text-shadow: 0 6px 24px rgba(0,0,0,0.35);
+  position: relative;
+  animation: cheat-rgb-settle 0.5s ease-out 0.1s both;
+}
+.cheat-real .cheat-title::before,
+.cheat-real .cheat-title::after {
+  content: attr(data-text);
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+.cheat-real .cheat-title::before {
+  color: #0ff;
+  mix-blend-mode: screen;
+  animation: cheat-rgb-c 0.5s steps(1) 0.1s both;
+}
+.cheat-real .cheat-title::after {
+  color: #f0f;
+  mix-blend-mode: screen;
+  animation: cheat-rgb-m 0.5s steps(1) 0.1s both;
+}
+@keyframes cheat-rgb-c{0%{transform:translateX(-8px);opacity:.85}20%{transform:translateX(5px);opacity:.6}45%{transform:translateX(-3px);opacity:.35}70%{transform:translateX(1px);opacity:.12}100%{transform:translateX(0);opacity:0}}
+@keyframes cheat-rgb-m{0%{transform:translateX(8px);opacity:.85}20%{transform:translateX(-5px);opacity:.6}45%{transform:translateX(3px);opacity:.35}70%{transform:translateX(-1px);opacity:.12}100%{transform:translateX(0);opacity:0}}
+@keyframes cheat-rgb-settle{0%{text-shadow:-5px 0 #0ff,5px 0 #f0f,0 6px 24px rgba(0,0,0,.35)}35%{text-shadow:2px 0 #0ff,-2px 0 #f0f,0 6px 24px rgba(0,0,0,.35)}70%{text-shadow:-1px 0 #0ff,1px 0 #f0f,0 6px 24px rgba(0,0,0,.35)}100%{text-shadow:0 0 transparent,0 0 transparent,0 6px 24px rgba(0,0,0,.35)}}
+.cheat-subtitle {
+  font-size: clamp(18px, 3vw, 24px);
+  font-weight: 700;
+  margin-top: 28px;
+  color: rgba(255,255,255,0.9);
+  letter-spacing: 6px;
+}
+.cheat-desc {
+  font-size: 15px;
+  color: rgba(255,255,255,0.6);
+  margin-top: 16px;
+  line-height: 1.8;
+  letter-spacing: 1px;
+}
+.cheat-divider {
+  width: 0;
+  height: 1px;
+  background: rgba(255,255,255,0.2);
+  margin: 36px auto 0;
+  animation: cheat-divider-in 0.6s ease-out 0.55s forwards;
+}
+@keyframes cheat-divider-in { to { width: min(70vw, 560px); } }
+.cheat-btn {
+  margin-top: 52px;
+  padding: 16px 72px;
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: 4px;
+  color: #fff;
+  background: rgba(255,255,255,0.1);
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: 2px;
+  cursor: pointer;
+  transition: all 0.25s ease;
+  backdrop-filter: blur(4px);
+  opacity: 0;
+  transform: translateY(8px);
+}
+.cheat-btn-visible {
+  animation: cheat-btn-in 0.4s cubic-bezier(0.16,1,0.3,1) forwards;
+}
+@keyframes cheat-btn-in { to { opacity: 1; transform: translateY(0); } }
+.cheat-btn:hover {
+  background: rgba(255,255,255,0.18);
+  border-color: rgba(255,255,255,0.4);
+  letter-spacing: 6px;
+  transform: translateY(-1px);
+}
+.cheat-flash {
+  position: fixed;
+  inset: 0;
+  z-index: 100000;
+  pointer-events: none;
+  animation: cheat-flash 0.25s steps(1) forwards;
+}
+@keyframes cheat-flash{0%{background:#fff;opacity:1}12%{opacity:0}20%{background:#f0f;opacity:.4}28%{opacity:0}36%{background:#0ff;opacity:.3}44%{background:#fff;opacity:.7}52%{background:#f0f;opacity:.2}60%{opacity:0}100%{background:transparent;opacity:0}}

--- a/packages/client/src/shared/socket.ts
+++ b/packages/client/src/shared/socket.ts
@@ -152,7 +152,12 @@ export function getSocket(): TypedSocket {
       }
     });
 
+    socket.on('game:cheat_detected', () => {
+      useGameStore.getState().setCheatDetected(true);
+    });
+
     socket.on('room:dissolved', (data) => {
+      if (useGameStore.getState().cheatDetected) return;
       useRoomStore.getState().clearRoom();
       useGameStore.getState().clearGame();
       leaveVoiceSession();

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -5,8 +5,10 @@ import type { Config } from './config';
 import { loadPlugins } from './plugin-loader';
 import { getDb } from './db/database';
 import { setupSocketHandlers } from './ws/socket-handler';
+import { dissolveRoom } from './ws/room-lifecycle';
 import { createKvStore } from './kv/index';
 import type { PluginContext } from './plugin-context';
+import { adminOnly } from './plugins/core/admin/middleware';
 
 export async function createApp(config: Config) {
   const fastify = Fastify({ logger: true });
@@ -29,6 +31,19 @@ export async function createApp(config: Config) {
   await loadPlugins(fastify, ctx);
 
   const wsContext = setupSocketHandlers(io, kv, config.jwtSecret, config.roomIdleTimeoutMs);
+  const { sessions, turnTimer, persister } = wsContext;
+
+  fastify.post<{ Params: { code: string } }>(
+    '/admin/rooms/:code/cheat',
+    { preHandler: adminOnly(config.jwtSecret) },
+    async (request, reply) => {
+      const { code } = request.params;
+      io.to(code).emit('game:cheat_detected');
+      await new Promise((r) => setTimeout(r, 1500));
+      await dissolveRoom(io, kv, code, sessions, turnTimer, persister, 'host_closed', getDb());
+      return { success: true };
+    },
+  );
 
   return { fastify, io, kv, ...wsContext };
 }

--- a/packages/server/src/ws/socket-handler.ts
+++ b/packages/server/src/ws/socket-handler.ts
@@ -327,5 +327,5 @@ export function setupSocketHandlers(io: SocketIOServer, redis: KvStore, jwtSecre
 
   setupSpectateHandlers(io, redis, sessions);
 
-  return { roomManager, turnTimer, sessions };
+  return { roomManager, turnTimer, sessions, persister };
 }

--- a/packages/shared/src/types/socket-events.ts
+++ b/packages/shared/src/types/socket-events.ts
@@ -45,6 +45,7 @@ export interface ServerToClientEvents {
   'room:spectator_joined': (data: { nickname: string; spectators: string[] }) => void;
   'room:spectator_left': (data: { nickname: string; spectators: string[] }) => void;
   'room:spectator_list': (data: { spectators: string[] }) => void;
+  'game:cheat_detected': () => void;
   'voice:presence': (presence: Record<string, unknown>) => void;
 }
 


### PR DESCRIPTION
## Summary

- 游戏开始时右下角弹出 ACE 风格反作弊加载提示（顿挫进度条 → 运行中状态 → 自动消失）
- 管理员后台房间列表新增 Cheat 按钮（仅 playing 状态房间可用）
- 点击后所有玩家全屏显示「检测到作弊者 · 比赛终止」页面
- glitch 切片 + RGB 偏色 + 分隔线展开 + 按钮延迟弹出
- 点击「继续」返回大厅，room:dissolved 事件在作弊状态下被跳过

## Test plan

- [ ] 进入游戏第 1 轮，右下角应弹出反作弊加载提示，约 10 秒后消失
- [ ] 管理后台房间列表，playing 状态房间显示 Cheat 按钮
- [ ] 点击 Cheat 并确认后，所有玩家看到全屏红色作弊检测页
- [ ] glitch 动画播放后「继续」按钮弹出
- [ ] 点击「继续」正确返回大厅

🤖 Generated with [Claude Code](https://claude.com/claude-code)