### PR TITLE
fix: 观众离开时 spectators 列表变为 undefined 导致崩溃

### DIFF
--- a/packages/client/src/features/game/hooks/useGameSocket.ts
+++ b/packages/client/src/features/game/hooks/useGameSocket.ts
@@ -44,9 +44,12 @@ export function useGameSocket(roomCode: string | undefined) {
     socket.on('chat:message', addChatMessage);
     socket.on('chat:cleared', clearChatMessages);
 
-    const onSpectatorList = (data: { spectators: string[] }) => setSpectators(data.spectators);
-    const onSpectatorJoined = (data: { spectators: string[] }) => setSpectators(data.spectators);
-    const onSpectatorLeft = (data: { spectators: string[] }) => setSpectators(data.spectators);
+    const onSpectatorList = (data: { spectators?: string[] }) => { if (data.spectators) setSpectators(data.spectators); };
+    const onSpectatorJoined = (data: { spectators?: string[] }) => { if (data.spectators) setSpectators(data.spectators); };
+    const onSpectatorLeft = (data: { spectators?: string[]; nickname?: string }) => {
+      if (data.spectators) setSpectators(data.spectators);
+      else if (data.nickname) useSpectatorStore.getState().removeSpectator(data.nickname);
+    };
     socket.on('room:spectator_list', onSpectatorList);
     socket.on('room:spectator_joined', onSpectatorJoined);
     socket.on('room:spectator_left', onSpectatorLeft);


### PR DESCRIPTION
## Summary
- `room:spectator_left` 在 `room-events.ts` 的 `room:leave` 中只发送了 `{ nickname }` 没有 `spectators` 数组
- 客户端 `setSpectators(data.spectators)` 收到 `undefined` 后污染 store
- `PlayerListPanel.tsx:77` 的 `spectators.length` 崩溃

## Fix
- 客户端对 `spectators` 字段做防御：有则全量替换，无则按 `nickname` 单条 `removeSpectator`

## Test plan
- [ ] 观众加入观战 → 观众列表正常显示
- [ ] 观众离开 → 不崩溃，观众列表正确更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)