### PR TITLE
fix: clearGame 时重置 cheatDetected 状态

### DIFF
--- a/packages/client/src/features/game/stores/game-store.ts
+++ b/packages/client/src/features/game/stores/game-store.ts
@@ -144,6 +144,7 @@ export const useGameStore = create<GameState>((set) => ({
       isSpectator: false,
       deckHash: null,
       nextRoundVote: null,
+      cheatDetected: false,
       infoDrawerOpen: false,
       infoDrawerTab: 'rules' as InfoDrawerTab,
     }),


### PR DESCRIPTION
## Summary
- `clearGame()` 遗漏了 `cheatDetected: false`，导致作弊弹窗在房间解散后状态残留，重开游戏立即弹出

## Test plan
- [ ] 触发作弊检测 → 弹窗显示 → 房间解散 → 重新开一局 → 不再弹出作弊弹窗

🤖 Generated with [Claude Code](https://claude.com/claude-code)