### PR TITLE
refactor: 简化近期代码

### DIFF
--- a/packages/client/src/features/game/components/ColorPicker.tsx
+++ b/packages/client/src/features/game/components/ColorPicker.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import type { Color } from '@uno-online/shared';
+import { UNO_COLOR_HEX } from '../constants/colors';
 
 const COLORS: { color: Color; bgClass: string; label: string }[] = [
   { color: 'red', bgClass: 'bg-uno-red', label: '红' },
@@ -8,10 +9,6 @@ const COLORS: { color: Color; bgClass: string; label: string }[] = [
   { color: 'green', bgClass: 'bg-uno-green', label: '绿' },
   { color: 'yellow', bgClass: 'bg-uno-yellow', label: '黄' },
 ];
-
-const BG_MAP: Record<Color, string> = {
-  red: '#ff3366', blue: '#4488ff', green: '#33cc66', yellow: '#fbbf24',
-};
 
 interface ColorPickerProps { onPick: (color: Color) => void; }
 
@@ -33,7 +30,7 @@ export default function ColorPicker({ onPick }: ColorPickerProps) {
             animate={{ scale: 30, opacity: 0 }}
             transition={{ duration: 0.5, ease: 'easeOut' }}
             className="absolute w-color-burst h-color-burst rounded-full pointer-events-none"
-            style={{ background: BG_MAP[picked] }}
+            style={{ background: UNO_COLOR_HEX[picked] }}
           />
         )}
       </AnimatePresence>

--- a/packages/client/src/features/game/components/ColorWave.tsx
+++ b/packages/client/src/features/game/components/ColorWave.tsx
@@ -2,20 +2,12 @@ import { useEffect, useRef, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useGameStore } from '../stores/game-store';
 import type { Color } from '@uno-online/shared';
-
-const COLOR_MAP: Record<Color, string> = {
-  red: '#ff3366',
-  blue: '#4488ff',
-  green: '#33cc66',
-  yellow: '#fbbf24',
-};
+import { UNO_COLOR_HEX } from '../constants/colors';
 
 interface WaveState {
   id: number;
   color: string;
 }
