### PR TITLE
fix: 质疑阶段叠加 +4 时不弹选色器导致游戏卡死

### DIFF
--- a/packages/client/src/features/game/components/PlayerHand.tsx
+++ b/packages/client/src/features/game/components/PlayerHand.tsx
@@ -146,7 +146,7 @@ export default function PlayerHand({ onPlayCard }: PlayerHandProps) {
   const houseRules = settings?.houseRules;
   const shouldPickColorBeforePlay = (card: CardType) => {
     if (card.type !== 'wild_draw_four' || !houseRules || !topCard) return false;
-    if (drawStack <= 0) return false;
+    if (phase !== 'challenging' && drawStack <= 0) return false;
     const canStack =
       (houseRules.stackDrawFour && topCard.type === 'wild_draw_four') ||
       (houseRules.crossStack && (topCard.type === 'draw_two' || topCard.type === 'wild_draw_four'));


### PR DESCRIPTION
## Summary
- 修复 challenging 阶段叠加 +4 时 `shouldPickColorBeforePlay` 因 `drawStack === 0` 误判不弹选色器，导致无色 +4 发送到服务端后状态死锁的 bug

## Test plan
- [ ] 开启 stackDrawFour 村规，P1 出 +4 选色后，P2 叠加 +4 时应弹出选色器
- [ ] 选色后游戏正常流转到下一位玩家，drawStack 正确累加为 8
- [ ] crossStack 场景下叠加 +4 同样正常弹选色器

🤖 Generated with [Claude Code](https://claude.com/claude-code)