### PR TITLE
feat: 选色光波、TopBar 牌面状态、+4 叠加修复、语音状态显示

### DIFF
--- a/packages/client/src/features/game/components/ColorWave.tsx
+++ b/packages/client/src/features/game/components/ColorWave.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useRef, useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { useGameStore } from '../stores/game-store';
+import type { Color } from '@uno-online/shared';
+
+const COLOR_MAP: Record<Color, string> = {
+  red: '#ff3366',
+  blue: '#4488ff',
+  green: '#33cc66',
+  yellow: '#fbbf24',
+};
+
+interface WaveState {
+  id: number;
+  color: string;
+}
+
+let waveId = 0;
+
+export default function ColorWave() {
+  const currentColor = useGameStore((s) => s.currentColor);
+  const phase = useGameStore((s) => s.phase);
+  const lastAction = useGameStore((s) => s.lastAction);
+  const [wave, setWave] = useState<WaveState | null>(null);
+  const prevColorRef = useRef<Color | null>(null);
+
+  useEffect(() => {
+    if (!currentColor || !lastAction) return;
+    if (lastAction.type !== 'CHOOSE_COLOR' && lastAction.type !== 'PLAY_CARD') return;
+    if (phase === 'round_end' || phase === 'game_over') return;
+
+    const prevColor = prevColorRef.current;
+    prevColorRef.current = currentColor;
+    if (prevColor === currentColor) return;
+
+    const hex = COLOR_MAP[currentColor];
+    if (!hex) return;
+
+    const id = ++waveId;
+    setWave({ id, color: hex });
+    const timer = setTimeout(() => setWave(null), 1200);
+    return () => clearTimeout(timer);
+  }, [currentColor, lastAction, phase]);
+
+  return (
+    <AnimatePresence>
+      {wave && (
+        <motion.div
+          key={wave.id}
+          className="fixed inset-0 pointer-events-none z-effects"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.15 }}
+        >
+          <motion.div
+            className="absolute rounded-full"
+            style={{
+              left: '50%',
+              top: '50%',
+              width: 40,
+              height: 40,
+              marginLeft: -20,
+              marginTop: -20,
+              background: `radial-gradient(circle, ${wave.color}44 0%, ${wave.color}00 70%)`,
+              boxShadow: `0 0 60px 20px ${wave.color}55`,
+            }}
+            initial={{ scale: 0, opacity: 0.9 }}
+            animate={{ scale: 60, opacity: 0 }}
+            transition={{ duration: 1, ease: 'easeOut' }}
+          />
+          <motion.div
+            className="absolute rounded-full"
+            style={{
+              left: '50%',
+              top: '50%',
+              width: 8,
+              height: 8,
+              marginLeft: -4,
+              marginTop: -4,
+              border: `2px solid ${wave.color}`,
+            }}
+            initial={{ scale: 0, opacity: 1 }}
+            animate={{ scale: 200, opacity: 0 }}
+            transition={{ duration: 1.1, ease: 'easeOut' }}
+          />
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/packages/client/src/features/game/components/GameTable.tsx
+++ b/packages/client/src/features/game/components/GameTable.tsx
@@ -53,6 +53,7 @@ export default function GameTable({ onDraw }: GameTableProps) {
   // Mumble speaking state
   const mumbleUsersById = useGatewayStore((s) => s.usersById);
   const mumbleSpeakingByUserId = useGatewayStore((s) => s.speakingByUserId);
+  const voicePresence = useGatewayStore((s) => s.playerVoicePresence);
   const mumbleSpeakingNames = useMemo(() => {
     const names = new Set<string>();
     for (const [uid, speaking] of Object.entries(mumbleSpeakingByUserId)) {
@@ -341,6 +342,7 @@ export default function GameTable({ onDraw }: GameTableProps) {
             isHost={player.id === ownerId}
             isSkipped={player.id === skippedPlayerId}
             isSpeaking={mumbleSpeakingNames.has(player.name)}
+            voiceState={voicePresence[player.id]}
             position={pos}
             turnEndTime={isActive ? turnEndTime : null}
             turnTimeLimit={settings ? (settings.houseRules?.fastMode ? Math.floor(settings.turnTimeLimit / 2) : settings.turnTimeLimit) : undefined}

--- a/packages/client/src/features/game/components/PlayerNode.tsx
+++ b/packages/client/src/features/game/components/PlayerNode.tsx
@@ -1,7 +1,8 @@
 import { memo, useState, useRef, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Bot, Trophy } from 'lucide-react';
+import { Bot, Trophy, Mic, MicOff } from 'lucide-react';
 import type { Card as CardType } from '@uno-online/shared';
+import type { PlayerVoicePresence } from '@/shared/voice/gateway-store';
 import Card from './Card';
 import CardBack from './CardBack';
 import CountdownRing from './CountdownRing';
@@ -23,6 +24,7 @@ interface PlayerNodeProps {
   isHost: boolean;
   isSkipped: boolean;
   isSpeaking?: boolean;
+  voiceState?: PlayerVoicePresence;
   position: { x: number; y: number };
   turnEndTime?: number | null;
   turnTimeLimit?: number;
@@ -42,6 +44,7 @@ function PlayerNode({
   isHost,
   isSkipped,
   isSpeaking = false,
+  voiceState,
   position,
   turnEndTime,
   turnTimeLimit,
@@ -218,6 +221,20 @@ function PlayerNode({
           )}
         </AnimatePresence>
 
+        {/* Voice indicator */}
+        {voiceState?.inVoice && (
+          <div
+            className={cn(
+              'absolute -bottom-0.5 -left-0.5 w-4.5 h-4.5 rounded-full flex items-center justify-center border-2 border-background',
+              isSpeaking ? 'bg-green-500' : voiceState.micEnabled ? 'bg-slate-600' : 'bg-red-500/80',
+            )}
+          >
+            {voiceState.micEnabled
+              ? <Mic size={10} className="text-white" />
+              : <MicOff size={10} className="text-white" />}
+          </div>
+        )}
+
         {/* Autopilot / Disconnected indicator */}
         {player.autopilot ? (
           <div className="absolute -top-1 -right-1 w-5 h-5 rounded-full bg-primary flex items-center justify-center border-2 border-background">
@@ -337,6 +354,8 @@ export default memo(PlayerNode, (prev, next) => {
     prev.isHost === next.isHost &&
     prev.isSkipped === next.isSkipped &&
     prev.isSpeaking === next.isSpeaking &&
+    prev.voiceState?.inVoice === next.voiceState?.inVoice &&
+    prev.voiceState?.micEnabled === next.voiceState?.micEnabled &&
     prev.position.x === next.position.x &&
     prev.position.y === next.position.y &&
     prev.turnEndTime === next.turnEndTime &&

--- a/packages/client/src/features/game/components/TopBar.tsx
+++ b/packages/client/src/features/game/components/TopBar.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Eye, Volume2, VolumeX, Spade, DoorOpen, Bot, HelpCircle } from 'lucide-react';
+import type { Card, Color } from '@uno-online/shared';
 import TurnTimer from './TurnTimer';
 import { useSettingsStore } from '@/shared/stores/settings-store';
 import { useRoomStore } from '@/shared/stores/room-store';
@@ -10,6 +11,76 @@ import { cn } from '@/shared/lib/utils';
 import { BUILD_VERSION } from '@/shared/build-info';
 
 const AUTOPILOT_COOLDOWN_MS = 3000;
+
+const COLOR_HEX: Record<Color, string> = {
+  red: 'var(--color-uno-red)',
+  blue: 'var(--color-uno-blue)',
+  green: 'var(--color-uno-green)',
+  yellow: 'var(--color-uno-yellow)',
+};
+
+const COLOR_LABEL: Record<Color, string> = {
+  red: '红', blue: '蓝', green: '绿', yellow: '黄',
+};
+
+function getCardLabel(card: Card): string {
+  switch (card.type) {
+    case 'number': return `${card.value}`;
+    case 'skip': return '禁';
+    case 'reverse': return '转';
+    case 'draw_two': return '+2';
+    case 'wild': return '变色';
+    case 'wild_draw_four': return '+4';
+  }
+}
+
+function GameStatus() {
+  const topCard = useGameStore((s) => s.discardPile?.[s.discardPile.length - 1]);
+  const currentColor = useGameStore((s) => s.currentColor);
+  const drawStack = useGameStore((s) => s.drawStack);
+  const phase = useGameStore((s) => s.phase);
+
+  if (!topCard || !currentColor || phase === 'round_end' || phase === 'game_over') return null;
+
+  const hex = COLOR_HEX[currentColor];
+
+  return (
+    <div className="hidden sm:flex items-center gap-2 text-xs">
+      <div
+        className="flex items-center gap-1.5 rounded-full px-2.5 py-1 font-game"
+        style={{ background: `color-mix(in srgb, ${hex} 20%, transparent)`, color: hex }}
+      >
+        <span
+          className="inline-block w-2.5 h-2.5 rounded-full shrink-0"
+          style={{ background: hex }}
+        />
+        <span>{COLOR_LABEL[currentColor]}</span>
+        <span className="opacity-60">·</span>
+        <span>{getCardLabel(topCard)}</span>
+      </div>
+      {drawStack > 0 && (
+        <span className="rounded-full bg-destructive/20 text-destructive px-2 py-1 font-game font-bold">
+          叠加 +{drawStack}
+        </span>
+      )}
+      {phase === 'choosing_color' && (
+        <span className="rounded-full bg-white/10 text-muted-foreground px-2 py-1 font-game">
+          选色中…
+        </span>
+      )}
+      {phase === 'challenging' && (
+        <span className="rounded-full bg-white/10 text-muted-foreground px-2 py-1 font-game">
+          质疑中…
+        </span>
+      )}
+      {phase === 'choosing_swap_target' && (
+        <span className="rounded-full bg-white/10 text-muted-foreground px-2 py-1 font-game">
+          选交换…
+        </span>
+      )}
+    </div>
+  );
+}
 
 interface TopBarProps { roomCode: string; }
 
@@ -42,6 +113,7 @@ export default function TopBar({ roomCode }: TopBarProps) {
         <span className="text-muted-foreground">房间: {roomCode}</span>
         <span className="text-muted-foreground/50 text-xs hidden md:inline">v{BUILD_VERSION}</span>
       </div>
+      <GameStatus />
       <div className="flex items-center gap-3">
         <button
           onClick={toggleInfoDrawer}

--- a/packages/client/src/features/game/hooks/usePlayableCardIds.ts
+++ b/packages/client/src/features/game/hooks/usePlayableCardIds.ts
@@ -3,6 +3,7 @@ import { useGameStore } from '../stores/game-store';
 import { useEffectiveUserId } from './useEffectiveUserId';
 import { useIsMyTurn } from './useIsMyTurn';
 import { getPlayableCardIds, getJumpInCardIds } from '@/shared/utils/playable-cards';
+import { canRespondToDrawStack } from '@uno-online/shared';
 
 export function usePlayableCardIds(): Set<string> {
   const userId = useEffectiveUserId();
@@ -11,11 +12,21 @@ export function usePlayableCardIds(): Set<string> {
   const currentColor = useGameStore((s) => s.currentColor);
   const drawStack = useGameStore((s) => s.drawStack);
   const pendingPenaltyDraws = useGameStore((s) => s.pendingPenaltyDraws);
+  const pendingDrawPlayerId = useGameStore((s) => s.pendingDrawPlayerId);
   const settings = useGameStore((s) => s.settings);
   const phase = useGameStore((s) => s.phase);
   const isMyTurn = useIsMyTurn();
 
   return useMemo(() => {
+    if (phase === 'challenging' && pendingDrawPlayerId === userId && topCard) {
+      const hr = settings?.houseRules;
+      const canStack = hr?.stackDrawFour || hr?.crossStack;
+      if (canStack) {
+        const ids = (myHand ?? []).filter(c => canRespondToDrawStack(c, topCard, hr)).map(c => c.id);
+        return new Set(ids);
+      }
+      return new Set<string>();
+    }
     if (phase !== 'playing') return new Set<string>();
     if (!isMyTurn) {
       if (!settings?.houseRules?.jumpIn) return new Set<string>();

--- a/packages/client/src/features/game/pages/GamePage.tsx
+++ b/packages/client/src/features/game/pages/GamePage.tsx
@@ -32,6 +32,7 @@ import AntiCheatToast from '../components/AntiCheatToast';
 import CheatOverlay from '../components/CheatOverlay';
 import { useSpectatorStore } from '../stores/spectator-store';
 import GameStartRulesModal from '../components/GameStartRulesModal';
+import ColorWave from '../components/ColorWave';
 
 export default function GamePage() {
   const { roomCode } = useParams<{ roomCode: string }>();
@@ -237,6 +238,7 @@ export default function GamePage() {
         onClose={() => setShowStartRules(false)}
       />
       <GameEffects />
+      <ColorWave />
       {antiCheatKey && <AntiCheatToast key={antiCheatKey} />}
       {(phase === 'round_end' || phase === 'game_over') && <Confetti />}
       {needsColorPick && <ColorPicker onPick={chooseColor} />}

--- a/packages/shared/src/rules/autopilot-strategy.ts
+++ b/packages/shared/src/rules/autopilot-strategy.ts
@@ -59,6 +59,17 @@ export function chooseAutopilotAction(state: GameState, playerId: string): GameA
 
   if (state.phase === 'challenging') {
     if (state.pendingDrawPlayerId === playerId) {
+      const topCard = state.discardPile[state.discardPile.length - 1];
+      if (topCard && (hr.stackDrawFour || hr.crossStack)) {
+        const stackable = player.hand.find(c =>
+          (hr.stackDrawFour && c.type === 'wild_draw_four') ||
+          (hr.crossStack && (c.type === 'draw_two' || c.type === 'wild_draw_four')),
+        );
+        if (stackable) {
+          const chosenColor = stackable.type === 'wild_draw_four' ? bestColor(player.hand) : undefined;
+          return [{ type: 'PLAY_CARD', playerId, cardId: stackable.id, ...(chosenColor ? { chosenColor } : {}) }];
+        }
+      }
       return [{ type: 'ACCEPT', playerId }];
     }
     return [];

--- a/packages/shared/src/rules/rules/stacking.ts
+++ b/packages/shared/src/rules/rules/stacking.ts
@@ -17,6 +17,40 @@ export const stacking: HouseRulePlugin = {
       return { handled: true, state };
     }
 
+    // Case (0): PLAY_CARD during challenging phase — stack instead of challenge/accept
+    if (action.type === 'PLAY_CARD' && state.phase === 'challenging' && state.pendingDrawPlayerId) {
+      if (action.playerId !== state.pendingDrawPlayerId) return { handled: false };
+      const playerIdx = state.players.findIndex(p => p.id === action.playerId);
+      if (playerIdx === -1) return { handled: true, state };
+      const player = state.players[playerIdx]!;
+      const card = player.hand.find(c => c.id === action.cardId);
+      if (!card) return { handled: true, state };
+      const canStack =
+        (hr.stackDrawFour && card.type === 'wild_draw_four') ||
+        (hr.crossStack && (card.type === 'draw_two' || card.type === 'wild_draw_four'));
+      if (!canStack) return { handled: false };
+
+      if (card.type === 'wild_draw_four' && !action.chosenColor) {
+        return {
+          handled: true,
+          state: {
+            ...state,
+            phase: 'choosing_color',
+            currentPlayerIndex: playerIdx,
+          },
+        };
+      }
+
+      const baseState: GameState = {
+        ...state,
+        phase: 'playing',
+        pendingDrawPlayerId: null,
+        drawStack: 4,
+        currentPlayerIndex: playerIdx,
+      };
+      return { handled: true, state: ctx.putAttackCardOnStack(baseState, action, card, ctx.getCardDrawPenalty(card)) };
+    }
+
     // Case (a): PLAY_CARD when drawStack > 0 — try to stack
     if (action.type === 'PLAY_CARD' && state.drawStack > 0) {
       const player = state.players[state.currentPlayerIndex];


### PR DESCRIPTION
## Summary
- **选色光波**：变色牌选色后，从牌面中心扩散一圈对应颜色的光波到全屏
- **TopBar 牌面状态**：标题栏中间显示当前颜色圆点 + 顶牌类型 + 叠加/选色/质疑等状态
- **+4 叠加修复**：开启 crossStack/stackDrawFour 时，被 +4 的玩家现在可以叠加 +2/+4，不再强制只能质疑或接受；托管模式同步优先叠加
- **语音状态图标**：玩家头像左下角显示麦克风状态（绿色=说话中，灰色=麦克风开启，红色=静音）
- **语音提示音**：其他玩家加入/离开语音频道时播放上扬/下沉提示音

## Test plan
- [ ] 出变色牌选色后观察光波扩散效果
- [ ] TopBar 显示当前颜色和牌面信息，叠加时显示 +N
- [ ] 开启 crossStack，出 +4 后下家手上有 +2 → 能叠加出牌
- [ ] 托管模式下 AI 也能在 +4 后叠加
- [ ] 加入语音频道 → 头像显示麦克风图标，说话时变绿
- [ ] 其他人加入/离开语音 → 听到提示音

🤖 Generated with [Claude Code](https://claude.com/claude-code)