-
-let waveId = 0;
 
 export default function ColorWave() {
   const currentColor = useGameStore((s) => s.currentColor);
@@ -23,6 +15,7 @@ export default function ColorWave() {
   const lastAction = useGameStore((s) => s.lastAction);
   const [wave, setWave] = useState<WaveState | null>(null);
   const prevColorRef = useRef<Color | null>(null);
+  const waveIdRef = useRef(0);
 
   useEffect(() => {
     if (!currentColor || !lastAction) return;
@@ -33,10 +26,10 @@ export default function ColorWave() {
     prevColorRef.current = currentColor;
     if (prevColor === currentColor) return;
 
-    const hex = COLOR_MAP[currentColor];
+    const hex = UNO_COLOR_HEX[currentColor];
     if (!hex) return;
 
-    const id = ++waveId;
+    const id = ++waveIdRef.current;
     setWave({ id, color: hex });
     const timer = setTimeout(() => setWave(null), 1200);
     return () => clearTimeout(timer);

--- a/packages/client/src/features/game/components/TopBar.tsx
+++ b/packages/client/src/features/game/components/TopBar.tsx
@@ -12,6 +12,12 @@ import { BUILD_VERSION } from '@/shared/build-info';
 
 const AUTOPILOT_COOLDOWN_MS = 3000;
 
+const PHASE_LABEL: Record<string, string> = {
+  choosing_color: '选色中…',
+  challenging: '质疑中…',
+  choosing_swap_target: '选交换…',
+};
+
 const COLOR_HEX: Record<Color, string> = {
   red: 'var(--color-uno-red)',
   blue: 'var(--color-uno-blue)',
@@ -63,19 +69,9 @@ function GameStatus() {
           叠加 +{drawStack}
         </span>
       )}
-      {phase === 'choosing_color' && (
+      {phase && PHASE_LABEL[phase] && (
         <span className="rounded-full bg-white/10 text-muted-foreground px-2 py-1 font-game">
-          选色中…
-        </span>
-      )}
-      {phase === 'challenging' && (
-        <span className="rounded-full bg-white/10 text-muted-foreground px-2 py-1 font-game">
-          质疑中…
-        </span>
-      )}
-      {phase === 'choosing_swap_target' && (
-        <span className="rounded-full bg-white/10 text-muted-foreground px-2 py-1 font-game">
-          选交换…
+          {PHASE_LABEL[phase]}
         </span>
       )}
     </div>

--- a/packages/client/src/features/game/constants/colors.ts
+++ b/packages/client/src/features/game/constants/colors.ts
@@ -1,0 +1,8 @@
+import type { Color } from '@uno-online/shared';
+
+export const UNO_COLOR_HEX: Record<Color, string> = {
+  red: '#ff3366',
+  blue: '#4488ff',
+  green: '#33cc66',
+  yellow: '#fbbf24',
+};

--- a/packages/client/src/features/game/hooks/useGameSocket.ts
+++ b/packages/client/src/features/game/hooks/useGameSocket.ts
@@ -44,22 +44,21 @@ export function useGameSocket(roomCode: string | undefined) {
     socket.on('chat:message', addChatMessage);
     socket.on('chat:cleared', clearChatMessages);
 
-    const onSpectatorList = (data: { spectators?: string[] }) => { if (data.spectators) setSpectators(data.spectators); };
-    const onSpectatorJoined = (data: { spectators?: string[] }) => { if (data.spectators) setSpectators(data.spectators); };
+    const onSpectatorUpdate = (data: { spectators?: string[] }) => { if (data.spectators) setSpectators(data.spectators); };
     const onSpectatorLeft = (data: { spectators?: string[]; nickname?: string }) => {
       if (data.spectators) setSpectators(data.spectators);
       else if (data.nickname) useSpectatorStore.getState().removeSpectator(data.nickname);
     };
-    socket.on('room:spectator_list', onSpectatorList);
-    socket.on('room:spectator_joined', onSpectatorJoined);
+    socket.on('room:spectator_list', onSpectatorUpdate);
+    socket.on('room:spectator_joined', onSpectatorUpdate);
     socket.on('room:spectator_left', onSpectatorLeft);
 
     return () => {
       socket.off('chat:history', setChatHistory);
       socket.off('chat:message', addChatMessage);
       socket.off('chat:cleared', clearChatMessages);
-      socket.off('room:spectator_list', onSpectatorList);
-      socket.off('room:spectator_joined', onSpectatorJoined);
+      socket.off('room:spectator_list', onSpectatorUpdate);
+      socket.off('room:spectator_joined', onSpectatorUpdate);
       socket.off('room:spectator_left', onSpectatorLeft);
     };
   }, [setChatHistory, addChatMessage, clearChatMessages, setSpectators]);

--- a/packages/client/src/shared/socket.ts
+++ b/packages/client/src/shared/socket.ts
@@ -36,19 +36,23 @@ export function getSocket(): TypedSocket {
     socket.on('voice:presence', (presence) => {
       const newPresence = (presence ?? {}) as Record<string, PlayerVoicePresence>;
       const oldPresence = useGatewayStore.getState().playerVoicePresence;
-      useGatewayStore.getState().setPlayerVoicePresence(newPresence);
 
       const selfId = useGameStore.getState().viewerId;
+      let changed = false;
       for (const [uid, p] of Object.entries(newPresence)) {
+        const old = oldPresence[uid];
+        if (!old || old.inVoice !== p.inVoice || old.micEnabled !== p.micEnabled) { changed = true; }
         if (uid === selfId) continue;
-        const wasInVoice = oldPresence[uid]?.inVoice;
+        const wasInVoice = old?.inVoice;
         if (p.inVoice && !wasInVoice) playSound('voice_join');
         else if (!p.inVoice && wasInVoice) playSound('voice_leave');
       }
       for (const [uid, p] of Object.entries(oldPresence)) {
+        if (!newPresence[uid]) { changed = true; }
         if (uid === selfId) continue;
         if (p.inVoice && !newPresence[uid]) playSound('voice_leave');
       }
+      if (changed) useGatewayStore.getState().setPlayerVoicePresence(newPresence);
     });
 
     const handleGameView = (view: PlayerView) => {


### PR DESCRIPTION
## Summary
- ColorWave 模块级 `let waveId` 改为 `useRef`，修复 React 严格模式兼容性
- 提取 `UNO_COLOR_HEX` 常量到 `constants/colors.ts`，消除 ColorWave/ColorPicker 重复色值映射
- 合并 `useGameSocket` 中重复的观战者事件处理函数
- TopBar 阶段状态条件渲染改为 `PHASE_LABEL` 查表
- `voice:presence` 处理增加变更检测，数据不变时跳过 store 更新，避免无效重渲染

## Test plan
- [x] TypeScript 类型检查通过
- [x] 全部 240 个测试通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)