### PR TITLE
feat: 语音频道加入/离开提示音

### DIFF
--- a/packages/client/src/shared/socket.ts
+++ b/packages/client/src/shared/socket.ts
@@ -34,7 +34,21 @@ export function getSocket(): TypedSocket {
     });
 
     socket.on('voice:presence', (presence) => {
-      useGatewayStore.getState().setPlayerVoicePresence((presence ?? {}) as Record<string, PlayerVoicePresence>);
+      const newPresence = (presence ?? {}) as Record<string, PlayerVoicePresence>;
+      const oldPresence = useGatewayStore.getState().playerVoicePresence;
+      useGatewayStore.getState().setPlayerVoicePresence(newPresence);
+
+      const selfId = useGameStore.getState().viewerId;
+      for (const [uid, p] of Object.entries(newPresence)) {
+        if (uid === selfId) continue;
+        const wasInVoice = oldPresence[uid]?.inVoice;
+        if (p.inVoice && !wasInVoice) playSound('voice_join');
+        else if (!p.inVoice && wasInVoice) playSound('voice_leave');
+      }
+      for (const [uid, p] of Object.entries(oldPresence)) {
+        if (uid === selfId) continue;
+        if (p.inVoice && !newPresence[uid]) playSound('voice_leave');
+      }
     });
 
     const handleGameView = (view: PlayerView) => {

--- a/packages/client/src/shared/sound/sound-manager.ts
+++ b/packages/client/src/shared/sound/sound-manager.ts
@@ -16,6 +16,8 @@ type SoundName =
   | 'lose'
   | 'player_join'
   | 'player_leave'
+  | 'voice_join'
+  | 'voice_leave'
   | 'your_turn'
   | 'error'
   | 'click'
@@ -41,6 +43,8 @@ const FREQUENCIES: Record<SoundName, { freq: number; duration: number; type: Osc
   lose:         { freq: 250, duration: 0.4, type: 'triangle' },
   player_join:  { freq: 700, duration: 0.1, type: 'sine' },
   player_leave: { freq: 350, duration: 0.15, type: 'sine' },
+  voice_join:   { freq: 660, duration: 0.12, type: 'sine' },
+  voice_leave:  { freq: 440, duration: 0.15, type: 'sine' },
   your_turn:    { freq: 880, duration: 0.15, type: 'sine' },
   error:        { freq: 200, duration: 0.2, type: 'square' },
   click:        { freq: 1100, duration: 0.04, type: 'sine' },
@@ -92,6 +96,10 @@ export function playSound(name: SoundName): void {
     osc.frequency.linearRampToValueAtTime(1200, ctx.currentTime + config.duration);
   } else if (name === 'danger') {
     osc.frequency.linearRampToValueAtTime(180, ctx.currentTime + config.duration);
+  } else if (name === 'voice_join') {
+    osc.frequency.linearRampToValueAtTime(880, ctx.currentTime + config.duration);
+  } else if (name === 'voice_leave') {
+    osc.frequency.linearRampToValueAtTime(330, ctx.currentTime + config.duration);
   }
 
   gain.gain.setValueAtTime(soundVolume * 0.3, ctx.currentTime);


### PR DESCRIPTION
## Summary
- 新增 `voice_join`（660→880Hz 上扬）和 `voice_leave`（440→330Hz 下沉）两个提示音
- 在 `voice:presence` 事件中对比新旧状态，检测其他玩家的语音加入/离开
- 不会对自己的操作播放提示音

## Test plan
- [ ] 玩家 A 在房间内，玩家 B 加入语音 → A 听到上扬提示音
- [ ] 玩家 B 离开语音 → A 听到下沉提示音
- [ ] 自己加入/离开语音 → 不会给自己播放提示音

🤖 Generated with [Claude Code](https://claude.com/claude-code)