### PR TITLE
feat: 浏览器通知、服务器更新提示、观战改进、默认分数调整

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,19 @@ src/
 ```bash
 pnpm test                                    # 运行所有测试
 pnpm --filter shared test                    # 仅 shared 测试
+pnpm --filter shared build                   # 构建 shared（生成类型声明，client/server 依赖此步骤）
 pnpm --filter server exec tsc --noEmit       # 服务端类型检查
-pnpm --filter client exec tsc --noEmit       # 客户端类型检查
-pnpm --filter client build                   # 客户端生产构建
+pnpm --filter client exec tsc --noEmit       # 客户端类型检查（需先 build shared）
+pnpm --filter client build                   # 客户端生产构建（需先 build shared）
+```
+
+### 验证流程
+
+client 和 server 的类型检查/构建依赖 shared 的编译产物。完整验证步骤：
+
+```bash
+pnpm --filter shared build                   # 1. 先构建 shared
+pnpm --filter server exec tsc --noEmit       # 2. 服务端类型检查
+pnpm --filter client build                   # 3. 客户端构建（含类型检查）
+pnpm test                                    # 4. 运行测试
 ```

--- a/packages/client/src/app/App.tsx
+++ b/packages/client/src/app/App.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import AppRouter from './router';
 import ToastContainer from '@/shared/components/Toast';
 import ChangelogModal from '@/shared/components/ChangelogModal';
+import NotificationPermissionDialog from '@/shared/components/NotificationPermissionDialog';
 import { useSettingsStore, FONT_OPTIONS } from '@/shared/stores/settings-store';
 
 export default function App() {
@@ -20,6 +21,7 @@ export default function App() {
       <AppRouter />
       <ToastContainer />
       <ChangelogModal />
+      <NotificationPermissionDialog />
     </div>
   );
 }

--- a/packages/client/src/app/App.tsx
+++ b/packages/client/src/app/App.tsx
@@ -3,6 +3,7 @@ import AppRouter from './router';
 import ToastContainer from '@/shared/components/Toast';
 import ChangelogModal from '@/shared/components/ChangelogModal';
 import NotificationPermissionDialog from '@/shared/components/NotificationPermissionDialog';
+import ServerUpdateDialog from '@/shared/components/ServerUpdateDialog';
 import { useSettingsStore, FONT_OPTIONS } from '@/shared/stores/settings-store';
 
 export default function App() {
@@ -22,6 +23,7 @@ export default function App() {
       <ToastContainer />
       <ChangelogModal />
       <NotificationPermissionDialog />
+      <ServerUpdateDialog />
     </div>
   );
 }

--- a/packages/client/src/features/game/pages/GamePage.tsx
+++ b/packages/client/src/features/game/pages/GamePage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import type { MouseEvent } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
-import { Loader2, Eye, LogOut, UserPlus } from 'lucide-react';
+import { Loader2, Eye, LogOut, UserPlus, X } from 'lucide-react';
 import { motion, AnimatePresence, LayoutGroup } from 'framer-motion';
 import { useGameStore } from '../stores/game-store';
 import { useIsMyTurn } from '../hooks/useIsMyTurn';
@@ -202,32 +202,11 @@ export default function GamePage() {
       {!isSpectator && <PlayerHand onPlayCard={playCard} />}
       </LayoutGroup>
       {isSpectator && (
-        <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-actions bg-card/90 backdrop-blur-sm rounded-full px-3 py-2 text-sm text-muted-foreground flex items-center gap-2">
-          <Eye size={16} /> 观战中
-          {phase === 'round_end' && (
-            <button
-              onClick={() => {
-                getSocket().emit('game:spectator_join', (res: { success?: boolean; error?: string }) => {
-                  if (res?.success) {
-                    setSpectator(false);
-                    clearSpectators();
-                  } else {
-                    useToastStore.getState().addToast(res?.error ?? '加入失败', 'error');
-                  }
-                });
-              }}
-              className="ml-1 inline-flex items-center gap-1 rounded-full bg-primary/80 px-2 py-1 text-xs text-white transition-colors hover:bg-primary"
-            >
-              <UserPlus size={12} /> 加入游戏
-            </button>
-          )}
-          <button
-            onClick={backToLobby}
-            className="ml-1 inline-flex items-center gap-1 rounded-full bg-white/10 px-2 py-1 text-xs text-foreground transition-colors hover:bg-white/20"
-          >
-            <LogOut size={12} /> 退出
-          </button>
-        </div>
+        <SpectatorBar
+          phase={phase}
+          onBackToLobby={backToLobby}
+          onJoined={() => { setSpectator(false); clearSpectators(); }}
+        />
       )}
       <VoicePanel />
       <InfoDrawer />
@@ -246,6 +225,60 @@ export default function GamePage() {
         <ScoreBoard onPlayAgain={playAgain} onRematch={rematch} onBackToLobby={backToLobby} onKickPlayer={kickPlayer} />
       )}
       {cheatDetected && <CheatOverlay />}
