### PR TITLE
chore: 开启生产构建 source map，修复 cheat 路由前缀

### DIFF
--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -4,6 +4,9 @@ import tailwindcss from '@tailwindcss/vite';
 import path from 'path';
 
 export default defineConfig({
+  build: {
+    sourcemap: true,
+  },
   plugins: [react(), tailwindcss()],
   define: {
     'import.meta.env.BUILD_VERSION': JSON.stringify(process.env.npm_package_version ?? '0.0.1'),

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -34,7 +34,7 @@ export async function createApp(config: Config) {
   const { sessions, turnTimer, persister } = wsContext;
 
   fastify.post<{ Params: { code: string } }>(
-    '/admin/rooms/:code/cheat',
+    '/api/admin/rooms/:code/cheat',
     { preHandler: adminOnly(config.jwtSecret) },
     async (request, reply) => {
       const { code } = request.params;


### PR DESCRIPTION
## Summary
- **client**: `build.sourcemap = true`，生产构建生成 `.map` 文件，浏览器 DevTools 可直接显示源码级报错堆栈
- **server**: cheat 检测路由从 `/admin/rooms/:code/cheat` 改为 `/api/admin/rooms/:code/cheat`，与其他 API 路由前缀一致

## Test plan
- [ ] `pnpm --filter client build` 后确认 `dist/assets/` 下有 `.js.map` 文件
- [ ] 浏览器打开生产构建页面，DevTools 报错堆栈显示原始文件名和行号
- [ ] 管理后台 cheat 检测功能正常调用 `/api/admin/rooms/:code/cheat`

🤖 Generated with [Claude Code](https://claude.com/claude-code)