### PR TITLE
fix: 自己的语音说话指示器不亮

### DIFF
--- a/packages/client/src/features/game/components/GameTable.tsx
+++ b/packages/client/src/features/game/components/GameTable.tsx
@@ -53,6 +53,7 @@ export default function GameTable({ onDraw }: GameTableProps) {
   // Mumble speaking state
   const mumbleUsersById = useGatewayStore((s) => s.usersById);
   const mumbleSpeakingByUserId = useGatewayStore((s) => s.speakingByUserId);
+  const selfSpeaking = useGatewayStore((s) => s.selfSpeaking);
   const voicePresence = useGatewayStore((s) => s.playerVoicePresence);
   const mumbleSpeakingNames = useMemo(() => {
     const names = new Set<string>();
@@ -341,7 +342,7 @@ export default function GameTable({ onDraw }: GameTableProps) {
             isMe={isMe}
             isHost={player.id === ownerId}
             isSkipped={player.id === skippedPlayerId}
-            isSpeaking={mumbleSpeakingNames.has(player.name)}
+            isSpeaking={isMe ? selfSpeaking : mumbleSpeakingNames.has(player.name)}
             voiceState={voicePresence[player.id]}
             position={pos}
             turnEndTime={isActive ? turnEndTime : null}


### PR DESCRIPTION
## Summary
- 自己的说话状态直接用 `selfSpeaking`，不再经过 Mumble 用户名匹配，解决自己说话时头像指示器不变绿的问题

## Test plan
- [ ] 加入语音说话 → 自己头像左下角麦克风图标变绿
- [ ] 停止说话 → 恢复灰色
- [ ] 其他人说话 → 他们的图标也正常变绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)