+    </div>
+  );
+}
+
+function SpectatorBar({ phase, onBackToLobby, onJoined }: { phase: string | null; onBackToLobby: () => void; onJoined: () => void }) {
+  const [queued, setQueued] = useState(false);
+
+  useEffect(() => {
+    const socket = getSocket();
+    const handleState = () => {
+      const { isSpectator } = useGameStore.getState();
+      if (!isSpectator && queued) {
+        onJoined();
+        setQueued(false);
+      }
+    };
+    socket.on('game:state', handleState);
+    return () => { socket.off('game:state', handleState); };
+  }, [queued, onJoined]);
+
+  const toggleQueue = () => {
+    getSocket().emit('game:spectator_join', (res: { success?: boolean; error?: string; queued?: boolean }) => {
+      if (res?.success) {
+        setQueued(res.queued ?? false);
+      } else {
+        useToastStore.getState().addToast(res?.error ?? '操作失败', 'error');
+      }
+    });
+  };
+
+  return (
+    <div className="fixed top-14 left-1/2 -translate-x-1/2 z-actions bg-card/90 backdrop-blur-sm rounded-full px-3 py-2 text-sm text-muted-foreground flex items-center gap-2">
+      <Eye size={16} /> 观战中
+      {queued ? (
+        <button
+          onClick={toggleQueue}
+          className="ml-1 inline-flex items-center gap-1 rounded-full bg-white/10 px-2 py-1 text-xs text-foreground transition-colors hover:bg-white/20"
+        >
+          <X size={12} /> 取消加入
+        </button>
+      ) : (
+        <button
+          onClick={toggleQueue}
+          className="ml-1 inline-flex items-center gap-1 rounded-full bg-primary/80 px-2 py-1 text-xs text-white transition-colors hover:bg-primary"
+        >
+          <UserPlus size={12} /> 下局加入
+        </button>
+      )}
+      <button
+        onClick={onBackToLobby}
+        className="ml-1 inline-flex items-center gap-1 rounded-full bg-white/10 px-2 py-1 text-xs text-foreground transition-colors hover:bg-white/20"
+      >
+        <LogOut size={12} /> 退出
+      </button>
     </div>
   );
 }

--- a/packages/client/src/features/profile/pages/ProfilePage.tsx
+++ b/packages/client/src/features/profile/pages/ProfilePage.tsx
@@ -4,8 +4,9 @@ import { useAuthStore } from '@/features/auth/stores/auth-store';
 import { apiGet, apiPatch, apiPost, apiDelete } from '@/shared/api';
 import { getRoleColor } from '@/shared/lib/utils';
 import AvatarUpload from '@/features/auth/components/AvatarUpload';
-import { Edit3, Save, Lock, Key, Copy, Trash2 } from 'lucide-react';
+import { Edit3, Save, Lock, Key, Copy, Trash2, Bell } from 'lucide-react';
 import { Button } from '@/shared/components/ui/Button';
