### PR TITLE
feat: 游戏信息展示改善、日志补全、托管节奏优化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,3 +104,14 @@ pnpm --filter server exec tsc --noEmit       # 2. 服务端类型检查
 pnpm --filter client build                   # 3. 客户端构建（含类型检查）
 pnpm test                                    # 4. 运行测试
 ```
+
+### Docker 构建与发布
+
+Dockerfile 包含两个目标镜像：`server`（Node.js 后端）和 `caddy`（前端 + 管理后台静态资源）。
+
+```bash
+docker build --target server -t djkcyl/uno-online-server:latest .   # 构建服务端镜像
+docker build --target caddy -t djkcyl/uno-online-caddy:latest .     # 构建前端镜像
+docker push djkcyl/uno-online-server:latest                         # 推送服务端镜像
+docker push djkcyl/uno-online-caddy:latest                          # 推送前端镜像
+```

--- a/packages/client/src/features/game/components/DrawPile.tsx
+++ b/packages/client/src/features/game/components/DrawPile.tsx
@@ -50,16 +50,6 @@ function DrawPile({ side, isPortrait, onDraw, drawTargetX, drawTargetY, drawAnim
     <div className="flex flex-col items-center gap-1.5 z-card relative min-w-draw-pile-min">
       <DrawCardAnimation trigger={drawAnimTrigger} targetX={drawTargetX} targetY={drawTargetY} />
       <AnimatePresence>
-        {isPenaltyDrawing && canDraw && side === 'left' && (
-          <motion.div
-            className="absolute bottom-hint-bottom left-1/2 -translate-x-1/2 whitespace-nowrap font-game text-caption text-destructive text-shadow-glow"
-            initial={{ opacity: 0, y: 6 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: 6 }}
-          >
-            还要摸 {remainingPenaltyDraws} 张
-          </motion.div>
-        )}
         {showNoPlayableHint && side === 'left' && (
           <motion.div
             className="absolute bottom-hint-bottom left-1/2 -translate-x-1/2 whitespace-nowrap font-game text-caption text-primary text-shadow-glow"

--- a/packages/client/src/features/game/components/GameLogEntry.tsx
+++ b/packages/client/src/features/game/components/GameLogEntry.tsx
@@ -34,6 +34,8 @@ function getActionDescription(entry: LogEntry): string {
     case 'call_uno': return '喊出';
     case 'catch_uno': return '抓到';
     case 'challenge': return '质疑';
+    case 'accept': return '接受';
+    case 'pass': return '过牌';
     default: return '';
   }
 }

--- a/packages/client/src/features/game/components/GameTable.tsx
+++ b/packages/client/src/features/game/components/GameTable.tsx
@@ -237,6 +237,10 @@ export default function GameTable({ onDraw }: GameTableProps) {
     setActiveThrows((prev) => prev.filter((t) => t.id !== id));
   }, []);
 
+  const pendingPenaltyDraws = useGameStore((s) => s.pendingPenaltyDraws);
+  const drawStack = useGameStore((s) => s.drawStack);
+  const remainingPenaltyDraws = pendingPenaltyDraws > 0 ? pendingPenaltyDraws : drawStack;
+
   const isClockwise = direction === 'clockwise';
 
   return (
@@ -324,6 +328,21 @@ export default function GameTable({ onDraw }: GameTableProps) {
           />
         );
       })()}
+
+      {/* Penalty draw hint centered above table */}
+      <AnimatePresence>
+        {remainingPenaltyDraws > 0 && dimensions.width > 0 && (
+          <motion.div
+            className="absolute left-1/2 -translate-x-1/2 z-card pointer-events-none whitespace-nowrap font-game text-lg font-bold text-destructive text-shadow-glow"
+            style={{ top: dimensions.height / 2 - 90 }}
+            initial={{ opacity: 0, y: 6 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 6 }}
+          >
+            还要摸 {remainingPenaltyDraws} 张
+          </motion.div>
+        )}
+      </AnimatePresence>
 
       {/* Player nodes */}
       {playerPositions.map((pos, i) => {

--- a/packages/client/src/features/game/components/TopBar.tsx
+++ b/packages/client/src/features/game/components/TopBar.tsx
@@ -103,14 +103,14 @@ export default function TopBar({ roomCode }: TopBarProps) {
   };
 
   return (
-    <div className="flex justify-between items-center px-4 py-2 bg-black/30 text-caption z-topbar">
+    <div className="grid grid-cols-[1fr_auto_1fr] items-center px-4 py-2 bg-black/30 text-caption z-topbar">
       <div className="flex items-center gap-3">
         <span className="font-bold text-primary font-game"><Spade size={18} className="inline align-middle" /> UNO Online</span>
         <span className="text-muted-foreground">房间: {roomCode}</span>
         <span className="text-muted-foreground/50 text-xs hidden md:inline">v{BUILD_VERSION}</span>
       </div>
       <GameStatus />
-      <div className="flex items-center gap-3">
+      <div className="flex items-center gap-3 justify-end">
         <button
           onClick={toggleInfoDrawer}
           className="hidden md:inline bg-transparent border-none text-sm cursor-pointer text-muted-foreground hover:text-accent transition-colors"

--- a/packages/client/src/features/game/hooks/useGameLogTracker.ts
+++ b/packages/client/src/features/game/hooks/useGameLogTracker.ts
@@ -112,11 +112,37 @@ export function useGameLogTracker(): void {
     } else if (lastAction.type === 'CHALLENGE') {
       const player = findPlayer(lastAction.playerId);
       if (!player) return;
+      const succeeded = lastAction.succeeded;
+      const penaltyPlayer = lastAction.penaltyPlayerId ? findPlayer(lastAction.penaltyPlayerId) : undefined;
+      const penaltyCount = lastAction.penaltyCount;
+      let extra = '+4';
+      if (succeeded !== undefined && penaltyPlayer && penaltyCount) {
+        extra = succeeded
+          ? `成功，${penaltyPlayer.name} 罚摸 ${penaltyCount} 张`
+          : `失败，${player.name} 罚摸 ${penaltyCount} 张`;
+      }
       addLogEntry({
         type: 'challenge',
         playerId: lastAction.playerId,
         playerName: player.name,
-        extra: '质疑 +4',
+        extra,
+      });
+    } else if (lastAction.type === 'ACCEPT') {
+      const player = findPlayer(lastAction.playerId);
+      if (!player) return;
+      addLogEntry({
+        type: 'accept',
+        playerId: lastAction.playerId,
+        playerName: player.name,
+        extra: '+4',
+      });
+    } else if (lastAction.type === 'PASS') {
+      const player = findPlayer(lastAction.playerId);
+      if (!player) return;
+      addLogEntry({
+        type: 'pass',
+        playerId: lastAction.playerId,
+        playerName: player.name,
       });
     }
   }, [lastAction, players, discardPile, addLogEntry]);

--- a/packages/client/src/features/game/stores/game-log-store.ts
+++ b/packages/client/src/features/game/stores/game-log-store.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import type { Card } from '@uno-online/shared';
 
-export type GameLogEntryType = 'play_skip' | 'play_reverse' | 'play_draw_two' | 'play_wild' | 'play_wild_draw_four' | 'play_number' | 'call_uno' | 'catch_uno' | 'challenge' | 'draw' | 'round_separator';
+export type GameLogEntryType = 'play_skip' | 'play_reverse' | 'play_draw_two' | 'play_wild' | 'play_wild_draw_four' | 'play_number' | 'call_uno' | 'catch_uno' | 'challenge' | 'accept' | 'pass' | 'draw' | 'round_separator';
 
 export interface GameLogEntry {
   id: string;

--- a/packages/server/src/ws/room-events.ts
+++ b/packages/server/src/ws/room-events.ts
@@ -15,7 +15,7 @@ import { dissolveRoom } from './room-lifecycle.js';
 import { removeVoicePresence, setForceMuted } from './voice-presence.js';
 import { getAutopilotActionPlayerId } from './autopilot-action-player.js';
 
-const DRAW_PENALTY_PAUSE_MS = 500;
+const AUTOPILOT_MIN_ACTION_INTERVAL_MS = 500;
 const AUTO_AUTOPILOT_THRESHOLD = 2;
 const BOT_TURN_TIME_LIMIT = 120;
 type AutopilotActionHandler = (roomCode: string, session: GameSession, action: GameAction) => void;
@@ -66,12 +66,6 @@ function canAutopilotActForPlayer(session: GameSession, playerId: string): boole
   return getAutopilotActionPlayerId(state) === playerId;
 }
 
-function shouldPauseAfterAction(before: GameState, session: GameSession, action: GameAction): boolean {
-  if (action.type === 'DRAW_CARD' && (before.pendingPenaltyDraws ?? 0) > 0) return true;
-  if (action.type !== 'PLAY_CARD') return false;
-  const topCard = session.getFullState().discardPile.at(-1);
-  return topCard?.type === 'draw_two' || topCard?.type === 'wild_draw_four';
-}
 
 export function registerRoomEvents(
   socket: Socket,
@@ -394,6 +388,7 @@ export async function executeAutopilot(
   onActionSuccess?: (action: GameAction) => void | Promise<void>,
 ): Promise<boolean> {
   let acted = false;
+  let lastActionTime = 0;
   for (let round = 0; round < 5; round++) {
     if (!canAutopilotActForPlayer(session, playerId)) break;
 
@@ -402,15 +397,18 @@ export async function executeAutopilot(
     if (actions.length === 0) break;
     let anySuccess = false;
     for (const action of actions) {
-      const beforeAction = session.getFullState();
+      if (lastActionTime > 0) {
+        const elapsed = Date.now() - lastActionTime;
+        if (elapsed < AUTOPILOT_MIN_ACTION_INTERVAL_MS) {
+          await sleep(AUTOPILOT_MIN_ACTION_INTERVAL_MS - elapsed);
+        }
+      }
       const result = session.applyAction(action);
       if (result.success) {
+        lastActionTime = Date.now();
         anySuccess = true;
         await onActionSuccess?.(action);
-        if (shouldPauseAfterAction(beforeAction, session, action)) {
-          await onPenaltyPause?.();
-          await sleep(DRAW_PENALTY_PAUSE_MS);
-        }
+        await onPenaltyPause?.();
       }
     }
     if (!anySuccess) break;
@@ -463,7 +461,7 @@ export function startTurnTimer(
   const immediateAutopilotPlayerId = getImmediateAutopilotPlayerId(state);
 
   if (immediateAutopilotPlayerId) {
-    turnTimer.start(roomCode, 2, async (code) => {
+    turnTimer.start(roomCode, 1, async (code) => {
       const s = sessions.get(code);
       if (!s) return;
       const pid = getImmediateAutopilotPlayerId(s.getFullState());


### PR DESCRIPTION
## Summary
- 罚牌提示移至游戏桌中央上方，所有玩家可见（原先只显示在左牌堆上且仅当事人可见）
- TopBar GameStatus 改为 grid 居中布局
- 游戏日志补全 ACCEPT、PASS 记录，质疑日志显示成功/失败及罚摸详情
- 托管操作最少 500ms 间隔，初始思考时间从 2s 降为 1s
- CLAUDE.md 补充 Docker 构建与发布流程

## Test plan
- [ ] 罚牌（+2/+4/叠加）时所有玩家都能看到中央的"还要摸 X 张"提示
- [ ] TopBar 状态栏在不同屏幕宽度下保持居中
- [ ] 游戏日志中出现接受、过牌、质疑结果记录
- [ ] 托管模式下操作节奏均匀，不再瞬间连续出牌

🤖 Generated with [Claude Code](https://claude.com/claude-code)