+import { useNotificationStore, type NotificationEventType } from '@/shared/stores/notification-store';
 
 interface ProfileData {
   user: { id: string; username: string; nickname: string; avatarUrl: string | null; totalGames: number; totalWins: number; githubId?: string | null; role?: string };
@@ -148,6 +149,9 @@ export default function ProfilePage() {
             </p>
           </div>
 
+          {/* Notification settings */}
+          <NotificationSettings />
+
           {/* Password section */}
           <div className="bg-card rounded-xl p-4 w-full max-w-[360px]">
             <h3 className="text-sm text-muted-foreground mb-3 flex items-center gap-1.5">
@@ -238,6 +242,67 @@ export default function ProfilePage() {
         </>
       )}
       <Button variant="secondary" onClick={() => navigate('/lobby')} sound="click">返回大厅</Button>
+    </div>
+  );
+}
+
+const NOTIFICATION_LABELS: { key: NotificationEventType; label: string }[] = [
+  { key: 'gameStart', label: '游戏开始' },
+  { key: 'myTurn', label: '轮到我出牌' },
+  { key: 'gameEnd', label: '游戏结束' },
+  { key: 'kicked', label: '被踢出房间' },
+  { key: 'roomDissolved', label: '房间解散' },
+];
+
+function NotificationSettings() {
+  const { preferences, setPreference } = useNotificationStore();
+  const permission = typeof Notification !== 'undefined' ? Notification.permission : 'unsupported';
+
+  const handleRequest = async () => {
+    if (typeof Notification !== 'undefined') {
+      await Notification.requestPermission();
+    }
+  };
+
+  return (
+    <div className="bg-card rounded-xl p-4 w-full max-w-[360px]">
+      <h3 className="text-sm text-muted-foreground mb-3 flex items-center gap-1.5">
+        <Bell size={14} /> 通知设置
+      </h3>
+
+      {permission !== 'granted' && (
+        <div className="mb-3 rounded-lg border border-accent/20 bg-accent/5 px-3 py-2">
+          {permission === 'denied' ? (
+            <p className="text-xs text-destructive/80">
+              通知权限已被拒绝，请在浏览器地址栏左侧的网站设置中手动开启。
+            </p>
+          ) : (
+            <div className="flex items-center justify-between">
+              <p className="text-xs text-muted-foreground">尚未开启通知权限</p>
+              <button onClick={handleRequest} className="text-xs font-bold text-accent hover:opacity-80 transition-opacity">
+                开启
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
+      <div className="flex flex-col gap-2">
+        {NOTIFICATION_LABELS.map(({ key, label }) => (
+          <label key={key} className="flex items-center justify-between cursor-pointer">
+            <span className="text-sm">{label}</span>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={preferences[key]}
+              onClick={() => setPreference(key, !preferences[key])}
+              className={`relative h-5 w-9 rounded-full transition-colors ${preferences[key] ? 'bg-accent' : 'bg-white/15'}`}
+            >
+              <span className={`absolute top-0.5 left-0.5 h-4 w-4 rounded-full bg-white transition-transform ${preferences[key] ? 'translate-x-4' : ''}`} />
+            </button>
+          </label>
+        ))}
+      </div>
     </div>
   );
 }

--- a/packages/client/src/shared/components/NotificationPermissionDialog.tsx
+++ b/packages/client/src/shared/components/NotificationPermissionDialog.tsx
@@ -1,0 +1,110 @@
+import { useState, useEffect } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { Bell, X } from 'lucide-react';
+
+export default function NotificationPermissionDialog() {
+  const [open, setOpen] = useState(false);
+  const [permission, setPermission] = useState<NotificationPermission | 'unsupported'>('default');
+
+  useEffect(() => {
+    if (typeof Notification === 'undefined') return;
+    const current = Notification.permission;
+    setPermission(current);
+    if (current !== 'granted') {
+      setOpen(true);
+    }
+  }, []);
+
+  const handleRequest = async () => {
+    if (typeof Notification === 'undefined') return;
+    const result = await Notification.requestPermission();
+    setPermission(result);
+    if (result === 'granted') {
+      setOpen(false);
+    }
+  };
+
+  const close = () => setOpen(false);
+
+  if (!open || permission === 'unsupported') return null;
+
+  const isDenied = permission === 'denied';
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <div className="fixed inset-0 z-modal flex items-center justify-center">
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="absolute inset-0 bg-black/50"
+            onClick={close}
+          />
+
+          <motion.div
+            initial={{ opacity: 0, scale: 0.9 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.9 }}
+            transition={{ duration: 0.2 }}
+            className="relative w-full max-w-[380px] rounded-2xl bg-card shadow-2xl"
+          >
+            <div className="flex items-center justify-between border-b border-white/[0.08] px-6 py-4">
+              <div className="flex items-center gap-2 text-lg font-bold">
+                <Bell size={18} className="text-accent" /> 开启通知
+              </div>
+              <button onClick={close} className="p-1 text-muted-foreground hover:text-foreground">
+                <X size={18} />
+              </button>
+            </div>
+
+            <div className="px-6 py-5 space-y-3">
+              <p className="text-sm text-foreground/90">
+                开启浏览器通知后，当你不在游戏页面时，我们会在以下情况提醒你：
+              </p>
+              <ul className="space-y-1.5 text-sm text-muted-foreground">
+                <li className="flex items-center gap-2">
+                  <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-accent" />
+                  游戏开始
+                </li>
+                <li className="flex items-center gap-2">
+                  <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-accent" />
+                  轮到你出牌
+                </li>
+                <li className="flex items-center gap-2">
+                  <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-accent" />
+                  游戏结束
+                </li>
+              </ul>
+
+              {isDenied ? (
+                <p className="text-xs text-destructive/80 mt-2">
+                  通知权限已被拒绝，请在浏览器地址栏左侧的网站设置中手动开启通知权限。
+                </p>
+              ) : null}
+            </div>
+
+            <div className="border-t border-white/[0.08] px-5 py-3.5">
+              {isDenied ? (
+                <button
+                  onClick={close}
+                  className="w-full rounded-lg bg-white/10 px-4 py-2 text-sm font-bold text-foreground transition-colors hover:bg-white/15"
+                >
+                  我知道了
+                </button>
+              ) : (
+                <button
+                  onClick={handleRequest}
+                  className="w-full rounded-lg bg-accent px-4 py-2 text-sm font-bold text-white transition-colors hover:opacity-90"
+                >
+                  允许通知
+                </button>
+              )}
+            </div>
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/packages/client/src/shared/components/ServerUpdateDialog.tsx
+++ b/packages/client/src/shared/components/ServerUpdateDialog.tsx
@@ -1,0 +1,54 @@
+import { AnimatePresence, motion } from 'framer-motion';
+import { RefreshCw } from 'lucide-react';
+import { useServerVersionStore } from '../stores/server-version-store';
+
+export default function ServerUpdateDialog() {
+  const needsRefresh = useServerVersionStore((s) => s.needsRefresh);
+
+  if (!needsRefresh) return null;
+
+  const handleRefresh = () => window.location.reload();
+
+  return (
+    <AnimatePresence>
+      {needsRefresh && (
+        <div className="fixed inset-0 z-modal flex items-center justify-center">
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="absolute inset-0 bg-black/50"
+          />
+
+          <motion.div
+            initial={{ opacity: 0, scale: 0.9 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.9 }}
+            transition={{ duration: 0.2 }}
+            className="relative w-full max-w-[380px] rounded-2xl bg-card shadow-2xl"
+          >
+            <div className="flex items-center gap-2 border-b border-white/[0.08] px-6 py-4 text-lg font-bold">
+              <RefreshCw size={18} className="text-accent" /> 服务器已更新
+            </div>
+
+            <div className="px-6 py-5">
+              <p className="text-sm text-foreground/90">
+                服务器刚刚完成了一次更新，请刷新页面以加载最新版本。
+              </p>
+            </div>
+
+            <div className="border-t border-white/[0.08] px-5 py-3.5">
+              <button
+                onClick={handleRefresh}
+                className="w-full rounded-lg bg-accent px-4 py-2 text-sm font-bold text-white transition-colors hover:opacity-90"
+              >
+                刷新页面
+              </button>
+            </div>
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/packages/client/src/shared/socket.ts
+++ b/packages/client/src/shared/socket.ts
@@ -7,6 +7,7 @@ import { useToastStore } from './stores/toast-store';
 import { playSound } from './sound/sound-manager';
 import { useGatewayStore, type PlayerVoicePresence } from './voice/gateway-store';
 import { leaveVoiceSession } from './voice/voice-runtime';
+import { sendNotification } from './utils/notification';
 
 type TypedSocket = SocketType<ServerToClientEvents, ClientToServerEvents>;
 
@@ -56,6 +57,8 @@ export function getSocket(): TypedSocket {
     });
 
     const handleGameView = (view: PlayerView) => {
+      const prevPhase = useGameStore.getState().phase;
+      const prevCurrentIndex = useGameStore.getState().currentPlayerIndex;
       useGameStore.getState().setGameState(view);
       const settings = view.settings;
       if (!settings || view.phase === 'round_end' || view.phase === 'game_over') {
@@ -65,6 +68,25 @@ export function getSocket(): TypedSocket {
           ? Math.floor(settings.turnTimeLimit / 2)
           : settings.turnTimeLimit;
         useGameStore.getState().setTurnEndTime(Date.now() + timeLimit * 1000);
+      }
+
+      const viewerId = view.viewerId ?? useGameStore.getState().viewerId;
+      const currentPlayerId = view.players[view.currentPlayerIndex]?.id;
+
+      if (prevPhase !== 'playing' && view.phase === 'playing' && view.roundNumber === 1) {
+        sendNotification('gameStart');
+      }
+
+      if (
+        view.phase === 'playing' &&
+        currentPlayerId === viewerId &&
+        (prevPhase !== 'playing' || prevCurrentIndex !== view.currentPlayerIndex)
+      ) {
+        sendNotification('myTurn');
+      }
+
+      if (view.phase === 'game_over' && prevPhase !== 'game_over') {
+        sendNotification('gameEnd');
       }
     };
 
@@ -164,6 +186,7 @@ export function getSocket(): TypedSocket {
       useRoomStore.getState().clearRoom();
       useGameStore.getState().clearGame();
       leaveVoiceSession();
+      sendNotification('kicked', data.reason || '你已被移出房间');
       useToastStore.getState().addToast(data.reason || '你已被移出游戏', 'error');
       if (window.location.pathname !== '/lobby') {
         window.location.assign('/lobby');
@@ -182,6 +205,7 @@ export function getSocket(): TypedSocket {
       const message = data?.reason === 'idle_timeout'
         ? '房间长时间没有活动，已自动解散'
         : '房间已被房主解散';
+      sendNotification('roomDissolved', message);
       useToastStore.getState().addToast(message, 'info');
       if (window.location.pathname !== '/lobby') {
         window.location.assign('/lobby');

--- a/packages/client/src/shared/socket.ts
+++ b/packages/client/src/shared/socket.ts
@@ -8,6 +8,7 @@ import { playSound } from './sound/sound-manager';
 import { useGatewayStore, type PlayerVoicePresence } from './voice/gateway-store';
 import { leaveVoiceSession } from './voice/voice-runtime';
 import { sendNotification } from './utils/notification';
+import { useServerVersionStore } from './stores/server-version-store';
 
 type TypedSocket = SocketType<ServerToClientEvents, ClientToServerEvents>;
 
@@ -144,6 +145,10 @@ export function getSocket(): TypedSocket {
 
     socket.on('room:spectator_left', (data) => {
       useToastStore.getState().addToast(`${data.nickname} 离开观战`, 'info');
+    });
+
+    socket.on('server:version', (data) => {
+      useServerVersionStore.getState().setVersion(data.version);
     });
 
     socket.on('connect', () => {

--- a/packages/client/src/shared/stores/notification-store.ts
+++ b/packages/client/src/shared/stores/notification-store.ts
@@ -1,0 +1,44 @@
+import { create } from 'zustand';
+
+export interface NotificationPreferences {
+  gameStart: boolean;
+  myTurn: boolean;
+  gameEnd: boolean;
+  kicked: boolean;
+  roomDissolved: boolean;
+}
+
+export type NotificationEventType = keyof NotificationPreferences;
+
+const STORAGE_KEY = 'notification-preferences';
+
+function loadPreferences(): NotificationPreferences {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) return { ...defaultPreferences, ...JSON.parse(raw) };
+  } catch { /* ignore */ }
+  return { ...defaultPreferences };
+}
+
+const defaultPreferences: NotificationPreferences = {
+  gameStart: true,
+  myTurn: true,
+  gameEnd: true,
+  kicked: true,
+  roomDissolved: true,
+};
+
+interface NotificationState {
+  preferences: NotificationPreferences;
+  setPreference: (key: NotificationEventType, value: boolean) => void;
+}
+
+export const useNotificationStore = create<NotificationState>((set) => ({
+  preferences: loadPreferences(),
+  setPreference: (key, value) =>
+    set((state) => {
+      const next = { ...state.preferences, [key]: value };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+      return { preferences: next };
+    }),
+}));

--- a/packages/client/src/shared/stores/server-version-store.ts
+++ b/packages/client/src/shared/stores/server-version-store.ts
@@ -1,0 +1,22 @@
+import { create } from 'zustand';
+
+interface ServerVersionState {
+  initialVersion: string | null;
+  needsRefresh: boolean;
+  setVersion: (version: string) => void;
+  dismiss: () => void;
+}
+
+export const useServerVersionStore = create<ServerVersionState>((set, get) => ({
+  initialVersion: null,
+  needsRefresh: false,
+  setVersion: (version) => {
+    const { initialVersion } = get();
+    if (!initialVersion) {
+      set({ initialVersion: version });
+    } else if (version !== initialVersion) {
+      set({ needsRefresh: true });
+    }
+  },
+  dismiss: () => set({ needsRefresh: false }),
+}));

--- a/packages/client/src/shared/utils/notification.ts
+++ b/packages/client/src/shared/utils/notification.ts
@@ -1,0 +1,24 @@
+import { useNotificationStore, type NotificationEventType } from '../stores/notification-store';
+
+const NOTIFICATION_CONFIG: Record<NotificationEventType, { title: string; body: string }> = {
+  gameStart: { title: 'UNO - 游戏开始', body: '游戏已开始，快来出牌吧！' },
+  myTurn: { title: 'UNO - 轮到你了', body: '现在轮到你出牌了！' },
+  gameEnd: { title: 'UNO - 游戏结束', body: '本局游戏已结束，查看结果吧！' },
+  kicked: { title: 'UNO - 被移出房间', body: '你已被移出房间' },
+  roomDissolved: { title: 'UNO - 房间解散', body: '你所在的房间已被解散' },
+};
+
+export function sendNotification(type: NotificationEventType, overrideBody?: string): void {
+  if (typeof Notification === 'undefined') return;
+  if (Notification.permission !== 'granted') return;
+  if (!document.hidden) return;
+
+  const { preferences } = useNotificationStore.getState();
+  if (!preferences[type]) return;
+
+  const config = NOTIFICATION_CONFIG[type];
+  new Notification(config.title, {
+    body: overrideBody ?? config.body,
+    icon: '/favicon.svg',
+  });
+}

--- a/packages/mcp/src/tools/room.ts
+++ b/packages/mcp/src/tools/room.ts
@@ -10,7 +10,7 @@ export function registerRoomTools(server: McpUnoServer): void {
     '创建游戏房间',
     {
       turnTimeLimit: z.number().optional().describe('每回合时间限制（秒）：15, 30, 或 60'),
-      targetScore: z.number().optional().describe('目标分数：200, 300, 或 500'),
+      targetScore: z.number().optional().describe('目标分数：200, 300, 500, 或 1000'),
       allowSpectators: z.boolean().optional().describe('是否允许观战'),
     },
     (args) => wrapTool(() => {
@@ -50,7 +50,7 @@ export function registerRoomTools(server: McpUnoServer): void {
     '房主更新房间设置（仅等待阶段）',
     {
       turnTimeLimit: z.union([z.literal(15), z.literal(30), z.literal(60)]).optional().describe('每回合时间限制（秒）'),
-      targetScore: z.union([z.literal(200), z.literal(300), z.literal(500)]).optional().describe('目标分数'),
+      targetScore: z.union([z.literal(200), z.literal(300), z.literal(500), z.literal(1000)]).optional().describe('目标分数'),
       allowSpectators: z.boolean().optional().describe('是否允许观战'),
       houseRules: z.record(z.unknown()).optional().describe('村规设置，如 {"stackDrawTwo":true}'),
     },

--- a/packages/server/src/plugins/core/room/manager.ts
+++ b/packages/server/src/plugins/core/room/manager.ts
@@ -17,7 +17,7 @@ function generateRoomCode(): string {
 export class RoomManager {
   constructor(private redis: KvStore) {}
 
-  async createRoom(ownerId: string, ownerNickname: string, settings: RoomSettings = { turnTimeLimit: 30, targetScore: 500, houseRules: DEFAULT_HOUSE_RULES, allowSpectators: true, spectatorMode: 'hidden' }, avatarUrl?: string | null, role?: string, isBot?: boolean): Promise<string> {
+  async createRoom(ownerId: string, ownerNickname: string, settings: RoomSettings = { turnTimeLimit: 30, targetScore: 1000, houseRules: DEFAULT_HOUSE_RULES, allowSpectators: true, spectatorMode: 'hidden' }, avatarUrl?: string | null, role?: string, isBot?: boolean): Promise<string> {
     let code = generateRoomCode();
     let existing = await getRoom(this.redis, code);
     while (existing) {

--- a/packages/server/src/plugins/core/spectate/ws.ts
+++ b/packages/server/src/plugins/core/spectate/ws.ts
@@ -15,6 +15,10 @@ export function clearRoomSpectators(roomCode: string): void {
   roomSpectators.delete(roomCode);
 }
 
+export function removeSpectator(roomCode: string, nickname: string): void {
+  roomSpectators.get(roomCode)?.delete(nickname);
+}
+
 export function setupSpectateHandlers(
   io: SocketIOServer,
   kv: KvStore,

--- a/packages/server/src/ws/game-events.ts
+++ b/packages/server/src/ws/game-events.ts
@@ -12,6 +12,7 @@ import { recordGameResult } from '../db/user-repo.js';
 import { saveGameEvents, saveDeckInfo } from '../plugins/core/game-history/service.js';
 import { getRoom, setRoomStatus, touchRoomActivity, removePlayerFromRoom, addPlayerToRoom } from '../plugins/core/room/store.js';
 import { MAX_PLAYERS } from '@uno-online/shared';
+import { removeSpectator } from '../plugins/core/spectate/ws.js';
 import type { SocketData } from './types.js';
 
 function getSession(socket: Socket, sessions: Map<string, GameSession>): { session: GameSession; roomCode: string } | null {
@@ -92,6 +93,7 @@ function buildChatMessage(user: SocketData['user'], text: string, isSpectator = 
 
 const gameStartTimes = new Map<string, number>();
 const nextRoundVotes = new Map<string, Set<string>>();
+const pendingSpectatorJoins = new Map<string, Map<string, { userId: string; nickname: string; avatarUrl?: string | null; role?: string; isBot?: boolean; socketId: string }>>();
 const AUTOPILOT_JUMP_IN_DELAY_MS = 2_000;
 const autopilotJumpInTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
@@ -244,6 +246,41 @@ function getNextRoundVoteState(roomCode: string, session: GameSession): NextRoun
   };
 }
 
+async function processPendingSpectatorJoins(
+  io: SocketIOServer,
+  redis: KvStore,
+  roomCode: string,
+  session: GameSession,
+): Promise<void> {
+  const pending = pendingSpectatorJoins.get(roomCode);
+  if (!pending || pending.size === 0) return;
+
+  for (const [userId, info] of pending) {
+    if (session.getPlayerCount() >= MAX_PLAYERS) break;
+    if (session.getFullState().players.some((p) => p.id === userId)) continue;
+
+    const sock = io.sockets.sockets.get(info.socketId);
+    if (sock) (sock.data as SocketData).isSpectator = false;
+
+    removeSpectator(roomCode, info.nickname);
+    session.addPlayer({
+      id: userId,
+      name: info.nickname,
+      avatarUrl: info.avatarUrl,
+      role: info.role as any,
+      isBot: info.isBot,
+    });
+    await addPlayerToRoom(redis, roomCode, {
+      userId,
+      nickname: info.nickname,
+      avatarUrl: info.avatarUrl,
+      role: info.role,
+      isBot: info.isBot,
+    });
+  }
+  pendingSpectatorJoins.delete(roomCode);
+}
+
 async function startNextRound(
   io: SocketIOServer,
   redis: KvStore,
@@ -254,6 +291,7 @@ async function startNextRound(
   persister: GameStatePersister,
 ): Promise<void> {
   nextRoundVotes.delete(roomCode);
+  await processPendingSpectatorJoins(io, redis, roomCode, session);
   session.startNextRound();
   persister.markDirty(roomCode, session.getFullState());
   await Promise.all([
@@ -617,33 +655,27 @@ export function registerGameEvents(
     if (!roomCode || !data.isSpectator) return callback?.({ success: false, error: '非观众' });
     const session = sessions.get(roomCode);
     if (!session) return callback?.({ success: false, error: '游戏会话不存在' });
-    if (!session.isRoundEnd()) return callback?.({ success: false, error: '只能在回合结束时加入' });
-    if (session.getPlayerCount() >= MAX_PLAYERS) return callback?.({ success: false, error: '玩家已满' });
     if (session.getFullState().players.some((p) => p.id === data.user.userId)) {
       return callback?.({ success: false, error: '已在游戏中' });
     }
 
-    data.isSpectator = false;
-    session.addPlayer({
-      id: data.user.userId,
-      name: data.user.nickname,
-      avatarUrl: data.user.avatarUrl,
-      role: data.user.role as any,
-      isBot: data.user.isBot,
-    });
-    await addPlayerToRoom(redis, roomCode, {
-      userId: data.user.userId,
-      nickname: data.user.nickname,
-      avatarUrl: data.user.avatarUrl,
-      role: data.user.role,
-      isBot: data.user.isBot,
-    });
-    persister.markDirty(roomCode, session.getFullState());
+    if (!pendingSpectatorJoins.has(roomCode)) pendingSpectatorJoins.set(roomCode, new Map());
+    const pending = pendingSpectatorJoins.get(roomCode)!;
 
-    const voteState = getNextRoundVoteState(roomCode, session);
-    io.to(roomCode).emit('game:next_round_vote', voteState);
-    await emitGameUpdate(io, roomCode, session, redis);
-    callback?.({ success: true });
+    if (pending.has(data.user.userId)) {
+      pending.delete(data.user.userId);
+      callback?.({ success: true, queued: false });
+    } else {
+      pending.set(data.user.userId, {
+        userId: data.user.userId,
+        nickname: data.user.nickname,
+        avatarUrl: data.user.avatarUrl,
+        role: data.user.role,
+        isBot: data.user.isBot,
+        socketId: socket.id,
+      });
+      callback?.({ success: true, queued: true });
+    }
   });
 
   socket.on('game:kick_player', async (payload: { targetId?: string }, callback) => {
@@ -715,6 +747,7 @@ export function registerGameEvents(
       return callback?.({ success: false, error: '只有房主可以发起再来一局' });
     }
     nextRoundVotes.delete(roomCode);
+    await processPendingSpectatorJoins(io, redis, roomCode, session);
     session.resetForRematch();
     sessions.set(roomCode, session);
     persister.cleanup(roomCode);

--- a/packages/server/src/ws/room-events.ts
+++ b/packages/server/src/ws/room-events.ts
@@ -88,7 +88,7 @@ export function registerRoomEvents(
   socket.on('room:create', async (settings: Partial<RoomSettings>, callback) => {
     const roomSettings: RoomSettings = {
       turnTimeLimit: settings?.turnTimeLimit ?? 30,
-      targetScore: settings?.targetScore ?? 500,
+      targetScore: settings?.targetScore ?? 1000,
       houseRules: settings?.houseRules ?? DEFAULT_HOUSE_RULES,
       allowSpectators: settings?.allowSpectators ?? true,
       spectatorMode: settings?.spectatorMode ?? 'hidden',
@@ -219,7 +219,7 @@ export function registerRoomEvents(
 
     const nextSettings: RoomSettings = {
       turnTimeLimit: settings.turnTimeLimit ?? room.settings.turnTimeLimit ?? 30,
-      targetScore: settings.targetScore ?? room.settings.targetScore ?? 500,
+      targetScore: settings.targetScore ?? room.settings.targetScore ?? 1000,
       houseRules: {
         ...DEFAULT_HOUSE_RULES,
         ...(room.settings.houseRules ?? {}),
@@ -330,7 +330,7 @@ export function registerRoomEvents(
     await touchRoomActivity(redis, roomCode);
     const session = GameSession.create(
       players.map((p) => ({ id: p.userId, name: p.nickname, avatarUrl: p.avatarUrl ?? null, role: p.role as import('@uno-online/shared').UserRole | undefined, isBot: p.isBot })),
-      { turnTimeLimit: room.settings?.turnTimeLimit ?? 30, targetScore: room.settings?.targetScore ?? 500, houseRules: room.settings?.houseRules ?? DEFAULT_HOUSE_RULES, allowSpectators: room.settings?.allowSpectators ?? true, spectatorMode: room.settings?.spectatorMode ?? 'hidden' } as RoomSettings,
+      { turnTimeLimit: room.settings?.turnTimeLimit ?? 30, targetScore: room.settings?.targetScore ?? 1000, houseRules: room.settings?.houseRules ?? DEFAULT_HOUSE_RULES, allowSpectators: room.settings?.allowSpectators ?? true, spectatorMode: room.settings?.spectatorMode ?? 'hidden' } as RoomSettings,
     );
     sessions.set(roomCode, session);
     setGameStartTime(roomCode);

--- a/packages/server/src/ws/socket-handler.ts
+++ b/packages/server/src/ws/socket-handler.ts
@@ -130,8 +130,12 @@ export function setupSocketHandlers(io: SocketIOServer, redis: KvStore, jwtSecre
   }, ROOM_IDLE_SWEEP_MS);
   idleCleanupInterval.unref?.();
 
+  const serverStartTime = new Date().toISOString();
+
   io.on('connection', async (socket) => {
     const userId = socket.data.user.userId;
+
+    socket.emit('server:version', { version: serverStartTime });
 
     // Multi-tab: kick existing connection for same user
     const existingSocketId = userSocketMap.get(userId);

--- a/packages/shared/src/constants/scoring.ts
+++ b/packages/shared/src/constants/scoring.ts
@@ -16,6 +16,6 @@ export function getCardScore(card: Card): number {
   return CARD_SCORES[card.type] as number;
 }
 
-export const DEFAULT_TARGET_SCORE = 500;
+export const DEFAULT_TARGET_SCORE = 1000;
 export const DEFAULT_TURN_TIME_LIMIT = 30;
 export const UNO_PENALTY_CARDS = 2;

--- a/packages/shared/src/rules/setup.ts
+++ b/packages/shared/src/rules/setup.ts
@@ -170,7 +170,7 @@ export function initializeGame(
     deckHash: '',
     settings: {
       turnTimeLimit: DEFAULT_TURN_TIME_LIMIT as 30,
-      targetScore: DEFAULT_TARGET_SCORE as 500,
+      targetScore: DEFAULT_TARGET_SCORE as 1000,
       houseRules: houseRules ?? DEFAULT_HOUSE_RULES,
       allowSpectators: true,
       spectatorMode: 'hidden' as const,

--- a/packages/shared/src/types/game.ts
+++ b/packages/shared/src/types/game.ts
@@ -36,7 +36,7 @@ export interface Player {
 
 export interface RoomSettings {
   turnTimeLimit: 15 | 30 | 60;
-  targetScore: 200 | 300 | 500;
+  targetScore: 200 | 300 | 500 | 1000;
   houseRules: HouseRules;
   allowSpectators: boolean;
   spectatorMode: 'full' | 'hidden';

--- a/packages/shared/src/types/socket-events.ts
+++ b/packages/shared/src/types/socket-events.ts
@@ -47,6 +47,7 @@ export interface ServerToClientEvents {
   'room:spectator_list': (data: { spectators: string[] }) => void;
   'game:cheat_detected': () => void;
   'voice:presence': (presence: Record<string, unknown>) => void;
+  'server:version': (data: { version: string }) => void;
 }
 
 export interface ClientToServerEvents {

--- a/packages/shared/src/types/socket-events.ts
+++ b/packages/shared/src/types/socket-events.ts
@@ -80,5 +80,5 @@ export interface ClientToServerEvents {
   'voice:presence': (data: Record<string, unknown>, callback?: (res: SocketCallbackResult) => void) => void;
   'throw:item': (payload: { targetId: string; item: string }, callback?: (res: SocketCallbackResult) => void) => void;
   'player:toggle-autopilot': (callback?: (res: SocketCallbackResult & { autopilot?: boolean }) => void) => void;
-  'game:spectator_join': (callback?: (res: SocketCallbackResult) => void) => void;
+  'game:spectator_join': (callback?: (res: SocketCallbackResult & { queued?: boolean }) => void) => void;
 }


### PR DESCRIPTION
## Summary
- **浏览器通知**：进入网站时弹窗申请通知权限，页面在后台时发送桌面通知（游戏开始、轮到出牌、游戏结束、被踢出、房间解散），个人资料页可按事件类型自定义开关
- **服务器更新提示**：服务端连接时下发启动时间戳，客户端重连后检测版本变化，弹窗提示刷新页面
- **观战改进**：观战提示栏移至屏幕顶部，观众可随时点击"下局加入"预约，下一回合或再来一局时自动加入，支持取消预约
- **默认获胜分数**：从 500 提高到 1000
- 更新 CLAUDE.md 验证流程文档

## Test plan
- [ ] 进入网站时弹出通知权限弹窗，允许后不再弹出，拒绝后每次进入仍提示
- [ ] 切到后台时，游戏开始/轮到出牌/游戏结束收到桌面通知，前台时不弹
- [ ] 个人资料页通知开关正常，刷新后保持
- [ ] 重启服务器后，已连接的客户端弹出"服务器已更新"刷新提示
- [ ] 观战时提示栏显示在顶部
- [ ] 观战中随时可点"下局加入"预约，按钮变为"取消加入"
- [ ] 回合结束/再来一局时，预约的观众自动加入为玩家
- [ ] 新建房间默认获胜分数为 1000

🤖 Generated with [Claude Code](https://claude.com/claude-code)