### PR TITLE
feat: 8-bit 程序化 BGM 系统

### DIFF
--- a/packages/client/src/features/game/components/GameTable.tsx
+++ b/packages/client/src/features/game/components/GameTable.tsx
@@ -334,7 +334,7 @@ export default function GameTable({ onDraw }: GameTableProps) {
         {remainingPenaltyDraws > 0 && dimensions.width > 0 && (
           <motion.div
             className="absolute left-1/2 -translate-x-1/2 z-card pointer-events-none whitespace-nowrap font-game text-lg font-bold text-destructive text-shadow-glow"
-            style={{ top: dimensions.height / 2 - 90 }}
+            style={{ top: dimensions.height / 2 - 130 }}
             initial={{ opacity: 0, y: 6 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: 6 }}

--- a/packages/client/src/features/game/components/TopBar.tsx
+++ b/packages/client/src/features/game/components/TopBar.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Eye, Volume2, VolumeX, Spade, DoorOpen, Bot, HelpCircle } from 'lucide-react';
+import { Eye, Volume2, VolumeX, Music, Spade, DoorOpen, Bot, HelpCircle } from 'lucide-react';
 import type { Card, Color } from '@uno-online/shared';
 import TurnTimer from './TurnTimer';
 import { useSettingsStore } from '@/shared/stores/settings-store';
@@ -81,7 +81,7 @@ function GameStatus() {
 interface TopBarProps { roomCode: string; }
 
 export default function TopBar({ roomCode }: TopBarProps) {
-  const { colorBlindMode, toggleColorBlind, soundEnabled, toggleSound } = useSettingsStore();
+  const { colorBlindMode, toggleColorBlind, soundEnabled, toggleSound, bgmEnabled, toggleBgm } = useSettingsStore();
   const ownerId = useRoomStore((s) => s.room?.ownerId);
   const userId = useEffectiveUserId();
   const isHost = ownerId === userId;
@@ -138,6 +138,16 @@ export default function TopBar({ roomCode }: TopBarProps) {
           title={colorBlindMode ? '关闭色盲模式' : '开启色盲模式'}
         >
           <Eye size={16} />
+        </button>
+        <button
+          onClick={toggleBgm}
+          className={cn(
+            'bg-transparent border-none text-sm cursor-pointer',
+            bgmEnabled ? 'text-accent' : 'text-muted-foreground'
+          )}
+          title={bgmEnabled ? '关闭背景音乐' : '开启背景音乐'}
+        >
+          <Music size={16} />
         </button>
         <button
           onClick={toggleSound}

--- a/packages/client/src/features/game/pages/GamePage.tsx
+++ b/packages/client/src/features/game/pages/GamePage.tsx
@@ -228,7 +228,7 @@ export default function GamePage() {
         <ScoreBoard onPlayAgain={playAgain} onRematch={rematch} onBackToLobby={backToLobby} onKickPlayer={kickPlayer} />
       )}
       {cheatDetected && <CheatOverlay />}
-      <BgmToast songName={bgmSongName} />
+      <BgmToast song={bgmSongName} />
     </div>
   );
 }

--- a/packages/client/src/features/game/pages/GamePage.tsx
+++ b/packages/client/src/features/game/pages/GamePage.tsx
@@ -11,6 +11,8 @@ import { useGameLogTracker } from '../hooks/useGameLogTracker';
 import { useAutoPlay } from '../hooks/useAutoPlay';
 import { useGameActions } from '../hooks/useGameActions';
 import { playSound } from '@/shared/sound/sound-manager';
+import { useBgm } from '@/shared/sound/useBgm';
+import BgmToast from '@/shared/components/BgmToast';
 import { getSocket, refreshVoicePresence } from '@/shared/socket';
 import { leaveVoiceSession } from '@/shared/voice/voice-runtime';
 import { useRoomStore } from '@/shared/stores/room-store';
@@ -53,6 +55,7 @@ export default function GamePage() {
 
   const connectionStatus = useGameSocket(roomCode);
   useGameLogTracker();
+  const bgmSongName = useBgm('game');
   const [showStartRules, setShowStartRules] = useState(false);
   const shownStartRulesRef = useRef<string | null>(null);
   const [antiCheatKey, setAntiCheatKey] = useState<string | null>(null);
@@ -225,6 +228,7 @@ export default function GamePage() {
         <ScoreBoard onPlayAgain={playAgain} onRematch={rematch} onBackToLobby={backToLobby} onKickPlayer={kickPlayer} />
       )}
       {cheatDetected && <CheatOverlay />}
+      <BgmToast songName={bgmSongName} />
     </div>
   );
 }

--- a/packages/client/src/features/lobby/pages/LobbyPage.tsx
+++ b/packages/client/src/features/lobby/pages/LobbyPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Spade, LogOut, User, Hexagon, Circle, Upload, X, Type, Eye, History, Users, Clock, ClipboardPaste } from 'lucide-react';
+import { Spade, LogOut, User, Hexagon, Circle, Upload, X, Type, Eye, History, Users, Clock, ClipboardPaste, Music } from 'lucide-react';
 import { useAuthStore } from '@/features/auth/stores/auth-store';
 import { getRoleColor } from '@/shared/lib/utils';
 import { useRoomStore } from '@/shared/stores/room-store';
@@ -12,6 +12,10 @@ import { Input } from '@/shared/components/ui/Input';
 import { BUILD_VERSION } from '@/shared/build-info';
 import { ServerButton } from '@/shared/components/ServerButton';
 import { ServerSelectModal } from '@/shared/components/ServerSelectModal';
+import { useBgm } from '@/shared/sound/useBgm';
+import TutorialModal from '@/shared/components/TutorialModal';
+import BgmToast from '@/shared/components/BgmToast';
+import MusicHallModal from '@/shared/components/MusicHallModal';
 import { useLobbyStore } from '../stores/lobby-store';
 
 export default function LobbyPage() {
@@ -24,6 +28,8 @@ export default function LobbyPage() {
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
   const { activeRooms, recentGames, fetchActiveRooms, fetchRecentGames } = useLobbyStore();
+  const songName = useBgm('lobby');
+  const [musicHall, setMusicHall] = useState(false);
 
   useEffect(() => {
     fetchActiveRooms();
@@ -270,11 +276,21 @@ export default function LobbyPage() {
             <Hexagon size={14} />
           </button>
         </div>
+        <button
+          onClick={() => setMusicHall(true)}
+          className="bg-card text-foreground border border-white/20 rounded-lg px-2.5 py-1.5 text-sm cursor-pointer flex items-center gap-1"
+          title="音乐厅"
+        >
+          <Music size={14} /> 音乐厅
+        </button>
         <ServerButton />
         <span className="text-xs text-muted-foreground/50">v{BUILD_VERSION}</span>
       </div>
 
       <ServerSelectModal />
+      <TutorialModal />
+      <BgmToast songName={songName} />
+      <MusicHallModal open={musicHall} onClose={() => setMusicHall(false)} currentScene="lobby" />
     </div>
   );
 }

--- a/packages/client/src/features/lobby/pages/LobbyPage.tsx
+++ b/packages/client/src/features/lobby/pages/LobbyPage.tsx
@@ -219,6 +219,13 @@ export default function LobbyPage() {
 
       {/* Settings + version */}
       <div className="absolute bottom-6 right-6 flex items-center gap-3">
+        <button
+          onClick={() => setMusicHall(true)}
+          className="bg-card text-foreground border border-white/20 rounded-lg px-2.5 py-1.5 text-sm cursor-pointer flex items-center gap-1"
+          title="音乐厅"
+        >
+          <Music size={14} /> 音乐厅
+        </button>
         {cardImagePack && isPackLoaded() ? (
           <button
             onClick={() => { clearCardPack(); setCardImagePack(false); }}
@@ -276,20 +283,16 @@ export default function LobbyPage() {
             <Hexagon size={14} />
           </button>
         </div>
-        <button
-          onClick={() => setMusicHall(true)}
-          className="bg-card text-foreground border border-white/20 rounded-lg px-2.5 py-1.5 text-sm cursor-pointer flex items-center gap-1"
-          title="音乐厅"
-        >
-          <Music size={14} /> 音乐厅
-        </button>
+      </div>
+
+      <div className="absolute bottom-6 left-6 flex items-center gap-3">
         <ServerButton />
         <span className="text-xs text-muted-foreground/50">v{BUILD_VERSION}</span>
       </div>
 
       <ServerSelectModal />
       <TutorialModal />
-      <BgmToast songName={songName} />
+      <BgmToast song={songName} />
       <MusicHallModal open={musicHall} onClose={() => setMusicHall(false)} currentScene="lobby" />
     </div>
   );

--- a/packages/client/src/shared/components/BgmToast.tsx
+++ b/packages/client/src/shared/components/BgmToast.tsx
@@ -1,22 +1,23 @@
 import { useEffect, useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { Music } from 'lucide-react';
+import type { SongInfo } from '@/shared/sound/bgm-engine';
 
 interface Props {
-  songName: string | null;
+  song: SongInfo | null;
 }
 
-export default function BgmToast({ songName }: Props) {
+export default function BgmToast({ song }: Props) {
   const [visible, setVisible] = useState(false);
-  const [display, setDisplay] = useState<string | null>(null);
+  const [display, setDisplay] = useState<SongInfo | null>(null);
 
   useEffect(() => {
-    if (!songName) return;
-    setDisplay(songName);
+    if (!song) return;
+    setDisplay(song);
     setVisible(true);
     const timer = setTimeout(() => setVisible(false), 3000);
     return () => clearTimeout(timer);
-  }, [songName]);
+  }, [song]);
 
   return (
     <AnimatePresence>
@@ -29,7 +30,8 @@ export default function BgmToast({ songName }: Props) {
           className="fixed top-4 left-4 z-50 flex items-center gap-2 rounded-lg bg-black/60 px-3 py-1.5 backdrop-blur-sm pointer-events-none"
         >
           <Music size={12} className="text-accent shrink-0" />
-          <span className="text-xs text-white/80">{display}</span>
+          <span className="text-xs text-white/80">{display.name}</span>
+          <span className="text-2xs text-white/40">— {display.meta.author}</span>
         </motion.div>
       )}
     </AnimatePresence>

--- a/packages/client/src/shared/components/BgmToast.tsx
+++ b/packages/client/src/shared/components/BgmToast.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { Music } from 'lucide-react';
+
+interface Props {
+  songName: string | null;
+}
+
+export default function BgmToast({ songName }: Props) {
+  const [visible, setVisible] = useState(false);
+  const [display, setDisplay] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!songName) return;
+    setDisplay(songName);
+    setVisible(true);
+    const timer = setTimeout(() => setVisible(false), 3000);
+    return () => clearTimeout(timer);
+  }, [songName]);
+
+  return (
+    <AnimatePresence>
+      {visible && display && (
+        <motion.div
+          initial={{ opacity: 0, x: -20 }}
+          animate={{ opacity: 1, x: 0 }}
+          exit={{ opacity: 0, x: -20 }}
+          transition={{ duration: 0.3 }}
+          className="fixed top-4 left-4 z-50 flex items-center gap-2 rounded-lg bg-black/60 px-3 py-1.5 backdrop-blur-sm pointer-events-none"
+        >
+          <Music size={12} className="text-accent shrink-0" />
+          <span className="text-xs text-white/80">{display}</span>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/packages/client/src/shared/components/MusicHallModal.tsx
+++ b/packages/client/src/shared/components/MusicHallModal.tsx
@@ -1,0 +1,187 @@
+import { useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { Music, X, Play, Square } from 'lucide-react';
+import { cn } from '@/shared/lib/utils';
+import { bgm } from '@/shared/sound/bgm-engine';
+
+interface SongMeta {
+  name: string;
+  bpm: string;
+  key: string;
+  style: string;
+  wave: string;
+}
+
+const GAME_SONGS: SongMeta[] = [
+  { name: 'UNO Bounce',  bpm: '138', key: 'C 大调', style: '弹跳琶音',   wave: '方波' },
+  { name: 'Reverse!',    bpm: '128', key: 'A 小调', style: '切分律动',   wave: '方波' },
+  { name: 'Draw Four!',  bpm: '144', key: 'A 小调', style: '高速连奏',   wave: '方波' },
+  { name: 'Color Wheel', bpm: '120', key: 'C 大调', style: '回旋轮盘',   wave: '方波' },
+  { name: 'Wild Card',   bpm: '148', key: 'A 小调', style: '极速冲刺',   wave: '方波' },
+  { name: 'Blitz',       bpm: '135', key: 'G 大调', style: '进行曲',     wave: '锯齿波' },
+  { name: 'Carnival',    bpm: '132', key: 'F 大调', style: '拉丁嘉年华', wave: '正弦波' },
+  { name: 'Midnight',    bpm: '116', key: 'D 小调', style: '暗夜氛围',   wave: '方波' },
+  { name: 'Pulse',       bpm: '140', key: 'A 小调', style: '纯节奏',     wave: '方波' },
+  { name: 'Minuet',      bpm: '108', key: 'C 大调', style: '巴洛克小步舞', wave: '三角波' },
+];
+
+const LOBBY_SONGS: SongMeta[] = [
+  { name: 'Shuffle',      bpm: '96', key: 'C 大调', style: '轻快摇曳',   wave: '方波' },
+  { name: 'Daydream',     bpm: '88', key: 'C 大调', style: '空灵梦幻',   wave: '方波' },
+  { name: 'Waiting Room', bpm: '92', key: 'C 大调', style: '温暖柔和',   wave: '方波' },
+  { name: 'Breeze',       bpm: '84', key: 'G 大调', style: '田园清风',   wave: '正弦波' },
+  { name: 'Sunset',       bpm: '78', key: 'F 大调', style: '日落音乐盒', wave: '三角波' },
+  { name: 'Nocturne',     bpm: '72', key: 'Am/C',  style: '浪漫夜曲',   wave: '正弦波' },
+];
+
+const TABS = [
+  { key: 'game' as const, label: '游戏曲目', songs: GAME_SONGS },
+  { key: 'lobby' as const, label: '大厅曲目', songs: LOBBY_SONGS },
+];
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  currentScene: string;
+}
+
+export default function MusicHallModal({ open, onClose, currentScene }: Props) {
+  const [tab, setTab] = useState<'game' | 'lobby'>('game');
+  const [playing, setPlaying] = useState<string | null>(null);
+
+  const play = (scene: string, index: number) => {
+    const key = `${scene}:${index}`;
+    if (playing === key) {
+      bgm.start(currentScene);
+      setPlaying(null);
+    } else {
+      bgm.playSingle(scene, index);
+      setPlaying(key);
+    }
+  };
+
+  const close = () => {
+    if (playing) bgm.start(currentScene);
+    setPlaying(null);
+    onClose();
+  };
+
+  if (!open) return null;
+
+  const current = TABS.find((t) => t.key === tab)!;
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <div className="fixed inset-0 z-modal flex items-center justify-center px-4">
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="absolute inset-0 bg-black/55"
+            onClick={close}
+          />
+
+          <motion.div
+            initial={{ opacity: 0, scale: 0.94, y: 8 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.94, y: 8 }}
+            transition={{ duration: 0.2 }}
+            className="relative w-full max-w-[460px] rounded-2xl bg-card shadow-2xl border border-white/[0.08]"
+          >
+            <div className="flex items-center justify-between border-b border-white/[0.08] px-6 py-4">
+              <div className="flex items-center gap-2 text-lg font-bold font-game">
+                <Music size={18} className="text-accent" /> 音乐厅
+              </div>
+              <button onClick={close} className="p-1 text-muted-foreground hover:text-foreground">
+                <X size={18} />
+              </button>
+            </div>
+
+            <div className="flex border-b border-white/[0.08]">
+              {TABS.map((t) => (
+                <button
+                  key={t.key}
+                  onClick={() => setTab(t.key)}
+                  className={cn(
+                    'flex-1 py-2.5 text-sm font-bold transition-colors',
+                    tab === t.key
+                      ? 'text-accent border-b-2 border-accent'
+                      : 'text-muted-foreground hover:text-foreground',
+                  )}
+                >
+                  {t.label}
+                  <span className="ml-1 text-xs opacity-50">({t.songs.length})</span>
+                </button>
+              ))}
+            </div>
+
+            <div className="max-h-[50vh] overflow-y-auto p-3 scrollbar-thin">
+              <div className="flex flex-col gap-1.5">
+                {current.songs.map((song, i) => {
+                  const key = `${tab}:${i}`;
+                  const isPlaying = playing === key;
+                  return (
+                    <button
+                      key={key}
+                      onClick={() => play(tab, i)}
+                      className={cn(
+                        'flex items-center gap-3 rounded-xl px-4 py-3 text-left transition-all w-full',
+                        isPlaying
+                          ? 'bg-accent/15 border border-accent/30'
+                          : 'bg-white/[0.03] border border-transparent hover:bg-white/[0.06]',
+                      )}
+                    >
+                      <div className={cn(
+                        'flex items-center justify-center w-8 h-8 rounded-full shrink-0 transition-colors',
+                        isPlaying ? 'bg-accent text-white' : 'bg-white/10 text-muted-foreground',
+                      )}>
+                        {isPlaying ? <Square size={12} /> : <Play size={12} className="ml-0.5" />}
+                      </div>
+
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2">
+                          <span className={cn('text-sm font-bold truncate', isPlaying && 'text-accent')}>
+                            {song.name}
+                          </span>
+                          {isPlaying && (
+                            <span className="flex gap-0.5 shrink-0">
+                              {[0, 1, 2].map((j) => (
+                                <motion.span
+                                  key={j}
+                                  className="inline-block w-0.5 bg-accent rounded-full"
+                                  animate={{ height: [4, 12, 4] }}
+                                  transition={{ duration: 0.6, repeat: Infinity, delay: j * 0.15 }}
+                                />
+                              ))}
+                            </span>
+                          )}
+                        </div>
+                        <div className="flex items-center gap-2 mt-0.5 text-2xs text-muted-foreground">
+                          <span>{song.bpm} BPM</span>
+                          <span className="opacity-40">·</span>
+                          <span>{song.key}</span>
+                          <span className="opacity-40">·</span>
+                          <span>{song.style}</span>
+                          <span className="opacity-40">·</span>
+                          <span>{song.wave}</span>
+                        </div>
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div className="border-t border-white/[0.08] px-5 py-3">
+              <p className="text-center text-2xs text-muted-foreground">
+                点击曲目试听，关闭后自动恢复背景音乐
+              </p>
+            </div>
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/packages/client/src/shared/components/MusicHallModal.tsx
+++ b/packages/client/src/shared/components/MusicHallModal.tsx
@@ -44,116 +44,105 @@ export default function MusicHallModal({ open, onClose, currentScene }: Props) {
   return (
     <AnimatePresence>
       {open && (
-        <div className="fixed inset-0 z-modal flex items-center justify-center px-4">
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.2 }}
-            className="absolute inset-0 bg-black/55"
-            onClick={close}
-          />
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.3 }}
+          className="fixed inset-0 z-modal flex flex-col bg-gradient-to-b from-slate-950 via-slate-900 to-slate-950"
+        >
+          <div className="flex items-center justify-between px-6 py-5 shrink-0">
+            <div className="flex items-center gap-3 text-xl sm:text-2xl font-bold font-game text-foreground">
+              <Music size={24} className="text-accent" /> 音乐厅
+            </div>
+            <button onClick={close} className="p-2 rounded-lg text-muted-foreground hover:text-foreground hover:bg-white/5 transition-colors">
+              <X size={20} />
+            </button>
+          </div>
 
-          <motion.div
-            initial={{ opacity: 0, scale: 0.94, y: 8 }}
-            animate={{ opacity: 1, scale: 1, y: 0 }}
-            exit={{ opacity: 0, scale: 0.94, y: 8 }}
-            transition={{ duration: 0.2 }}
-            className="relative w-full max-w-[460px] rounded-2xl bg-card shadow-2xl border border-white/[0.08]"
-          >
-            <div className="flex items-center justify-between border-b border-white/[0.08] px-6 py-4">
-              <div className="flex items-center gap-2 text-lg font-bold font-game">
-                <Music size={18} className="text-accent" /> 音乐厅
-              </div>
-              <button onClick={close} className="p-1 text-muted-foreground hover:text-foreground">
-                <X size={18} />
+          <div className="flex justify-center gap-1 px-6 mb-4 shrink-0">
+            {TABS.map((t) => (
+              <button
+                key={t.key}
+                onClick={() => setTab(t.key)}
+                className={cn(
+                  'px-6 py-2.5 rounded-lg text-sm font-bold transition-all',
+                  tab === t.key
+                    ? 'bg-accent/15 text-accent'
+                    : 'text-muted-foreground hover:text-foreground hover:bg-white/5',
+                )}
+              >
+                {t.label}
+                <span className="ml-1.5 text-xs opacity-50">({(PLAYLISTS[t.key] ?? []).length})</span>
               </button>
-            </div>
+            ))}
+          </div>
 
-            <div className="flex border-b border-white/[0.08]">
-              {TABS.map((t) => (
-                <button
-                  key={t.key}
-                  onClick={() => setTab(t.key)}
-                  className={cn(
-                    'flex-1 py-2.5 text-sm font-bold transition-colors',
-                    tab === t.key
-                      ? 'text-accent border-b-2 border-accent'
-                      : 'text-muted-foreground hover:text-foreground',
-                  )}
-                >
-                  {t.label}
-                  <span className="ml-1 text-xs opacity-50">({(PLAYLISTS[t.key] ?? []).length})</span>
-                </button>
-              ))}
-            </div>
+          <div className="flex-1 overflow-y-auto px-6 py-2 scrollbar-thin">
+            <div className="max-w-2xl mx-auto grid gap-2 sm:grid-cols-2">
+              {songs.map((song, i) => {
+                const key = `${tab}:${i}`;
+                const isPlaying = playing === key;
+                return (
+                  <motion.button
+                    key={key}
+                    layout
+                    onClick={() => play(tab, i)}
+                    className={cn(
+                      'flex items-center gap-4 rounded-xl px-5 py-4 text-left transition-all w-full',
+                      isPlaying
+                        ? 'bg-accent/10 border border-accent/25'
+                        : 'bg-white/[0.03] border border-white/[0.06] hover:bg-white/[0.06]',
+                    )}
+                  >
+                    <div className={cn(
+                      'flex items-center justify-center w-11 h-11 rounded-full shrink-0 transition-colors',
+                      isPlaying ? 'bg-accent text-white' : 'bg-white/10 text-muted-foreground',
+                    )}>
+                      {isPlaying ? <Square size={14} /> : <Play size={14} className="ml-0.5" />}
+                    </div>
 
-            <div className="max-h-[50vh] overflow-y-auto p-3 scrollbar-thin">
-              <div className="flex flex-col gap-1.5">
-                {songs.map((song, i) => {
-                  const key = `${tab}:${i}`;
-                  const isPlaying = playing === key;
-                  return (
-                    <button
-                      key={key}
-                      onClick={() => play(tab, i)}
-                      className={cn(
-                        'flex items-center gap-3 rounded-xl px-4 py-3 text-left transition-all w-full',
-                        isPlaying
-                          ? 'bg-accent/15 border border-accent/30'
-                          : 'bg-white/[0.03] border border-transparent hover:bg-white/[0.06]',
-                      )}
-                    >
-                      <div className={cn(
-                        'flex items-center justify-center w-8 h-8 rounded-full shrink-0 transition-colors',
-                        isPlaying ? 'bg-accent text-white' : 'bg-white/10 text-muted-foreground',
-                      )}>
-                        {isPlaying ? <Square size={12} /> : <Play size={12} className="ml-0.5" />}
-                      </div>
-
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center gap-2">
-                          <span className={cn('text-sm font-bold truncate', isPlaying && 'text-accent')}>
-                            {song.name}
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2">
+                        <span className={cn('text-sm font-bold truncate', isPlaying && 'text-accent')}>
+                          {song.name}
+                        </span>
+                        <span className="text-2xs text-muted-foreground shrink-0">— {song.meta.author}</span>
+                        {isPlaying && (
+                          <span className="flex gap-0.5 shrink-0">
+                            {[0, 1, 2].map((j) => (
+                              <motion.span
+                                key={j}
+                                className="inline-block w-0.5 bg-accent rounded-full"
+                                animate={{ height: [4, 14, 4] }}
+                                transition={{ duration: 0.6, repeat: Infinity, delay: j * 0.15 }}
+                              />
+                            ))}
                           </span>
-                          {isPlaying && (
-                            <span className="flex gap-0.5 shrink-0">
-                              {[0, 1, 2].map((j) => (
-                                <motion.span
-                                  key={j}
-                                  className="inline-block w-0.5 bg-accent rounded-full"
-                                  animate={{ height: [4, 12, 4] }}
-                                  transition={{ duration: 0.6, repeat: Infinity, delay: j * 0.15 }}
-                                />
-                              ))}
-                            </span>
-                          )}
-                        </div>
-                        <div className="flex items-center gap-2 mt-0.5 text-2xs text-muted-foreground">
-                          <span>{song.bpm} BPM</span>
-                          <span className="opacity-40">·</span>
-                          <span>{song.meta.key}</span>
-                          <span className="opacity-40">·</span>
-                          <span>{song.meta.style}</span>
-                          <span className="opacity-40">·</span>
-                          <span>{song.meta.wave}</span>
-                          <span className="opacity-40">·</span>
-                          <span>{song.meta.author}</span>
-                        </div>
+                        )}
                       </div>
-                    </button>
-                  );
-                })}
-              </div>
+                      <div className="flex items-center gap-2 mt-1 text-xs text-muted-foreground">
+                        <span>{song.bpm} BPM</span>
+                        <span className="opacity-30">·</span>
+                        <span>{song.meta.key}</span>
+                        <span className="opacity-30">·</span>
+                        <span>{song.meta.style}</span>
+                        <span className="opacity-30">·</span>
+                        <span>{song.meta.wave}</span>
+                      </div>
+                    </div>
+                  </motion.button>
+                );
+              })}
             </div>
+          </div>
 
-            <div className="border-t border-white/[0.08] px-5 py-3">
-              <p className="text-center text-2xs text-muted-foreground">
-                点击曲目试听，关闭后自动恢复背景音乐
-              </p>
-            </div>
-          </motion.div>
-        </div>
+          <div className="shrink-0 px-6 py-4">
+            <p className="text-center text-xs text-muted-foreground/60">
+              点击曲目试听 · 关闭后自动恢复背景音乐
+            </p>
+          </div>
+        </motion.div>
       )}
     </AnimatePresence>
   );

--- a/packages/client/src/shared/components/MusicHallModal.tsx
+++ b/packages/client/src/shared/components/MusicHallModal.tsx
@@ -3,40 +3,11 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { Music, X, Play, Square } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
 import { bgm } from '@/shared/sound/bgm-engine';
-
-interface SongMeta {
-  name: string;
-  bpm: string;
-  key: string;
-  style: string;
-  wave: string;
-}
-
-const GAME_SONGS: SongMeta[] = [
-  { name: 'UNO Bounce',  bpm: '138', key: 'C 大调', style: '弹跳琶音',   wave: '方波' },
-  { name: 'Reverse!',    bpm: '128', key: 'A 小调', style: '切分律动',   wave: '方波' },
-  { name: 'Draw Four!',  bpm: '144', key: 'A 小调', style: '高速连奏',   wave: '方波' },
-  { name: 'Color Wheel', bpm: '120', key: 'C 大调', style: '回旋轮盘',   wave: '方波' },
-  { name: 'Wild Card',   bpm: '148', key: 'A 小调', style: '极速冲刺',   wave: '方波' },
-  { name: 'Blitz',       bpm: '135', key: 'G 大调', style: '进行曲',     wave: '锯齿波' },
-  { name: 'Carnival',    bpm: '132', key: 'F 大调', style: '拉丁嘉年华', wave: '正弦波' },
-  { name: 'Midnight',    bpm: '116', key: 'D 小调', style: '暗夜氛围',   wave: '方波' },
-  { name: 'Pulse',       bpm: '140', key: 'A 小调', style: '纯节奏',     wave: '方波' },
-  { name: 'Minuet',      bpm: '108', key: 'C 大调', style: '巴洛克小步舞', wave: '三角波' },
-];
-
-const LOBBY_SONGS: SongMeta[] = [
-  { name: 'Shuffle',      bpm: '96', key: 'C 大调', style: '轻快摇曳',   wave: '方波' },
-  { name: 'Daydream',     bpm: '88', key: 'C 大调', style: '空灵梦幻',   wave: '方波' },
-  { name: 'Waiting Room', bpm: '92', key: 'C 大调', style: '温暖柔和',   wave: '方波' },
-  { name: 'Breeze',       bpm: '84', key: 'G 大调', style: '田园清风',   wave: '正弦波' },
-  { name: 'Sunset',       bpm: '78', key: 'F 大调', style: '日落音乐盒', wave: '三角波' },
-  { name: 'Nocturne',     bpm: '72', key: 'Am/C',  style: '浪漫夜曲',   wave: '正弦波' },
-];
+import { PLAYLISTS } from '@/shared/sound/songs/index';
 
 const TABS = [
-  { key: 'game' as const, label: '游戏曲目', songs: GAME_SONGS },
-  { key: 'lobby' as const, label: '大厅曲目', songs: LOBBY_SONGS },
+  { key: 'game' as const, label: '游戏曲目' },
+  { key: 'lobby' as const, label: '大厅曲目' },
 ];
 
 interface Props {
@@ -48,6 +19,8 @@ interface Props {
 export default function MusicHallModal({ open, onClose, currentScene }: Props) {
   const [tab, setTab] = useState<'game' | 'lobby'>('game');
   const [playing, setPlaying] = useState<string | null>(null);
+
+  const songs = PLAYLISTS[tab] ?? [];
 
   const play = (scene: string, index: number) => {
     const key = `${scene}:${index}`;
@@ -67,8 +40,6 @@ export default function MusicHallModal({ open, onClose, currentScene }: Props) {
   };
 
   if (!open) return null;
-
-  const current = TABS.find((t) => t.key === tab)!;
 
   return (
     <AnimatePresence>
@@ -112,14 +83,14 @@ export default function MusicHallModal({ open, onClose, currentScene }: Props) {
                   )}
                 >
                   {t.label}
-                  <span className="ml-1 text-xs opacity-50">({t.songs.length})</span>
+                  <span className="ml-1 text-xs opacity-50">({(PLAYLISTS[t.key] ?? []).length})</span>
                 </button>
               ))}
             </div>
 
             <div className="max-h-[50vh] overflow-y-auto p-3 scrollbar-thin">
               <div className="flex flex-col gap-1.5">
-                {current.songs.map((song, i) => {
+                {songs.map((song, i) => {
                   const key = `${tab}:${i}`;
                   const isPlaying = playing === key;
                   return (
@@ -161,11 +132,13 @@ export default function MusicHallModal({ open, onClose, currentScene }: Props) {
                         <div className="flex items-center gap-2 mt-0.5 text-2xs text-muted-foreground">
                           <span>{song.bpm} BPM</span>
                           <span className="opacity-40">·</span>
-                          <span>{song.key}</span>
+                          <span>{song.meta.key}</span>
                           <span className="opacity-40">·</span>
-                          <span>{song.style}</span>
+                          <span>{song.meta.style}</span>
                           <span className="opacity-40">·</span>
-                          <span>{song.wave}</span>
+                          <span>{song.meta.wave}</span>
+                          <span className="opacity-40">·</span>
+                          <span>{song.meta.author}</span>
                         </div>
                       </div>
                     </button>

--- a/packages/client/src/shared/components/TutorialModal.tsx
+++ b/packages/client/src/shared/components/TutorialModal.tsx
@@ -1,0 +1,242 @@
+import { useState, useEffect } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { Spade, ChevronRight, ChevronLeft, Megaphone, Trophy } from 'lucide-react';
+import { cn } from '@/shared/lib/utils';
+
+function MiniCard({ color, label }: { color: string; label: string }) {
+  const bg: Record<string, string> = {
+    red: 'bg-uno-red',
+    blue: 'bg-uno-blue',
+    green: 'bg-uno-green',
+    yellow: 'bg-uno-yellow',
+    wild: 'bg-wild-gradient',
+    dark: 'bg-slate-700 border border-slate-500',
+  };
+  return (
+    <div className={cn('inline-flex items-center justify-center w-8 h-11 rounded text-white text-2xs font-bold shrink-0', bg[color] ?? 'bg-slate-600')}>
+      {label}
+    </div>
+  );
+}
+
+function CardRow({ children }: { children: React.ReactNode }) {
+  return <div className="flex gap-1.5 my-1.5">{children}</div>;
+}
+
+interface PageDef {
+  title: string;
+  body: React.ReactNode;
+}
+
+const PAGES: PageDef[] = [
+  {
+    title: '欢迎来到 UNO Online',
+    body: (
+      <div className="flex flex-col gap-3.5">
+        <p className="text-sm text-foreground/90 leading-relaxed">
+          UNO 是一款经典的多人卡牌对战游戏，支持 2-10 人同时游戏。
+          快速匹配、出牌、喊 UNO —— 最先打完手牌的玩家获胜！
+        </p>
+        <div className="flex justify-center gap-2 py-2">
+          <MiniCard color="red" label="7" />
+          <MiniCard color="blue" label="3" />
+          <MiniCard color="green" label="⇆" />
+          <MiniCard color="yellow" label="+2" />
+          <MiniCard color="wild" label="W" />
+          <MiniCard color="dark" label="+4" />
+        </div>
+        <div className="rounded-lg bg-white/5 p-3 text-xs text-slate-300 leading-relaxed space-y-1.5">
+          <p>每人发 <strong className="text-foreground">7 张</strong>手牌，翻开一张作为弃牌堆起始。</p>
+          <p>轮到你时，打出一张与弃牌堆顶<strong className="text-foreground">颜色</strong>或<strong className="text-foreground">数字/符号</strong>相同的牌。</p>
+          <p>无牌可出时从牌堆<strong className="text-foreground">摸一张</strong>牌。</p>
+        </div>
+      </div>
+    ),
+  },
+  {
+    title: '卡牌图鉴',
+    body: (
+      <div className="flex flex-col gap-3 text-xs text-slate-300 leading-relaxed">
+        <div className="rounded-lg bg-white/5 p-3">
+          <p className="text-foreground text-xs font-bold mb-1">数字牌（0-9）</p>
+          <CardRow>
+            <MiniCard color="red" label="3" />
+            <MiniCard color="blue" label="7" />
+            <MiniCard color="green" label="1" />
+            <MiniCard color="yellow" label="9" />
+          </CardRow>
+          <p>四种颜色各有 0-9 数字牌，匹配颜色或数字即可打出。</p>
+        </div>
+
+        <div className="rounded-lg bg-white/5 p-3">
+          <p className="text-foreground text-xs font-bold mb-1">功能牌</p>
+          <CardRow>
+            <MiniCard color="red" label="⊘" />
+            <MiniCard color="green" label="⇆" />
+            <MiniCard color="blue" label="+2" />
+          </CardRow>
+          <ul className="list-disc pl-4 space-y-1 mt-1">
+            <li><strong className="text-foreground">跳过</strong> ⊘ — 下一位玩家被跳过，失去出牌机会</li>
+            <li><strong className="text-foreground">反转</strong> ⇆ — 改变出牌方向，两人时等同跳过</li>
+            <li><strong className="text-foreground">+2</strong> — 下家摸 2 张牌并跳过回合</li>
+          </ul>
+        </div>
+
+        <div className="rounded-lg bg-white/5 p-3">
+          <p className="text-foreground text-xs font-bold mb-1">万能牌</p>
+          <CardRow>
+            <MiniCard color="wild" label="W" />
+            <MiniCard color="dark" label="+4" />
+          </CardRow>
+          <ul className="list-disc pl-4 space-y-1 mt-1">
+            <li><strong className="text-foreground">变色牌</strong> W — 任何时候都能打出，自选颜色</li>
+            <li><strong className="text-foreground">+4</strong> — 选颜色并让下家摸 4 张，下家可质疑合法性</li>
+          </ul>
+        </div>
+      </div>
+    ),
+  },
+  {
+    title: 'UNO 喊牌 & 计分',
+    body: (
+      <div className="flex flex-col gap-3 text-xs text-slate-300 leading-relaxed">
+        <div className="rounded-lg bg-white/5 p-3">
+          <div className="flex items-center gap-2 mb-2">
+            <Megaphone size={16} className="text-accent shrink-0" />
+            <p className="text-foreground text-xs font-bold">UNO 喊牌</p>
+          </div>
+          <ul className="list-disc pl-4 space-y-1">
+            <li>手中只剩 <strong className="text-foreground">1 张牌</strong>时，必须喊「UNO」</li>
+            <li>未喊被其他玩家抓到，罚摸 <strong className="text-foreground">2 张</strong>牌</li>
+            <li>其他玩家可以在你出下一张牌之前点击抓牌按钮</li>
+          </ul>
+        </div>
+
+        <div className="rounded-lg bg-white/5 p-3">
+          <div className="flex items-center gap-2 mb-2">
+            <Trophy size={16} className="text-accent shrink-0" />
+            <p className="text-foreground text-xs font-bold">胜利与计分</p>
+          </div>
+          <ul className="list-disc pl-4 space-y-1">
+            <li>最先出完手牌的玩家赢得本轮</li>
+            <li>赢家获得其他玩家手中剩余牌的分值总和</li>
+          </ul>
+          <div className="mt-2 grid grid-cols-3 gap-2 text-center">
+            <div className="rounded bg-white/5 py-1.5">
+              <p className="text-foreground font-bold text-sm">0-9</p>
+              <p className="text-muted-foreground mt-0.5">面值分</p>
+            </div>
+            <div className="rounded bg-white/5 py-1.5">
+              <p className="text-foreground font-bold text-sm">20</p>
+              <p className="text-muted-foreground mt-0.5">功能牌</p>
+            </div>
+            <div className="rounded bg-white/5 py-1.5">
+              <p className="text-foreground font-bold text-sm">50</p>
+              <p className="text-muted-foreground mt-0.5">万能牌</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    ),
+  },
+];
+
+export default function TutorialModal() {
+  const [open, setOpen] = useState(false);
+  const [page, setPage] = useState(0);
+  const [dir, setDir] = useState(1);
+
+  useEffect(() => { setOpen(true); }, []);
+
+  const close = () => { setOpen(false); setPage(0); };
+  const go = (next: number) => { setDir(next > page ? 1 : -1); setPage(next); };
+
+  if (!open) return null;
+
+  const current = PAGES[page]!;
+  const isLast = page === PAGES.length - 1;
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <div className="fixed inset-0 z-modal flex items-center justify-center px-4">
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="absolute inset-0 bg-black/55"
+          />
+
+          <motion.div
+            initial={{ opacity: 0, scale: 0.94, y: 8 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.94, y: 8 }}
+            transition={{ duration: 0.2 }}
+            className="relative w-full max-w-[440px] rounded-2xl bg-card shadow-2xl border border-white/[0.08]"
+          >
+            <div className="flex items-center justify-between border-b border-white/[0.08] px-6 py-4">
+              <div className="flex items-center gap-2 text-lg font-bold font-game">
+                <Spade size={18} className="text-accent" /> {current.title}
+              </div>
+            </div>
+
+            <div className="max-h-[52vh] overflow-y-auto p-5 scrollbar-thin">
+              <AnimatePresence mode="wait" initial={false}>
+                <motion.div
+                  key={page}
+                  initial={{ opacity: 0, x: dir * 40 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  exit={{ opacity: 0, x: dir * -40 }}
+                  transition={{ duration: 0.18 }}
+                >
+                  {current.body}
+                </motion.div>
+              </AnimatePresence>
+            </div>
+
+            <div className="border-t border-white/[0.08] px-5 py-3.5">
+              <div className="flex justify-center gap-1.5 mb-3">
+                {PAGES.map((_, i) => (
+                  <button
+                    key={i}
+                    onClick={() => go(i)}
+                    className={cn(
+                      'h-1.5 rounded-full transition-all',
+                      i === page ? 'w-5 bg-accent' : 'w-1.5 bg-white/20 hover:bg-white/40',
+                    )}
+                  />
+                ))}
+              </div>
+              <div className="flex gap-3">
+                {page > 0 && (
+                  <button
+                    onClick={() => go(page - 1)}
+                    className="flex-1 rounded-lg border border-white/15 px-4 py-2 text-sm font-bold text-foreground transition-colors hover:bg-white/5"
+                  >
+                    <ChevronLeft size={14} className="mr-1 inline" /> 上一页
+                  </button>
+                )}
+                {isLast ? (
+                  <button
+                    onClick={close}
+                    className="flex-1 rounded-lg bg-accent px-4 py-2 text-sm font-bold text-white transition-colors hover:opacity-90"
+                  >
+                    开始游戏
+                  </button>
+                ) : (
+                  <button
+                    onClick={() => go(page + 1)}
+                    className="flex-1 rounded-lg bg-accent px-4 py-2 text-sm font-bold text-white transition-colors hover:opacity-90"
+                  >
+                    下一页 <ChevronRight size={14} className="ml-1 inline" />
+                  </button>
+                )}
+              </div>
+            </div>
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/packages/client/src/shared/components/TutorialModal.tsx
+++ b/packages/client/src/shared/components/TutorialModal.tsx
@@ -181,7 +181,7 @@ export default function TutorialModal() {
               </div>
             </div>
 
-            <div className="max-h-[52vh] overflow-y-auto p-5 scrollbar-thin">
+            <div className="min-h-[320px] max-h-[52vh] overflow-y-auto p-5 scrollbar-thin">
               <AnimatePresence mode="wait" initial={false}>
                 <motion.div
                   key={page}

--- a/packages/client/src/shared/components/TutorialModal.tsx
+++ b/packages/client/src/shared/components/TutorialModal.tsx
@@ -3,136 +3,134 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { Spade, ChevronRight, ChevronLeft, Megaphone, Trophy } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
 
-function MiniCard({ color, label }: { color: string; label: string }) {
+function Card({ color, label, size = 'md' }: { color: string; label: string; size?: 'md' | 'lg' }) {
   const bg: Record<string, string> = {
-    red: 'bg-uno-red',
-    blue: 'bg-uno-blue',
-    green: 'bg-uno-green',
-    yellow: 'bg-uno-yellow',
-    wild: 'bg-wild-gradient',
+    red: 'bg-uno-red', blue: 'bg-uno-blue', green: 'bg-uno-green',
+    yellow: 'bg-uno-yellow', wild: 'bg-wild-gradient',
     dark: 'bg-slate-700 border border-slate-500',
   };
+  const s = size === 'lg' ? 'w-11 h-16 text-sm' : 'w-8 h-11 text-2xs';
   return (
-    <div className={cn('inline-flex items-center justify-center w-8 h-11 rounded text-white text-2xs font-bold shrink-0', bg[color] ?? 'bg-slate-600')}>
+    <div className={cn('inline-flex items-center justify-center rounded text-white font-bold shrink-0 shadow-lg', s, bg[color] ?? 'bg-slate-600')}>
       {label}
     </div>
   );
 }
 
-function CardRow({ children }: { children: React.ReactNode }) {
-  return <div className="flex gap-1.5 my-1.5">{children}</div>;
-}
-
-interface PageDef {
-  title: string;
-  body: React.ReactNode;
-}
+interface PageDef { title: string; subtitle: string; body: React.ReactNode }
 
 const PAGES: PageDef[] = [
   {
     title: '欢迎来到 UNO Online',
+    subtitle: '经典多人卡牌对战 · 2-10 人',
     body: (
-      <div className="flex flex-col gap-3.5">
-        <p className="text-sm text-foreground/90 leading-relaxed">
-          UNO 是一款经典的多人卡牌对战游戏，支持 2-10 人同时游戏。
-          快速匹配、出牌、喊 UNO —— 最先打完手牌的玩家获胜！
-        </p>
-        <div className="flex justify-center gap-2 py-2">
-          <MiniCard color="red" label="7" />
-          <MiniCard color="blue" label="3" />
-          <MiniCard color="green" label="⇆" />
-          <MiniCard color="yellow" label="+2" />
-          <MiniCard color="wild" label="W" />
-          <MiniCard color="dark" label="+4" />
+      <div className="flex flex-col items-center gap-6">
+        <div className="flex justify-center gap-3">
+          <Card color="red" label="7" size="lg" />
+          <Card color="blue" label="3" size="lg" />
+          <Card color="green" label="⇆" size="lg" />
+          <Card color="yellow" label="+2" size="lg" />
+          <Card color="wild" label="W" size="lg" />
+          <Card color="dark" label="+4" size="lg" />
         </div>
-        <div className="rounded-lg bg-white/5 p-3 text-xs text-slate-300 leading-relaxed space-y-1.5">
-          <p>每人发 <strong className="text-foreground">7 张</strong>手牌，翻开一张作为弃牌堆起始。</p>
-          <p>轮到你时，打出一张与弃牌堆顶<strong className="text-foreground">颜色</strong>或<strong className="text-foreground">数字/符号</strong>相同的牌。</p>
-          <p>无牌可出时从牌堆<strong className="text-foreground">摸一张</strong>牌。</p>
+        <div className="w-full max-w-sm space-y-3">
+          <div className="flex items-start gap-3 rounded-xl bg-white/5 p-4">
+            <span className="mt-0.5 flex h-6 w-6 items-center justify-center rounded-full bg-accent/20 text-accent text-xs font-bold shrink-0">1</span>
+            <p className="text-sm text-slate-300">每人发 <strong className="text-foreground">7 张</strong>手牌，翻开一张作为弃牌堆起始</p>
+          </div>
+          <div className="flex items-start gap-3 rounded-xl bg-white/5 p-4">
+            <span className="mt-0.5 flex h-6 w-6 items-center justify-center rounded-full bg-accent/20 text-accent text-xs font-bold shrink-0">2</span>
+            <p className="text-sm text-slate-300">打出与弃牌堆顶<strong className="text-foreground">颜色</strong>或<strong className="text-foreground">数字</strong>相同的牌，无牌可出则摸牌</p>
+          </div>
+          <div className="flex items-start gap-3 rounded-xl bg-white/5 p-4">
+            <span className="mt-0.5 flex h-6 w-6 items-center justify-center rounded-full bg-accent/20 text-accent text-xs font-bold shrink-0">3</span>
+            <p className="text-sm text-slate-300">最先出完所有手牌的玩家<strong className="text-foreground">获胜</strong></p>
+          </div>
         </div>
       </div>
     ),
   },
   {
     title: '卡牌图鉴',
+    subtitle: '了解每种卡牌的效果',
     body: (
-      <div className="flex flex-col gap-3 text-xs text-slate-300 leading-relaxed">
-        <div className="rounded-lg bg-white/5 p-3">
-          <p className="text-foreground text-xs font-bold mb-1">数字牌（0-9）</p>
-          <CardRow>
-            <MiniCard color="red" label="3" />
-            <MiniCard color="blue" label="7" />
-            <MiniCard color="green" label="1" />
-            <MiniCard color="yellow" label="9" />
-          </CardRow>
-          <p>四种颜色各有 0-9 数字牌，匹配颜色或数字即可打出。</p>
+      <div className="w-full max-w-sm space-y-3">
+        <div className="rounded-xl bg-white/5 p-4">
+          <div className="flex items-center gap-3 mb-2">
+            <Card color="red" label="3" />
+            <Card color="blue" label="7" />
+            <Card color="green" label="1" />
+            <Card color="yellow" label="9" />
+          </div>
+          <p className="text-sm font-bold text-foreground">数字牌 (0-9)</p>
+          <p className="text-xs text-slate-400 mt-1">四种颜色各有 0-9，匹配颜色或数字即可打出</p>
         </div>
-
-        <div className="rounded-lg bg-white/5 p-3">
-          <p className="text-foreground text-xs font-bold mb-1">功能牌</p>
-          <CardRow>
-            <MiniCard color="red" label="⊘" />
-            <MiniCard color="green" label="⇆" />
-            <MiniCard color="blue" label="+2" />
-          </CardRow>
-          <ul className="list-disc pl-4 space-y-1 mt-1">
-            <li><strong className="text-foreground">跳过</strong> ⊘ — 下一位玩家被跳过，失去出牌机会</li>
-            <li><strong className="text-foreground">反转</strong> ⇆ — 改变出牌方向，两人时等同跳过</li>
-            <li><strong className="text-foreground">+2</strong> — 下家摸 2 张牌并跳过回合</li>
-          </ul>
+        <div className="rounded-xl bg-white/5 p-4">
+          <div className="flex items-center gap-3 mb-2">
+            <Card color="red" label="⊘" />
+            <Card color="green" label="⇆" />
+            <Card color="blue" label="+2" />
+          </div>
+          <p className="text-sm font-bold text-foreground">功能牌</p>
+          <div className="text-xs text-slate-400 mt-1 space-y-1">
+            <p><strong className="text-slate-200">⊘ 跳过</strong> — 下家失去出牌机会</p>
+            <p><strong className="text-slate-200">⇆ 反转</strong> — 改变出牌方向</p>
+            <p><strong className="text-slate-200">+2</strong> — 下家摸 2 张并跳过回合</p>
+          </div>
         </div>
-
-        <div className="rounded-lg bg-white/5 p-3">
-          <p className="text-foreground text-xs font-bold mb-1">万能牌</p>
-          <CardRow>
-            <MiniCard color="wild" label="W" />
-            <MiniCard color="dark" label="+4" />
-          </CardRow>
-          <ul className="list-disc pl-4 space-y-1 mt-1">
-            <li><strong className="text-foreground">变色牌</strong> W — 任何时候都能打出，自选颜色</li>
-            <li><strong className="text-foreground">+4</strong> — 选颜色并让下家摸 4 张，下家可质疑合法性</li>
-          </ul>
+        <div className="rounded-xl bg-white/5 p-4">
+          <div className="flex items-center gap-3 mb-2">
+            <Card color="wild" label="W" />
+            <Card color="dark" label="+4" />
+          </div>
+          <p className="text-sm font-bold text-foreground">万能牌</p>
+          <div className="text-xs text-slate-400 mt-1 space-y-1">
+            <p><strong className="text-slate-200">W 变色</strong> — 任何时候打出，自选颜色</p>
+            <p><strong className="text-slate-200">+4</strong> — 选颜色 + 下家摸 4 张，可被质疑</p>
+          </div>
         </div>
       </div>
     ),
   },
   {
     title: 'UNO 喊牌 & 计分',
+    subtitle: '掌握规则，赢得胜利',
     body: (
-      <div className="flex flex-col gap-3 text-xs text-slate-300 leading-relaxed">
-        <div className="rounded-lg bg-white/5 p-3">
-          <div className="flex items-center gap-2 mb-2">
-            <Megaphone size={16} className="text-accent shrink-0" />
-            <p className="text-foreground text-xs font-bold">UNO 喊牌</p>
+      <div className="w-full max-w-sm space-y-3">
+        <div className="rounded-xl bg-white/5 p-4">
+          <div className="flex items-center gap-2 mb-3">
+            <Megaphone size={18} className="text-accent shrink-0" />
+            <p className="text-sm font-bold text-foreground">UNO 喊牌</p>
           </div>
-          <ul className="list-disc pl-4 space-y-1">
-            <li>手中只剩 <strong className="text-foreground">1 张牌</strong>时，必须喊「UNO」</li>
-            <li>未喊被其他玩家抓到，罚摸 <strong className="text-foreground">2 张</strong>牌</li>
-            <li>其他玩家可以在你出下一张牌之前点击抓牌按钮</li>
-          </ul>
+          <div className="space-y-2">
+            <div className="flex items-start gap-3">
+              <span className="mt-0.5 flex h-5 w-5 items-center justify-center rounded-full bg-red-500/20 text-red-400 text-2xs font-bold shrink-0">!</span>
+              <p className="text-xs text-slate-300">手中只剩 <strong className="text-foreground">1 张牌</strong>时必须喊「UNO」</p>
+            </div>
+            <div className="flex items-start gap-3">
+              <span className="mt-0.5 flex h-5 w-5 items-center justify-center rounded-full bg-red-500/20 text-red-400 text-2xs font-bold shrink-0">!</span>
+              <p className="text-xs text-slate-300">未喊被抓到 → 罚摸 <strong className="text-foreground">2 张</strong></p>
+            </div>
+          </div>
         </div>
-
-        <div className="rounded-lg bg-white/5 p-3">
-          <div className="flex items-center gap-2 mb-2">
-            <Trophy size={16} className="text-accent shrink-0" />
-            <p className="text-foreground text-xs font-bold">胜利与计分</p>
+        <div className="rounded-xl bg-white/5 p-4">
+          <div className="flex items-center gap-2 mb-3">
+            <Trophy size={18} className="text-accent shrink-0" />
+            <p className="text-sm font-bold text-foreground">胜利与计分</p>
           </div>
-          <ul className="list-disc pl-4 space-y-1">
-            <li>最先出完手牌的玩家赢得本轮</li>
-            <li>赢家获得其他玩家手中剩余牌的分值总和</li>
-          </ul>
-          <div className="mt-2 grid grid-cols-3 gap-2 text-center">
-            <div className="rounded bg-white/5 py-1.5">
-              <p className="text-foreground font-bold text-sm">0-9</p>
-              <p className="text-muted-foreground mt-0.5">面值分</p>
+          <p className="text-xs text-slate-400 mb-3">赢家获得其他玩家手中剩余牌的分值总和</p>
+          <div className="grid grid-cols-3 gap-2 text-center">
+            <div className="rounded-lg bg-white/5 py-2.5">
+              <p className="text-foreground font-bold text-base">0-9</p>
+              <p className="text-2xs text-muted-foreground mt-0.5">面值分</p>
             </div>
-            <div className="rounded bg-white/5 py-1.5">
-              <p className="text-foreground font-bold text-sm">20</p>
-              <p className="text-muted-foreground mt-0.5">功能牌</p>
+            <div className="rounded-lg bg-white/5 py-2.5">
+              <p className="text-foreground font-bold text-base">20</p>
+              <p className="text-2xs text-muted-foreground mt-0.5">功能牌</p>
             </div>
-            <div className="rounded bg-white/5 py-1.5">
-              <p className="text-foreground font-bold text-sm">50</p>
-              <p className="text-muted-foreground mt-0.5">万能牌</p>
+            <div className="rounded-lg bg-white/5 py-2.5">
+              <p className="text-foreground font-bold text-base">50</p>
+              <p className="text-2xs text-muted-foreground mt-0.5">万能牌</p>
             </div>
           </div>
         </div>
@@ -159,83 +157,73 @@ export default function TutorialModal() {
   return (
     <AnimatePresence>
       {open && (
-        <div className="fixed inset-0 z-modal flex items-center justify-center px-4">
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.2 }}
-            className="absolute inset-0 bg-black/55"
-          />
-
-          <motion.div
-            initial={{ opacity: 0, scale: 0.94, y: 8 }}
-            animate={{ opacity: 1, scale: 1, y: 0 }}
-            exit={{ opacity: 0, scale: 0.94, y: 8 }}
-            transition={{ duration: 0.2 }}
-            className="relative w-full max-w-[440px] rounded-2xl bg-card shadow-2xl border border-white/[0.08]"
-          >
-            <div className="flex items-center justify-between border-b border-white/[0.08] px-6 py-4">
-              <div className="flex items-center gap-2 text-lg font-bold font-game">
-                <Spade size={18} className="text-accent" /> {current.title}
-              </div>
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.3 }}
+          className="fixed inset-0 z-modal flex flex-col bg-gradient-to-b from-slate-950 via-slate-900 to-slate-950"
+        >
+          <div className="flex flex-col flex-1 items-center justify-center px-6 py-8 overflow-y-auto">
+            <div className="flex flex-col items-center gap-2 mb-8">
+              <motion.div
+                key={`title-${page}`}
+                initial={{ opacity: 0, y: -10 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.2 }}
+                className="flex items-center gap-2.5 text-2xl font-bold font-game text-foreground"
+              >
+                <Spade size={24} className="text-accent" />
+                {current.title}
+              </motion.div>
+              <p className="text-sm text-muted-foreground">{current.subtitle}</p>
             </div>
 
-            <div className="min-h-[320px] max-h-[52vh] overflow-y-auto p-5 scrollbar-thin">
-              <AnimatePresence mode="wait" initial={false}>
-                <motion.div
-                  key={page}
-                  initial={{ opacity: 0, x: dir * 40 }}
-                  animate={{ opacity: 1, x: 0 }}
-                  exit={{ opacity: 0, x: dir * -40 }}
-                  transition={{ duration: 0.18 }}
+            <AnimatePresence mode="wait" initial={false}>
+              <motion.div
+                key={page}
+                initial={{ opacity: 0, x: dir * 60 }}
+                animate={{ opacity: 1, x: 0 }}
+                exit={{ opacity: 0, x: dir * -60 }}
+                transition={{ duration: 0.2 }}
+                className="flex justify-center w-full"
+              >
+                {current.body}
+              </motion.div>
+            </AnimatePresence>
+          </div>
+
+          <div className="shrink-0 px-6 pb-8 pt-4">
+            <div className="flex justify-center gap-2 mb-5">
+              {PAGES.map((_, i) => (
+                <button
+                  key={i}
+                  onClick={() => go(i)}
+                  className={cn(
+                    'h-1.5 rounded-full transition-all',
+                    i === page ? 'w-8 bg-accent' : 'w-2 bg-white/20 hover:bg-white/40',
+                  )}
+                />
+              ))}
+            </div>
+            <div className="flex gap-3 max-w-sm mx-auto">
+              {page > 0 && (
+                <button
+                  onClick={() => go(page - 1)}
+                  className="flex-1 rounded-xl border border-white/15 px-5 py-3 text-sm font-bold text-foreground transition-colors hover:bg-white/5"
                 >
-                  {current.body}
-                </motion.div>
-              </AnimatePresence>
+                  <ChevronLeft size={14} className="mr-1 inline" /> 上一页
+                </button>
+              )}
+              <button
+                onClick={isLast ? close : () => go(page + 1)}
+                className="flex-1 rounded-xl bg-accent px-5 py-3 text-sm font-bold text-white transition-colors hover:opacity-90"
+              >
+                {isLast ? '开始游戏' : <>下一页 <ChevronRight size={14} className="ml-1 inline" /></>}
+              </button>
             </div>
-
-            <div className="border-t border-white/[0.08] px-5 py-3.5">
-              <div className="flex justify-center gap-1.5 mb-3">
-                {PAGES.map((_, i) => (
-                  <button
-                    key={i}
-                    onClick={() => go(i)}
-                    className={cn(
-                      'h-1.5 rounded-full transition-all',
-                      i === page ? 'w-5 bg-accent' : 'w-1.5 bg-white/20 hover:bg-white/40',
-                    )}
-                  />
-                ))}
-              </div>
-              <div className="flex gap-3">
-                {page > 0 && (
-                  <button
-                    onClick={() => go(page - 1)}
-                    className="flex-1 rounded-lg border border-white/15 px-4 py-2 text-sm font-bold text-foreground transition-colors hover:bg-white/5"
-                  >
-                    <ChevronLeft size={14} className="mr-1 inline" /> 上一页
-                  </button>
-                )}
-                {isLast ? (
-                  <button
-                    onClick={close}
-                    className="flex-1 rounded-lg bg-accent px-4 py-2 text-sm font-bold text-white transition-colors hover:opacity-90"
-                  >
-                    开始游戏
-                  </button>
-                ) : (
-                  <button
-                    onClick={() => go(page + 1)}
-                    className="flex-1 rounded-lg bg-accent px-4 py-2 text-sm font-bold text-white transition-colors hover:opacity-90"
-                  >
-                    下一页 <ChevronRight size={14} className="ml-1 inline" />
-                  </button>
-                )}
-              </div>
-            </div>
-          </motion.div>
-        </div>
+          </div>
+        </motion.div>
       )}
     </AnimatePresence>
   );

--- a/packages/client/src/shared/components/TutorialModal.tsx
+++ b/packages/client/src/shared/components/TutorialModal.tsx
@@ -3,15 +3,27 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { Spade, ChevronRight, ChevronLeft, Megaphone, Trophy } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
 
-function Card({ color, label, size = 'md' }: { color: string; label: string; size?: 'md' | 'lg' }) {
+function Card({ color, label }: { color: string; label: string }) {
   const bg: Record<string, string> = {
     red: 'bg-uno-red', blue: 'bg-uno-blue', green: 'bg-uno-green',
     yellow: 'bg-uno-yellow', wild: 'bg-wild-gradient',
     dark: 'bg-slate-700 border border-slate-500',
   };
-  const s = size === 'lg' ? 'w-11 h-16 text-sm' : 'w-8 h-11 text-2xs';
   return (
-    <div className={cn('inline-flex items-center justify-center rounded text-white font-bold shrink-0 shadow-lg', s, bg[color] ?? 'bg-slate-600')}>
+    <div className={cn('inline-flex items-center justify-center w-14 h-20 rounded-lg text-white text-lg font-bold shrink-0 shadow-xl', bg[color] ?? 'bg-slate-600')}>
+      {label}
+    </div>
+  );
+}
+
+function SmallCard({ color, label }: { color: string; label: string }) {
+  const bg: Record<string, string> = {
+    red: 'bg-uno-red', blue: 'bg-uno-blue', green: 'bg-uno-green',
+    yellow: 'bg-uno-yellow', wild: 'bg-wild-gradient',
+    dark: 'bg-slate-700 border border-slate-500',
+  };
+  return (
+    <div className={cn('inline-flex items-center justify-center w-9 h-13 rounded text-white text-xs font-bold shrink-0 shadow-md', bg[color] ?? 'bg-slate-600')}>
       {label}
     </div>
   );
@@ -22,30 +34,39 @@ interface PageDef { title: string; subtitle: string; body: React.ReactNode }
 const PAGES: PageDef[] = [
   {
     title: '欢迎来到 UNO Online',
-    subtitle: '经典多人卡牌对战 · 2-10 人',
+    subtitle: '经典多人卡牌对战 · 支持 2-10 人同时游戏',
     body: (
-      <div className="flex flex-col items-center gap-6">
-        <div className="flex justify-center gap-3">
-          <Card color="red" label="7" size="lg" />
-          <Card color="blue" label="3" size="lg" />
-          <Card color="green" label="⇆" size="lg" />
-          <Card color="yellow" label="+2" size="lg" />
-          <Card color="wild" label="W" size="lg" />
-          <Card color="dark" label="+4" size="lg" />
+      <div className="flex flex-col items-center gap-8 w-full max-w-xl">
+        <div className="flex justify-center items-end gap-3 sm:gap-4">
+          {[
+            { color: 'red', label: '7', rotate: -12 },
+            { color: 'blue', label: '3', rotate: -6 },
+            { color: 'green', label: '⇆', rotate: 0 },
+            { color: 'yellow', label: '+2', rotate: 6 },
+            { color: 'wild', label: 'W', rotate: 12 },
+            { color: 'dark', label: '+4', rotate: 18 },
+          ].map((c, i) => (
+            <motion.div
+              key={i}
+              initial={{ opacity: 0, y: 30, rotate: 0 }}
+              animate={{ opacity: 1, y: 0, rotate: c.rotate }}
+              transition={{ duration: 0.4, delay: i * 0.08 }}
+            >
+              <Card color={c.color} label={c.label} />
+            </motion.div>
+          ))}
         </div>
-        <div className="w-full max-w-sm space-y-3">
-          <div className="flex items-start gap-3 rounded-xl bg-white/5 p-4">
-            <span className="mt-0.5 flex h-6 w-6 items-center justify-center rounded-full bg-accent/20 text-accent text-xs font-bold shrink-0">1</span>
-            <p className="text-sm text-slate-300">每人发 <strong className="text-foreground">7 张</strong>手牌，翻开一张作为弃牌堆起始</p>
-          </div>
-          <div className="flex items-start gap-3 rounded-xl bg-white/5 p-4">
-            <span className="mt-0.5 flex h-6 w-6 items-center justify-center rounded-full bg-accent/20 text-accent text-xs font-bold shrink-0">2</span>
-            <p className="text-sm text-slate-300">打出与弃牌堆顶<strong className="text-foreground">颜色</strong>或<strong className="text-foreground">数字</strong>相同的牌，无牌可出则摸牌</p>
-          </div>
-          <div className="flex items-start gap-3 rounded-xl bg-white/5 p-4">
-            <span className="mt-0.5 flex h-6 w-6 items-center justify-center rounded-full bg-accent/20 text-accent text-xs font-bold shrink-0">3</span>
-            <p className="text-sm text-slate-300">最先出完所有手牌的玩家<strong className="text-foreground">获胜</strong></p>
-          </div>
+        <div className="w-full grid gap-3 sm:grid-cols-3">
+          {[
+            { n: '1', text: <>每人发 <strong className="text-foreground">7 张</strong>手牌，翻开一张作为起始</> },
+            { n: '2', text: <>出与弃牌堆顶<strong className="text-foreground">颜色</strong>或<strong className="text-foreground">数字</strong>相同的牌</> },
+            { n: '3', text: <>最先打完所有手牌的玩家<strong className="text-foreground">获胜</strong></> },
+          ].map((step) => (
+            <div key={step.n} className="flex items-start gap-3 rounded-xl bg-white/5 p-4">
+              <span className="flex h-7 w-7 items-center justify-center rounded-full bg-accent/20 text-accent text-sm font-bold shrink-0">{step.n}</span>
+              <p className="text-sm text-slate-300 leading-relaxed">{step.text}</p>
+            </div>
+          ))}
         </div>
       </div>
     ),
@@ -54,39 +75,39 @@ const PAGES: PageDef[] = [
     title: '卡牌图鉴',
     subtitle: '了解每种卡牌的效果',
     body: (
-      <div className="w-full max-w-sm space-y-3">
-        <div className="rounded-xl bg-white/5 p-4">
-          <div className="flex items-center gap-3 mb-2">
-            <Card color="red" label="3" />
-            <Card color="blue" label="7" />
-            <Card color="green" label="1" />
-            <Card color="yellow" label="9" />
+      <div className="w-full max-w-xl grid gap-3 sm:grid-cols-2">
+        <div className="rounded-xl bg-white/5 p-5">
+          <div className="flex items-center gap-2 mb-3">
+            <SmallCard color="red" label="3" />
+            <SmallCard color="blue" label="7" />
+            <SmallCard color="green" label="1" />
+            <SmallCard color="yellow" label="9" />
           </div>
           <p className="text-sm font-bold text-foreground">数字牌 (0-9)</p>
-          <p className="text-xs text-slate-400 mt-1">四种颜色各有 0-9，匹配颜色或数字即可打出</p>
+          <p className="text-xs text-slate-400 mt-1.5 leading-relaxed">四种颜色各有 0-9 数字牌，匹配颜色或数字即可打出</p>
         </div>
-        <div className="rounded-xl bg-white/5 p-4">
-          <div className="flex items-center gap-3 mb-2">
-            <Card color="red" label="⊘" />
-            <Card color="green" label="⇆" />
-            <Card color="blue" label="+2" />
+        <div className="rounded-xl bg-white/5 p-5">
+          <div className="flex items-center gap-2 mb-3">
+            <SmallCard color="red" label="⊘" />
+            <SmallCard color="green" label="⇆" />
+            <SmallCard color="blue" label="+2" />
           </div>
           <p className="text-sm font-bold text-foreground">功能牌</p>
-          <div className="text-xs text-slate-400 mt-1 space-y-1">
+          <div className="text-xs text-slate-400 mt-1.5 leading-relaxed space-y-1">
             <p><strong className="text-slate-200">⊘ 跳过</strong> — 下家失去出牌机会</p>
             <p><strong className="text-slate-200">⇆ 反转</strong> — 改变出牌方向</p>
             <p><strong className="text-slate-200">+2</strong> — 下家摸 2 张并跳过回合</p>
           </div>
         </div>
-        <div className="rounded-xl bg-white/5 p-4">
-          <div className="flex items-center gap-3 mb-2">
-            <Card color="wild" label="W" />
-            <Card color="dark" label="+4" />
+        <div className="rounded-xl bg-white/5 p-5 sm:col-span-2">
+          <div className="flex items-center gap-2 mb-3">
+            <SmallCard color="wild" label="W" />
+            <SmallCard color="dark" label="+4" />
           </div>
           <p className="text-sm font-bold text-foreground">万能牌</p>
-          <div className="text-xs text-slate-400 mt-1 space-y-1">
-            <p><strong className="text-slate-200">W 变色</strong> — 任何时候打出，自选颜色</p>
-            <p><strong className="text-slate-200">+4</strong> — 选颜色 + 下家摸 4 张，可被质疑</p>
+          <div className="text-xs text-slate-400 mt-1.5 leading-relaxed sm:flex sm:gap-6">
+            <p><strong className="text-slate-200">W 变色</strong> — 任何时候打出，自由选择接下来的颜色</p>
+            <p className="mt-1 sm:mt-0"><strong className="text-slate-200">+4</strong> — 选颜色 + 下家摸 4 张牌，下家可以质疑合法性</p>
           </div>
         </div>
       </div>
@@ -96,41 +117,41 @@ const PAGES: PageDef[] = [
     title: 'UNO 喊牌 & 计分',
     subtitle: '掌握规则，赢得胜利',
     body: (
-      <div className="w-full max-w-sm space-y-3">
-        <div className="rounded-xl bg-white/5 p-4">
-          <div className="flex items-center gap-2 mb-3">
-            <Megaphone size={18} className="text-accent shrink-0" />
-            <p className="text-sm font-bold text-foreground">UNO 喊牌</p>
+      <div className="w-full max-w-xl grid gap-3 sm:grid-cols-2">
+        <div className="rounded-xl bg-white/5 p-5">
+          <div className="flex items-center gap-2 mb-4">
+            <Megaphone size={20} className="text-accent shrink-0" />
+            <p className="text-base font-bold text-foreground">UNO 喊牌</p>
           </div>
-          <div className="space-y-2">
+          <div className="space-y-3">
             <div className="flex items-start gap-3">
-              <span className="mt-0.5 flex h-5 w-5 items-center justify-center rounded-full bg-red-500/20 text-red-400 text-2xs font-bold shrink-0">!</span>
-              <p className="text-xs text-slate-300">手中只剩 <strong className="text-foreground">1 张牌</strong>时必须喊「UNO」</p>
+              <span className="mt-0.5 flex h-6 w-6 items-center justify-center rounded-full bg-red-500/20 text-red-400 text-xs font-bold shrink-0">!</span>
+              <p className="text-sm text-slate-300">手中只剩 <strong className="text-foreground">1 张牌</strong>时必须喊「UNO」</p>
             </div>
             <div className="flex items-start gap-3">
-              <span className="mt-0.5 flex h-5 w-5 items-center justify-center rounded-full bg-red-500/20 text-red-400 text-2xs font-bold shrink-0">!</span>
-              <p className="text-xs text-slate-300">未喊被抓到 → 罚摸 <strong className="text-foreground">2 张</strong></p>
+              <span className="mt-0.5 flex h-6 w-6 items-center justify-center rounded-full bg-red-500/20 text-red-400 text-xs font-bold shrink-0">!</span>
+              <p className="text-sm text-slate-300">未喊被抓到 → 罚摸 <strong className="text-foreground">2 张</strong></p>
             </div>
           </div>
         </div>
-        <div className="rounded-xl bg-white/5 p-4">
-          <div className="flex items-center gap-2 mb-3">
-            <Trophy size={18} className="text-accent shrink-0" />
-            <p className="text-sm font-bold text-foreground">胜利与计分</p>
+        <div className="rounded-xl bg-white/5 p-5">
+          <div className="flex items-center gap-2 mb-4">
+            <Trophy size={20} className="text-accent shrink-0" />
+            <p className="text-base font-bold text-foreground">胜利与计分</p>
           </div>
-          <p className="text-xs text-slate-400 mb-3">赢家获得其他玩家手中剩余牌的分值总和</p>
+          <p className="text-sm text-slate-400 mb-4">赢家获得其他玩家手中剩余牌的分值总和</p>
           <div className="grid grid-cols-3 gap-2 text-center">
-            <div className="rounded-lg bg-white/5 py-2.5">
-              <p className="text-foreground font-bold text-base">0-9</p>
-              <p className="text-2xs text-muted-foreground mt-0.5">面值分</p>
+            <div className="rounded-lg bg-white/5 py-3">
+              <p className="text-foreground font-bold text-lg">0-9</p>
+              <p className="text-2xs text-muted-foreground mt-1">面值分</p>
             </div>
-            <div className="rounded-lg bg-white/5 py-2.5">
-              <p className="text-foreground font-bold text-base">20</p>
-              <p className="text-2xs text-muted-foreground mt-0.5">功能牌</p>
+            <div className="rounded-lg bg-white/5 py-3">
+              <p className="text-foreground font-bold text-lg">20</p>
+              <p className="text-2xs text-muted-foreground mt-1">功能牌</p>
             </div>
-            <div className="rounded-lg bg-white/5 py-2.5">
-              <p className="text-foreground font-bold text-base">50</p>
-              <p className="text-2xs text-muted-foreground mt-0.5">万能牌</p>
+            <div className="rounded-lg bg-white/5 py-3">
+              <p className="text-foreground font-bold text-lg">50</p>
+              <p className="text-2xs text-muted-foreground mt-1">万能牌</p>
             </div>
           </div>
         </div>
@@ -164,14 +185,14 @@ export default function TutorialModal() {
           transition={{ duration: 0.3 }}
           className="fixed inset-0 z-modal flex flex-col bg-gradient-to-b from-slate-950 via-slate-900 to-slate-950"
         >
-          <div className="flex flex-col flex-1 items-center justify-center px-6 py-8 overflow-y-auto">
+          <div className="flex flex-col flex-1 items-center justify-center px-6 py-6 overflow-hidden">
             <div className="flex flex-col items-center gap-2 mb-8">
               <motion.div
                 key={`title-${page}`}
                 initial={{ opacity: 0, y: -10 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.2 }}
-                className="flex items-center gap-2.5 text-2xl font-bold font-game text-foreground"
+                className="flex items-center gap-3 text-xl sm:text-2xl font-bold font-game text-foreground"
               >
                 <Spade size={24} className="text-accent" />
                 {current.title}
@@ -206,7 +227,7 @@ export default function TutorialModal() {
                 />
               ))}
             </div>
-            <div className="flex gap-3 max-w-sm mx-auto">
+            <div className="flex gap-3 max-w-xs mx-auto">
               {page > 0 && (
                 <button
                   onClick={() => go(page - 1)}

--- a/packages/client/src/shared/sound/audio-context.ts
+++ b/packages/client/src/shared/sound/audio-context.ts
@@ -1,0 +1,24 @@
+let ctx: AudioContext | null = null;
+let listenerAdded = false;
+
+export function getAudioContext(): AudioContext {
+  if (!ctx) {
+    ctx = new AudioContext();
+    addInteractionListener();
+  }
+  return ctx;
+}
+
+function addInteractionListener() {
+  if (listenerAdded) return;
+  listenerAdded = true;
+  const resume = () => {
+    if (ctx && ctx.state !== 'running') void ctx.resume();
+    document.removeEventListener('click', resume, true);
+    document.removeEventListener('keydown', resume, true);
+    document.removeEventListener('touchstart', resume, true);
+  };
+  document.addEventListener('click', resume, true);
+  document.addEventListener('keydown', resume, true);
+  document.addEventListener('touchstart', resume, true);
+}

--- a/packages/client/src/shared/sound/bgm-engine.ts
+++ b/packages/client/src/shared/sound/bgm-engine.ts
@@ -1,6 +1,8 @@
 import { getAudioContext } from './audio-context';
 import { PLAYLISTS, type Song } from './songs/index';
-import type { ToneCh } from './songs/common';
+import type { ToneCh, SongMeta } from './songs/common';
+
+export interface SongInfo { name: string; meta: SongMeta }
 
 function shuffle<T>(arr: T[]): T[] {
   const a = [...arr];
@@ -28,11 +30,11 @@ class BgmEngine {
   private step = 0;
   private nextTime = 0;
   private _playing = false;
-  private _onSongChange: ((name: string) => void) | null = null;
+  private _onSongChange: ((info: SongInfo) => void) | null = null;
 
   get isPlaying() { return this._playing; }
-  get currentSongName() { return this._playing ? this.song?.name ?? null : null; }
-  set onSongChange(cb: ((name: string) => void) | null) { this._onSongChange = cb; }
+  get currentSong(): SongInfo | null { return this._playing && this.song ? { name: this.song.name, meta: this.song.meta } : null; }
+  set onSongChange(cb: ((info: SongInfo) => void) | null) { this._onSongChange = cb; }
 
   private getMaster(): GainNode {
     if (!this.master) {
@@ -123,7 +125,7 @@ class BgmEngine {
     this.buildVoices();
     this.step = 0;
     this.nextTime = ctx.currentTime + 0.05;
-    this._onSongChange?.(this.song.name);
+    this._onSongChange?.({ name: this.song.name, meta: this.song.meta });
     this.tick();
     this.timer = setInterval(() => this.tick(), 25);
   }
@@ -161,7 +163,7 @@ class BgmEngine {
       this.song = this.playlist[this.songIdx]!;
       this.step = 0;
       this.buildVoices();
-      this._onSongChange?.(this.song.name);
+      this._onSongChange?.({ name: this.song.name, meta: this.song.meta });
     }
 
     const i = this.step;

--- a/packages/client/src/shared/sound/bgm-engine.ts
+++ b/packages/client/src/shared/sound/bgm-engine.ts
@@ -1,0 +1,239 @@
+import { getAudioContext } from './audio-context';
+import { PLAYLISTS, type Song } from './songs/index';
+import type { ToneCh } from './songs/common';
+
+function shuffle<T>(arr: T[]): T[] {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j]!, a[i]!];
+  }
+  return a;
+}
+
+interface Voice {
+  osc: OscillatorNode;
+  gain: GainNode;
+  ch: ToneCh;
+}
+
+class BgmEngine {
+  private master: GainNode | null = null;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private noiseBuffer: AudioBuffer | null = null;
+  private voices: Voice[] = [];
+  private playlist: Song[] = [];
+  private songIdx = 0;
+  private song!: Song;
+  private step = 0;
+  private nextTime = 0;
+  private _playing = false;
+  private _onSongChange: ((name: string) => void) | null = null;
+
+  get isPlaying() { return this._playing; }
+  get currentSongName() { return this._playing ? this.song?.name ?? null : null; }
+  set onSongChange(cb: ((name: string) => void) | null) { this._onSongChange = cb; }
+
+  private getMaster(): GainNode {
+    if (!this.master) {
+      const ctx = getAudioContext();
+      this.master = ctx.createGain();
+      this.master.gain.value = 0.3;
+      this.master.connect(ctx.destination);
+    }
+    return this.master;
+  }
+
+  private getNoise(): AudioBuffer {
+    if (!this.noiseBuffer) {
+      const ctx = getAudioContext();
+      const len = Math.ceil(ctx.sampleRate * 0.05);
+      this.noiseBuffer = ctx.createBuffer(1, len, ctx.sampleRate);
+      const ch = this.noiseBuffer.getChannelData(0);
+      for (let i = 0; i < len; i++) ch[i] = Math.random() * 2 - 1;
+    }
+    return this.noiseBuffer;
+  }
+
+  private buildVoices() {
+    this.destroyVoices();
+    const ctx = getAudioContext();
+    const master = this.getMaster();
+    for (const ch of this.song.tones) {
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.type = ch.wave;
+      gain.gain.setValueAtTime(0, ctx.currentTime);
+      osc.connect(gain).connect(master);
+      osc.start();
+      this.voices.push({ osc, gain, ch });
+    }
+  }
+
+  private destroyVoices() {
+    for (const v of this.voices) {
+      try { v.osc.stop(); } catch { /* already stopped */ }
+      v.osc.disconnect();
+      v.gain.disconnect();
+    }
+    this.voices = [];
+  }
+
+  setVolume(v: number) {
+    this.getMaster().gain.setTargetAtTime(v, getAudioContext().currentTime, 0.05);
+  }
+
+  start(scene: string) {
+    this.stop();
+    const base = PLAYLISTS[scene] ?? PLAYLISTS.game!;
+    this.playlist = shuffle(base);
+    this.songIdx = 0;
+    this.song = this.playlist[0]!;
+    this._playing = true;
+    this.launch();
+  }
+
+  playSingle(scene: string, index: number) {
+    this.stop();
+    const base = PLAYLISTS[scene] ?? PLAYLISTS.game!;
+    const song = base[index];
+    if (!song) return;
+    this.playlist = [song];
+    this.songIdx = 0;
+    this.song = song;
+    this._playing = true;
+    this.launch();
+  }
+
+  private launch() {
+    const ctx = getAudioContext();
+    void ctx.resume();
+    this.getMaster();
+    if (ctx.state === 'running') {
+      this.beginScheduler();
+    } else {
+      ctx.addEventListener('statechange', () => {
+        if (this._playing && !this.timer) this.beginScheduler();
+      }, { once: true });
+    }
+  }
+
+  private beginScheduler() {
+    const ctx = getAudioContext();
+    this.buildVoices();
+    this.step = 0;
+    this.nextTime = ctx.currentTime + 0.05;
+    this._onSongChange?.(this.song.name);
+    this.tick();
+    this.timer = setInterval(() => this.tick(), 25);
+  }
+
+  stop() {
+    if (this.timer != null) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    this.destroyVoices();
+    this._playing = false;
+  }
+
+  private tick() {
+    const now = getAudioContext().currentTime;
+    if (this.nextTime < now - 0.5) this.nextTime = now + 0.05;
+    const horizon = now + 0.1;
+    while (this.nextTime < horizon) {
+      this.playStep();
+      this.nextTime += 60 / this.song.bpm / this.song.stepsPerBeat;
+      this.step++;
+    }
+  }
+
+  private playStep() {
+    const s = this.song;
+    const len = s.tones[0]!.notes.length;
+
+    if (this.step >= len) {
+      this.songIdx++;
+      if (this.songIdx >= this.playlist.length) {
+        this.playlist = shuffle(this.playlist);
+        this.songIdx = 0;
+      }
+      this.song = this.playlist[this.songIdx]!;
+      this.step = 0;
+      this.buildVoices();
+      this._onSongChange?.(this.song.name);
+    }
+
+    const i = this.step;
+    const t = this.nextTime;
+
+    for (const v of this.voices) {
+      const note = v.ch.notes[i];
+      if (note != null) {
+        v.osc.frequency.setValueAtTime(note, t);
+        v.gain.gain.setValueAtTime(v.ch.gain, t);
+        v.gain.gain.exponentialRampToValueAtTime(0.001, t + v.ch.dur);
+      }
+    }
+
+    if (s.kick.hits[i])  this.kick(t, s.kick.gain);
+    if (s.snare.hits[i]) this.snare(t, s.snare.gain);
+    if (s.hihat.hits[i]) this.hihat(t, s.hihat.gain);
+  }
+
+  private kick(t: number, vol: number) {
+    const ctx = getAudioContext();
+    const o = ctx.createOscillator();
+    const g = ctx.createGain();
+    o.type = 'sine';
+    o.frequency.setValueAtTime(150, t);
+    o.frequency.exponentialRampToValueAtTime(30, t + 0.08);
+    g.gain.setValueAtTime(vol, t);
+    g.gain.exponentialRampToValueAtTime(0.001, t + 0.08);
+    o.connect(g).connect(this.master!);
+    o.start(t);
+    o.stop(t + 0.1);
+  }
+
+  private hihat(t: number, vol: number) {
+    const ctx = getAudioContext();
+    const s = ctx.createBufferSource();
+    s.buffer = this.getNoise();
+    const f = ctx.createBiquadFilter();
+    f.type = 'highpass';
+    f.frequency.value = 8000;
+    const g = ctx.createGain();
+    g.gain.setValueAtTime(vol, t);
+    g.gain.exponentialRampToValueAtTime(0.001, t + 0.03);
+    s.connect(f).connect(g).connect(this.master!);
+    s.start(t);
+    s.stop(t + 0.04);
+  }
+
+  private snare(t: number, vol: number) {
+    const ctx = getAudioContext();
+    const s = ctx.createBufferSource();
+    s.buffer = this.getNoise();
+    const bf = ctx.createBiquadFilter();
+    bf.type = 'bandpass';
+    bf.frequency.value = 3000;
+    const ng = ctx.createGain();
+    ng.gain.setValueAtTime(vol, t);
+    ng.gain.exponentialRampToValueAtTime(0.001, t + 0.05);
+    s.connect(bf).connect(ng).connect(this.master!);
+    s.start(t);
+    s.stop(t + 0.06);
+
+    const o = ctx.createOscillator();
+    o.type = 'triangle';
+    o.frequency.setValueAtTime(200, t);
+    const tg = ctx.createGain();
+    tg.gain.setValueAtTime(vol * 0.5, t);
+    tg.gain.exponentialRampToValueAtTime(0.001, t + 0.04);
+    o.connect(tg).connect(this.master!);
+    o.start(t);
+    o.stop(t + 0.05);
+  }
+}
+
+export const bgm = new BgmEngine();

--- a/packages/client/src/shared/sound/songs/common.ts
+++ b/packages/client/src/shared/sound/songs/common.ts
@@ -1,0 +1,38 @@
+export const _ = null;
+export const T = true, F = false;
+
+export const C2 = 65.41, D2 = 73.42, E2 = 82.41, F2 = 87.31, G2 = 98.00, A2 = 110.00, B2 = 123.47;
+export const C3 = 130.81, D3 = 146.83, E3 = 164.81, F3 = 174.61, G3 = 196.00, A3 = 220.00, B3 = 246.94;
+export const C4 = 261.63, D4 = 293.66, E4 = 329.63, F4 = 349.23, G4 = 392.00, A4 = 440.00, B4 = 493.88;
+export const C5 = 523.25, D5 = 587.33, E5 = 659.25, F5 = 698.46, G5 = 783.99, A5 = 880.00, B5 = 987.77;
+export const C6 = 1046.50, D6 = 1174.66;
+
+export const Fs3 = 185.00, Fs4 = 369.99, Fs5 = 739.99;
+export const Bb2 = 116.54, Bb3 = 233.08, Bb4 = 466.16, Bb5 = 932.33;
+
+export type N = number | null;
+export interface ToneCh { wave: OscillatorType; gain: number; dur: number; notes: N[] }
+export interface DrumCh { gain: number; hits: boolean[] }
+export interface Song { name: string; bpm: number; stepsPerBeat: number; tones: ToneCh[]; kick: DrumCh; snare: DrumCh; hihat: DrumCh }
+
+export function rep(p: boolean[], n: number): boolean[] {
+  const r: boolean[] = [];
+  for (let i = 0; i < n; i++) r.push(...p);
+  return r;
+}
+
+export function harm(...bars: [N, N][]): N[] {
+  return bars.flatMap(([a, b]) => [a, _, _, _, b, _, _, _]);
+}
+
+export function harmArp(...bars: [N, N, N][]): N[] {
+  return bars.flatMap(([a, b, c]) => [a, _, b, _, c, _, b, _]);
+}
+
+export function bass(...bars: [N, N][]): N[] {
+  return bars.flatMap(([lo, hi]) => [lo, _, hi, _, lo, _, hi, _]);
+}
+
+export function bassHalf(...bars: [N, N][]): N[] {
+  return bars.flatMap(([lo, hi]) => [lo, _, _, _, hi, _, _, _]);
+}

--- a/packages/client/src/shared/sound/songs/common.ts
+++ b/packages/client/src/shared/sound/songs/common.ts
@@ -13,7 +13,8 @@ export const Bb2 = 116.54, Bb3 = 233.08, Bb4 = 466.16, Bb5 = 932.33;
 export type N = number | null;
 export interface ToneCh { wave: OscillatorType; gain: number; dur: number; notes: N[] }
 export interface DrumCh { gain: number; hits: boolean[] }
-export interface Song { name: string; bpm: number; stepsPerBeat: number; tones: ToneCh[]; kick: DrumCh; snare: DrumCh; hihat: DrumCh }
+export interface SongMeta { author: string; key: string; style: string; wave: string }
+export interface Song { name: string; meta: SongMeta; bpm: number; stepsPerBeat: number; tones: ToneCh[]; kick: DrumCh; snare: DrumCh; hihat: DrumCh }
 
 export function rep(p: boolean[], n: number): boolean[] {
   const r: boolean[] = [];

--- a/packages/client/src/shared/sound/songs/game-1.ts
+++ b/packages/client/src/shared/sound/songs/game-1.ts
@@ -1,0 +1,69 @@
+import type { N, Song } from './common';
+import { _, T, F, rep, harm, harmArp, bass,
+  C2, C3, F2, F3, G2, G3, A2, A3, B2, D3,
+  B3, C4, D4, E4, F4, G4,
+  A4, B4, C5, D5, E5, F5, G5, A5, B5, D6,
+} from './common';
+
+
+// ── Melody sections (4 bars = 32 steps) ──
+
+const mA: N[] = [ // C – G – Am – F  (bouncy arpeggios)
+  C5,C5,E5,E5,G5,G5,E5, _,  B4,B4,D5,D5,G5, _,D5, _,
+  A4,A4,C5,C5,E5,E5,C5, _,  F4,F4,A4,A4,C5, _, _, _,
+];
+const mB: N[] = [ // C – G – F – G  (flowing)
+  E5, _,G5, _,C5, _,G5,E5,  D5, _,G5, _,B5, _,A5,G5,
+  F5, _,A5, _,G5,F5, _,E5,  G5, _,B5, _,D6, _, _, _,
+];
+const mC: N[] = [ // C – G – Am – F  (A' variation)
+  C5,C5,E5,E5,G5,G5,E5, _,  B4,B4,D5,D5,G5, _,D5, _,
+  A4,A4,C5,C5,E5,E5,C5, _,  A4, _,C5, _,F5, _,E5,D5,
+];
+const mD: N[] = [ // Am – F – G – C  (bridge)
+  E5, _,A5, _,E5,C5, _,A4,  F5, _,C5, _,A4, _,C5,F5,
+  G5, _,D5, _,B4,D5,G5, _,  C5, _,E5, _,G5, _, _, _,
+];
+const mE: N[] = [ // Dm – G – C – Am  (new: descending stepwise)
+  D5, _,F5, _,E5,D5, _,C5,  B4, _,D5, _,G5, _,F5,E5,
+  E5, _,G5, _,C5, _,E5,G5,  A5, _,G5, _,E5, _,C5, _,
+];
+const mF: N[] = [ // F – G – Am – C  (new: syncopated climax)
+   _,F5, _,A5,C5, _,F5, _,   _,G5, _,B5,D5, _,G5, _,
+  A5, _,E5, _,C5,E5,A5, _,  G5, _,E5, _,C5, _, _, _,
+];
+
+// ── Harmony ──
+const hA  = harm([E4,G4],[D4,G4],[C4,E4],[C4,A3]);
+const hB  = harmArp([C4,E4,G4],[B3,D4,G4],[A3,C4,F4],[B3,D4,G4]);
+const hD  = harmArp([A3,C4,E4],[F3,A3,C4],[G3,B3,D4],[C4,E4,G4]);
+const hE  = harm([D4,F4],[B3,D4],[C4,E4],[C4,A3]);
+const hF  = harm([A3,F4],[B3,G4],[C4,E4],[C4,G4]);
+
+// ── Bass ──
+const bA = bass([C3,C2],[G2,G3],[A2,A3],[F2,F3]);
+const bB = bass([C2,C3],[G2,G3],[F2,F3],[G2,G3]);
+const bD = bass([A2,A3],[F2,F3],[G2,G3],[C2,C3]);
+const bE = bass([D3,F3],[G2,G3],[C2,C3],[A2,A3]);
+const bF = bass([F2,F3],[G2,G3],[A2,A3],[C2,C3]);
+
+function join(...s: N[][]): N[] { return s.flat(); }
+
+const song: Song = {
+  name: 'UNO Bounce', bpm: 138, stepsPerBeat: 2,
+  tones: [
+    { wave: 'square', gain: 0.15, dur: 0.1,
+      notes: join(mA, mC, mB, mD, mE, mA, mB, mF) },
+    { wave: 'square', gain: 0.07, dur: 0.12,
+      notes: join(hA, hA, hB, hD, hE, hA, hB, hF) },
+    { wave: 'triangle', gain: 0.18, dur: 0.15,
+      notes: join(bA, bA, bB, bD, bE, bA, bB, bF) },
+  ],
+  kick:  { gain: 0.20, hits: [...rep([T,F,F,F,T,F,F,F], 31), T,F,F,T,T,F,T,F] },
+  snare: { gain: 0.10, hits: [...rep([F,F,T,F,F,F,T,F], 31), F,F,T,F,T,F,T,T] },
+  hihat: { gain: 0.04, hits: [
+    ...rep([T,F,T,F,T,F,T,F], 8), ...rep([T,T,T,T,T,T,T,T], 8),
+    ...rep([T,F,T,F,T,F,T,F], 8), ...rep([T,T,T,T,T,T,T,T], 8),
+  ]},
+};
+export default song;

--- a/packages/client/src/shared/sound/songs/game-1.ts
+++ b/packages/client/src/shared/sound/songs/game-1.ts
@@ -5,42 +5,37 @@ import { _, T, F, rep, harm, harmArp, bass,
   A4, B4, C5, D5, E5, F5, G5, A5, B5, D6,
 } from './common';
 
-
-// ── Melody sections (4 bars = 32 steps) ──
-
-const mA: N[] = [ // C – G – Am – F  (bouncy arpeggios)
+const mA: N[] = [
   C5,C5,E5,E5,G5,G5,E5, _,  B4,B4,D5,D5,G5, _,D5, _,
   A4,A4,C5,C5,E5,E5,C5, _,  F4,F4,A4,A4,C5, _, _, _,
 ];
-const mB: N[] = [ // C – G – F – G  (flowing)
+const mB: N[] = [
   E5, _,G5, _,C5, _,G5,E5,  D5, _,G5, _,B5, _,A5,G5,
   F5, _,A5, _,G5,F5, _,E5,  G5, _,B5, _,D6, _, _, _,
 ];
-const mC: N[] = [ // C – G – Am – F  (A' variation)
+const mC: N[] = [
   C5,C5,E5,E5,G5,G5,E5, _,  B4,B4,D5,D5,G5, _,D5, _,
   A4,A4,C5,C5,E5,E5,C5, _,  A4, _,C5, _,F5, _,E5,D5,
 ];
-const mD: N[] = [ // Am – F – G – C  (bridge)
+const mD: N[] = [
   E5, _,A5, _,E5,C5, _,A4,  F5, _,C5, _,A4, _,C5,F5,
   G5, _,D5, _,B4,D5,G5, _,  C5, _,E5, _,G5, _, _, _,
 ];
-const mE: N[] = [ // Dm – G – C – Am  (new: descending stepwise)
+const mE: N[] = [
   D5, _,F5, _,E5,D5, _,C5,  B4, _,D5, _,G5, _,F5,E5,
   E5, _,G5, _,C5, _,E5,G5,  A5, _,G5, _,E5, _,C5, _,
 ];
-const mF: N[] = [ // F – G – Am – C  (new: syncopated climax)
+const mF: N[] = [
    _,F5, _,A5,C5, _,F5, _,   _,G5, _,B5,D5, _,G5, _,
   A5, _,E5, _,C5,E5,A5, _,  G5, _,E5, _,C5, _, _, _,
 ];
 
-// ── Harmony ──
 const hA  = harm([E4,G4],[D4,G4],[C4,E4],[C4,A3]);
 const hB  = harmArp([C4,E4,G4],[B3,D4,G4],[A3,C4,F4],[B3,D4,G4]);
 const hD  = harmArp([A3,C4,E4],[F3,A3,C4],[G3,B3,D4],[C4,E4,G4]);
 const hE  = harm([D4,F4],[B3,D4],[C4,E4],[C4,A3]);
 const hF  = harm([A3,F4],[B3,G4],[C4,E4],[C4,G4]);
 
-// ── Bass ──
 const bA = bass([C3,C2],[G2,G3],[A2,A3],[F2,F3]);
 const bB = bass([C2,C3],[G2,G3],[F2,F3],[G2,G3]);
 const bD = bass([A2,A3],[F2,F3],[G2,G3],[C2,C3]);

--- a/packages/client/src/shared/sound/songs/game-1.ts
+++ b/packages/client/src/shared/sound/songs/game-1.ts
@@ -45,7 +45,7 @@ const bF = bass([F2,F3],[G2,G3],[A2,A3],[C2,C3]);
 function join(...s: N[][]): N[] { return s.flat(); }
 
 const song: Song = {
-  name: 'UNO Bounce', bpm: 138, stepsPerBeat: 2,
+  name: 'UNO Bounce', meta: { 'author':'Claude', 'key':'C 大调', 'style':'弹跳琶音', 'wave':'方波' }, bpm: 138, stepsPerBeat: 2,
   tones: [
     { wave: 'square', gain: 0.15, dur: 0.1,
       notes: join(mA, mC, mB, mD, mE, mA, mB, mF) },

--- a/packages/client/src/shared/sound/songs/game-10.ts
+++ b/packages/client/src/shared/sound/songs/game-10.ts
@@ -1,0 +1,58 @@
+import type { N, Song } from './common';
+import { _, T, F, rep, harm, harmArp, bass, bassHalf,
+  C2, C3, D2, D3, E2, E3, F2, F3, G2, G3, A2, A3, B2, B3,
+  C4, D4, E4, F4, G4, A4, B4,
+  C5, D5, E5, F5, G5, A5, B5, C6,
+} from './common';
+
+
+const mA: N[] = [ // C – G – Am – Em  (古典乐句：上行-下行弧线)
+  C5, _,D5, _,E5, _,G5, _,  G5, _,A5, _,B5, _,C6, _,
+  B5, _,A5, _,G5, _,E5, _,  D5, _,C5, _, _, _, _, _,
+];
+const mB: N[] = [ // Am – Em – F – C  (对位应答)
+  A5, _,G5, _,E5, _,C5, _,  E5, _,G5, _,B5, _,G5, _,
+  F5, _,A5, _,C5, _,A5, _,  G5, _,E5, _,C5, _, _, _,
+];
+const mC: N[] = [ // G – D – Em – C  (属调离调)
+  B5, _,A5, _,G5, _,D5, _,  A5, _,G5, _,F5, _,D5, _,
+  E5, _,G5, _,B5, _,G5,E5,  C5, _,E5, _,G5, _, _, _,
+];
+const mD: N[] = [ // F – G – Am – G  (三度音程双声部)
+  F5,A5, _,E5,G5, _,D5,F5,  G5,B5, _,F5,A5, _,E5,G5,
+  A5,C6, _,G5,B5, _,A5,C6,  B5, _,G5, _,D5, _, _, _,
+];
+const mE: N[] = [ // F – G – C – C  (古典终止式)
+  F5, _,A5, _,C6,A5,F5, _,  G5, _,B5, _,D5,B5,G5, _,
+  E5, _,G5, _,C6, _,E5, _,  C5, _, _, _, _, _, _, _,
+];
+
+const hA = harmArp([E4,G4,C5],[D4,G4,B4],[C4,E4,A4],[B3,E4,G4]);
+const hB = harmArp([C4,E4,A4],[B3,E4,G4],[A3,C4,F4],[E4,G4,C5]);
+const hC = harmArp([D4,G4,B4],[A3,D4,F4],[B3,E4,G4],[E4,G4,C5]);
+const hD = harm([A3,C4],[B3,D4],[C4,E4],[B3,D4]);
+const hE = harmArp([A3,C4,F4],[B3,D4,G4],[E4,G4,C5],[E4,G4,C5]);
+
+const bA = bassHalf([C2,C3],[G2,G3],[A2,A3],[E2,E3]);
+const bB = bassHalf([A2,A3],[E2,E3],[F2,F3],[C2,C3]);
+const bC = bassHalf([G2,G3],[D2,D3],[E2,E3],[C2,C3]);
+const bD = bassHalf([F2,F3],[G2,G3],[A2,A3],[G2,G3]);
+const bE = bassHalf([F2,F3],[G2,G3],[C2,C3],[C2,C3]);
+
+function join(...s: N[][]): N[] { return s.flat(); }
+
+const song: Song = {
+  name: 'Minuet', bpm: 108, stepsPerBeat: 2,
+  tones: [
+    { wave: 'triangle', gain: 0.14, dur: 0.16,
+      notes: join(mA, mB, mA, mC, mD, mA, mB, mE) },
+    { wave: 'sine', gain: 0.06, dur: 0.2,
+      notes: join(hA, hB, hA, hC, hD, hA, hB, hE) },
+    { wave: 'triangle', gain: 0.14, dur: 0.2,
+      notes: join(bA, bB, bA, bC, bD, bA, bB, bE) },
+  ],
+  kick:  { gain: 0.00, hits: rep([F,F,F,F,F,F,F,F], 32) },
+  snare: { gain: 0.00, hits: rep([F,F,F,F,F,F,F,F], 32) },
+  hihat: { gain: 0.03, hits: rep([T,F,T,F,T,F,T,F], 32) },
+};
+export default song;

--- a/packages/client/src/shared/sound/songs/game-10.ts
+++ b/packages/client/src/shared/sound/songs/game-10.ts
@@ -41,7 +41,7 @@ const bE = bassHalf([F2,F3],[G2,G3],[C2,C3],[C2,C3]);
 function join(...s: N[][]): N[] { return s.flat(); }
 
 const song: Song = {
-  name: 'Minuet', bpm: 108, stepsPerBeat: 2,
+  name: 'Minuet', meta: { 'author':'Claude', 'key':'C 大调', 'style':'巴洛克小步舞', 'wave':'三角波' }, bpm: 108, stepsPerBeat: 2,
   tones: [
     { wave: 'triangle', gain: 0.14, dur: 0.16,
       notes: join(mA, mB, mA, mC, mD, mA, mB, mE) },

--- a/packages/client/src/shared/sound/songs/game-10.ts
+++ b/packages/client/src/shared/sound/songs/game-10.ts
@@ -5,24 +5,23 @@ import { _, T, F, rep, harm, harmArp, bass, bassHalf,
   C5, D5, E5, F5, G5, A5, B5, C6,
 } from './common';
 
-
-const mA: N[] = [ // C – G – Am – Em  (古典乐句：上行-下行弧线)
+const mA: N[] = [
   C5, _,D5, _,E5, _,G5, _,  G5, _,A5, _,B5, _,C6, _,
   B5, _,A5, _,G5, _,E5, _,  D5, _,C5, _, _, _, _, _,
 ];
-const mB: N[] = [ // Am – Em – F – C  (对位应答)
+const mB: N[] = [
   A5, _,G5, _,E5, _,C5, _,  E5, _,G5, _,B5, _,G5, _,
   F5, _,A5, _,C5, _,A5, _,  G5, _,E5, _,C5, _, _, _,
 ];
-const mC: N[] = [ // G – D – Em – C  (属调离调)
+const mC: N[] = [
   B5, _,A5, _,G5, _,D5, _,  A5, _,G5, _,F5, _,D5, _,
   E5, _,G5, _,B5, _,G5,E5,  C5, _,E5, _,G5, _, _, _,
 ];
-const mD: N[] = [ // F – G – Am – G  (三度音程双声部)
+const mD: N[] = [
   F5,A5, _,E5,G5, _,D5,F5,  G5,B5, _,F5,A5, _,E5,G5,
   A5,C6, _,G5,B5, _,A5,C6,  B5, _,G5, _,D5, _, _, _,
 ];
-const mE: N[] = [ // F – G – C – C  (古典终止式)
+const mE: N[] = [
   F5, _,A5, _,C6,A5,F5, _,  G5, _,B5, _,D5,B5,G5, _,
   E5, _,G5, _,C6, _,E5, _,  C5, _, _, _, _, _, _, _,
 ];

--- a/packages/client/src/shared/sound/songs/game-2.ts
+++ b/packages/client/src/shared/sound/songs/game-2.ts
@@ -47,7 +47,7 @@ const bF = bass([C2,C3],[A2,A3],[F2,F3],[G2,G3]);
 function join(...s: N[][]): N[] { return s.flat(); }
 
 const song: Song = {
-  name: 'Reverse!', bpm: 128, stepsPerBeat: 2,
+  name: 'Reverse!', meta: { 'author':'Claude', 'key':'A 小调', 'style':'切分律动', 'wave':'方波' }, bpm: 128, stepsPerBeat: 2,
   tones: [
     { wave: 'square', gain: 0.15, dur: 0.1,
       notes: join(mA, mB, mC, mD, mE, mA, mF, mD) },

--- a/packages/client/src/shared/sound/songs/game-2.ts
+++ b/packages/client/src/shared/sound/songs/game-2.ts
@@ -5,28 +5,27 @@ import { _, T, F, rep, harm, harmArp, bass,
   A4, B4, C5, D5, E5, F5, G5, A5, B5, D6,
 } from './common';
 
-
-const mA: N[] = [ // Am – F – C – G  (off-beat syncopated)
+const mA: N[] = [
    _,E5, _,E5,A5, _,E5, _,   _,C5, _,C5,F5, _,C5, _,
    _,G5, _,G5,C5, _,G5, _,   _,D5, _,D5,G5, _, _, _,
 ];
-const mB: N[] = [ // Am – F – C – G  (descending runs)
+const mB: N[] = [
   A5,G5,E5, _,C5, _, _, _,  F5,E5,C5, _,A4, _, _, _,
   G5,E5,C5, _,E5, _, _, _,  G5, _, _, _,D5, _, _, _,
 ];
-const mC: N[] = [ // F – G – Am – C  (call-and-response)
+const mC: N[] = [
   F5,F5, _, _,A5, _, _, _,  G5,G5, _, _,B5, _, _, _,
   A5,A5, _, _,E5, _, _, _,  E5,E5, _, _,G5, _, _, _,
 ];
-const mD: N[] = [ // Am – F – G – C  (climactic close)
+const mD: N[] = [
   A5, _,G5, _,E5, _,C5, _,  A4,C5,E5, _,F5, _,E5,C5,
   D5, _,G5, _,B5, _,A5,G5,  C5, _,E5, _,G5, _, _, _,
 ];
-const mE: N[] = [ // Dm – Am – F – G  (new: walking melody)
+const mE: N[] = [
   D5, _,E5,F5, _,A5, _,F5,  A4, _,C5, _,E5, _,C5,A4,
   F5, _,E5, _,D5, _,C5,A4,  B4, _,D5, _,G5, _, _, _,
 ];
-const mF: N[] = [ // C – Am – F – G  (new: triumphant)
+const mF: N[] = [
   C5, _,E5, _,G5, _,C5,E5,  A5, _,E5, _,C5, _,A4, _,
   F5, _,A5, _,C5,A5, _,F5,  G5, _,B5, _,D6, _, _, _,
 ];

--- a/packages/client/src/shared/sound/songs/game-2.ts
+++ b/packages/client/src/shared/sound/songs/game-2.ts
@@ -1,0 +1,73 @@
+import type { N, Song } from './common';
+import { _, T, F, rep, harm, harmArp, bass,
+  C2, C3, F2, F3, G2, G3, A2, A3, B2, D3, E3,
+  B3, C4, D4, E4, F4, G4,
+  A4, B4, C5, D5, E5, F5, G5, A5, B5, D6,
+} from './common';
+
+
+const mA: N[] = [ // Am – F – C – G  (off-beat syncopated)
+   _,E5, _,E5,A5, _,E5, _,   _,C5, _,C5,F5, _,C5, _,
+   _,G5, _,G5,C5, _,G5, _,   _,D5, _,D5,G5, _, _, _,
+];
+const mB: N[] = [ // Am – F – C – G  (descending runs)
+  A5,G5,E5, _,C5, _, _, _,  F5,E5,C5, _,A4, _, _, _,
+  G5,E5,C5, _,E5, _, _, _,  G5, _, _, _,D5, _, _, _,
+];
+const mC: N[] = [ // F – G – Am – C  (call-and-response)
+  F5,F5, _, _,A5, _, _, _,  G5,G5, _, _,B5, _, _, _,
+  A5,A5, _, _,E5, _, _, _,  E5,E5, _, _,G5, _, _, _,
+];
+const mD: N[] = [ // Am – F – G – C  (climactic close)
+  A5, _,G5, _,E5, _,C5, _,  A4,C5,E5, _,F5, _,E5,C5,
+  D5, _,G5, _,B5, _,A5,G5,  C5, _,E5, _,G5, _, _, _,
+];
+const mE: N[] = [ // Dm – Am – F – G  (new: walking melody)
+  D5, _,E5,F5, _,A5, _,F5,  A4, _,C5, _,E5, _,C5,A4,
+  F5, _,E5, _,D5, _,C5,A4,  B4, _,D5, _,G5, _, _, _,
+];
+const mF: N[] = [ // C – Am – F – G  (new: triumphant)
+  C5, _,E5, _,G5, _,C5,E5,  A5, _,E5, _,C5, _,A4, _,
+  F5, _,A5, _,C5,A5, _,F5,  G5, _,B5, _,D6, _, _, _,
+];
+
+const hA = harm([A3,E4],[F3,C4],[E4,G4],[B3,D4]);
+const hB = harmArp([A3,C4,E4],[F3,A3,C4],[C4,E4,G4],[B3,D4,G4]);
+const hC = harm([A3,F4],[B3,G4],[C4,E4],[C4,G4]);
+const hD = harmArp([A3,C4,E4],[F3,A3,C4],[G3,B3,D4],[C4,E4,G4]);
+const hE = harm([D4,F4],[C4,E4],[A3,C4],[B3,D4]);
+const hF = harmArp([C4,E4,G4],[A3,C4,E4],[F3,A3,C4],[B3,D4,G4]);
+
+const bA = bass([A2,A3],[F2,F3],[C2,C3],[G2,G3]);
+const bB = bA;
+const bC = bass([F2,F3],[G2,G3],[A2,A3],[C2,C3]);
+const bD = bass([A2,A3],[F2,F3],[G2,G3],[C2,C3]);
+const bE = bass([D3,F3],[A2,A3],[F2,F3],[G2,G3]);
+const bF = bass([C2,C3],[A2,A3],[F2,F3],[G2,G3]);
+
+function join(...s: N[][]): N[] { return s.flat(); }
+
+const song: Song = {
+  name: 'Reverse!', bpm: 128, stepsPerBeat: 2,
+  tones: [
+    { wave: 'square', gain: 0.15, dur: 0.1,
+      notes: join(mA, mB, mC, mD, mE, mA, mF, mD) },
+    { wave: 'square', gain: 0.07, dur: 0.12,
+      notes: join(hA, hB, hC, hD, hE, hA, hF, hD) },
+    { wave: 'triangle', gain: 0.18, dur: 0.15,
+      notes: join(bA, bB, bC, bD, bE, bA, bF, bD) },
+  ],
+  kick:  { gain: 0.20, hits: [
+    ...rep([T,T,F,F,T,F,F,T], 8), ...rep([T,F,F,F,T,F,F,F], 8),
+    ...rep([T,F,F,F,F,F,F,F], 8), ...rep([T,F,F,F,T,F,F,F], 7), T,F,T,F,T,F,T,F,
+  ]},
+  snare: { gain: 0.10, hits: [
+    ...rep([F,F,T,F,F,T,F,F], 8), ...rep([F,F,T,F,F,F,T,F], 8),
+    ...rep([F,F,F,F,T,F,F,F], 8), ...rep([F,F,T,F,F,F,T,F], 7), F,F,T,T,F,T,T,T,
+  ]},
+  hihat: { gain: 0.04, hits: [
+    ...rep([T,T,T,T,T,T,T,T], 8), ...rep([T,F,T,F,T,F,T,F], 8),
+    ...rep([T,F,T,F,T,F,T,F], 8), ...rep([T,T,T,T,T,T,T,T], 8),
+  ]},
+};
+export default song;

--- a/packages/client/src/shared/sound/songs/game-3.ts
+++ b/packages/client/src/shared/sound/songs/game-3.ts
@@ -1,0 +1,76 @@
+import type { N, Song } from './common';
+import { _, T, F, rep, harm, harmArp, bass,
+  C2, C3, F2, F3, G2, G3, A2, A3, B2, E3,
+  B3, C4, D4, E4, F4, G4,
+  A4, B4, C5, D5, E5, F5, G5, A5, B5, D6,
+} from './common';
+
+
+const mA: N[] = [ // Am – Am – F – G  (urgent arpeggios)
+  A4, _,C5, _,E5, _,A5, _,  G5, _,E5, _,C5, _,A4, _,
+  F5, _,A5, _,F5, _,C5, _,  G5, _,D5, _,B4, _,G4, _,
+];
+const mB: N[] = [ // Am – F – C – G  (running 8ths)
+  A4,C5,E5,A5,G5,E5,C5,A4,  A4,C5,F5,A5,G5,F5,C5,A4,
+  G4,C5,E5,G5,E5,C5,G4,E4,  G4,B4,D5,G5,D5,B4,G4, _,
+];
+const mC: N[] = [ // Am – G – F – Am  (high-energy stabs)
+  E5, _,E5, _,A5,A5,G5, _,  D5, _,D5, _,G5,G5,B5, _,
+  C5, _,C5, _,F5,F5,A5, _,  E5, _,E5, _,A5, _, _, _,
+];
+const mD: N[] = [ // F – G – Am – Am  (resolving descent)
+  A5, _,G5,E5, _,C5, _,A4,  A4, _,C5, _,F5, _,E5,D5,
+  D5, _,G5, _,B5, _,D6, _,  A5, _, _, _, _, _, _, _,
+];
+const mE: N[] = [ // Am – F – G – C  (new: pulsing octaves)
+  A4,A5,A4,A5, _,E5, _,C5,  F5, _,F4,F5, _,C5, _,A4,
+  G5, _,G4,G5, _,D5, _,B4,  C5,E5,G5, _,C5, _, _, _,
+];
+const mF: N[] = [ // Am – G – F – Am  (new: final rush)
+  E5,A5,E5,C5,A4,C5,E5,A5,  D5,G5,D5,B4,G4,B4,D5,G5,
+  C5,F5,C5,A4,F4,A4,C5,F5,  A5, _,E5, _,A4, _, _, _,
+];
+
+const hA = harm([C4,E4],[C4,E4],[A3,C4],[B3,D4]);
+const hB: N[] = [
+   _, _, _, _,C4, _, _, _,   _, _, _, _,A3, _, _, _,
+   _, _, _, _,E4, _, _, _,   _, _, _, _,D4, _, _, _,
+];
+const hC = harm([C4,E4],[B3,G4],[A3,C4],[C4,E4]);
+const hD = harm([A3,C4],[G3,B3],[C4,E4],[A3,E4]);
+const hE = harm([C4,E4],[A3,C4],[B3,D4],[C4,E4]);
+const hF: N[] = [
+  C4, _,E4, _,C4, _,E4, _,  B3, _,D4, _,B3, _,D4, _,
+  A3, _,C4, _,A3, _,C4, _,  A3, _, _, _, _, _, _, _,
+];
+
+const bA = bass([A2,A3],[A2,A3],[F2,F3],[G2,G3]);
+const bB = bass([A2,A3],[F2,F3],[C2,C3],[G2,G3]);
+const bC = bass([A2,A3],[G2,G3],[F2,F3],[A2,A3]);
+const bD = bass([F2,F3],[G2,G3],[A2,A3],[A2,A3]);
+const bE = bass([A2,A3],[F2,F3],[G2,G3],[C2,C3]);
+const bF = bass([A2,A3],[G2,G3],[F2,F3],[A2,A3]);
+
+function join(...s: N[][]): N[] { return s.flat(); }
+
+const song: Song = {
+  name: 'Draw Four!', bpm: 144, stepsPerBeat: 2,
+  tones: [
+    { wave: 'square', gain: 0.15, dur: 0.1,
+      notes: join(mA, mB, mA, mC, mD, mE, mB, mF) },
+    { wave: 'square', gain: 0.07, dur: 0.12,
+      notes: join(hA, hB, hA, hC, hD, hE, hB, hF) },
+    { wave: 'triangle', gain: 0.18, dur: 0.15,
+      notes: join(bA, bB, bA, bC, bD, bE, bB, bF) },
+  ],
+  kick:  { gain: 0.22, hits: [
+    ...rep([T,F,F,F,T,F,F,F], 8), ...rep([T,F,T,F,T,F,T,F], 8),
+    ...rep([T,F,F,F,T,F,F,F], 8), ...rep([T,F,T,F,T,F,T,F], 7), T,F,T,T,T,F,T,T,
+  ]},
+  snare: { gain: 0.10, hits: [...rep([F,F,T,F,F,F,T,F], 31), F,T,F,T,T,F,T,T] },
+  hihat: { gain: 0.04, hits: [
+    ...rep([T,F,T,F,T,F,T,F], 8), ...rep([T,T,T,T,T,T,T,T], 8),
+    ...rep([T,F,T,F,T,F,T,F], 8), ...rep([T,T,T,T,T,T,T,T], 8),
+  ]},
+};
+export default song;

--- a/packages/client/src/shared/sound/songs/game-3.ts
+++ b/packages/client/src/shared/sound/songs/game-3.ts
@@ -53,7 +53,7 @@ const bF = bass([A2,A3],[G2,G3],[F2,F3],[A2,A3]);
 function join(...s: N[][]): N[] { return s.flat(); }
 
 const song: Song = {
-  name: 'Draw Four!', bpm: 144, stepsPerBeat: 2,
+  name: 'Draw Four!', meta: { 'author':'Claude', 'key':'A 小调', 'style':'高速连奏', 'wave':'方波' }, bpm: 144, stepsPerBeat: 2,
   tones: [
     { wave: 'square', gain: 0.15, dur: 0.1,
       notes: join(mA, mB, mA, mC, mD, mE, mB, mF) },

--- a/packages/client/src/shared/sound/songs/game-3.ts
+++ b/packages/client/src/shared/sound/songs/game-3.ts
@@ -5,28 +5,27 @@ import { _, T, F, rep, harm, harmArp, bass,
   A4, B4, C5, D5, E5, F5, G5, A5, B5, D6,
 } from './common';
 
-
-const mA: N[] = [ // Am – Am – F – G  (urgent arpeggios)
+const mA: N[] = [
   A4, _,C5, _,E5, _,A5, _,  G5, _,E5, _,C5, _,A4, _,
   F5, _,A5, _,F5, _,C5, _,  G5, _,D5, _,B4, _,G4, _,
 ];
-const mB: N[] = [ // Am – F – C – G  (running 8ths)
+const mB: N[] = [
   A4,C5,E5,A5,G5,E5,C5,A4,  A4,C5,F5,A5,G5,F5,C5,A4,
   G4,C5,E5,G5,E5,C5,G4,E4,  G4,B4,D5,G5,D5,B4,G4, _,
 ];
-const mC: N[] = [ // Am – G – F – Am  (high-energy stabs)
+const mC: N[] = [
   E5, _,E5, _,A5,A5,G5, _,  D5, _,D5, _,G5,G5,B5, _,
   C5, _,C5, _,F5,F5,A5, _,  E5, _,E5, _,A5, _, _, _,
 ];
-const mD: N[] = [ // F – G – Am – Am  (resolving descent)
+const mD: N[] = [
   A5, _,G5,E5, _,C5, _,A4,  A4, _,C5, _,F5, _,E5,D5,
   D5, _,G5, _,B5, _,D6, _,  A5, _, _, _, _, _, _, _,
 ];
-const mE: N[] = [ // Am – F – G – C  (new: pulsing octaves)
+const mE: N[] = [
   A4,A5,A4,A5, _,E5, _,C5,  F5, _,F4,F5, _,C5, _,A4,
   G5, _,G4,G5, _,D5, _,B4,  C5,E5,G5, _,C5, _, _, _,
 ];
-const mF: N[] = [ // Am – G – F – Am  (new: final rush)
+const mF: N[] = [
   E5,A5,E5,C5,A4,C5,E5,A5,  D5,G5,D5,B4,G4,B4,D5,G5,
   C5,F5,C5,A4,F4,A4,C5,F5,  A5, _,E5, _,A4, _, _, _,
 ];

--- a/packages/client/src/shared/sound/songs/game-4.ts
+++ b/packages/client/src/shared/sound/songs/game-4.ts
@@ -5,20 +5,19 @@ import { _, T, F, rep, harm, harmArp, bass, bassHalf,
   A4, B4, C5, D5, E5, F5, G5, A5, B5,
 } from './common';
 
-
-const mA: N[] = [ // C – Am – F – G  (main theme: stepwise + leaps)
+const mA: N[] = [
   C5, _,D5, _,E5, _,G5, _,  A4, _,C5, _,E5, _, _, _,
   F5, _,E5, _,D5, _,C5, _,  B4, _,D5, _, _, _, _, _,
 ];
-const mB: N[] = [ // Am – F – C – G  (contrast: legato descending)
+const mB: N[] = [
   A5, _,G5, _,E5, _,D5,C5,  F5, _,E5, _,C5, _,A4, _,
   G5, _,E5, _,C5, _,E5, _,  D5, _, _, _, _, _, _, _,
 ];
-const mC: N[] = [ // F – G – Am – F  (bridge: call & response)
+const mC: N[] = [
   F5, _,A5, _, _, _,G5, _,  G5, _,B5, _, _, _,A5, _,
   A5, _,E5, _,C5, _,A4, _,  A4, _,C5, _,F5, _, _, _,
 ];
-const mD: N[] = [ // Dm – G – C – C  (outro: resolving)
+const mD: N[] = [
   D5, _,F5, _,A5, _,G5,F5,  G5, _,B5, _,D5, _,B4, _,
   C5, _,E5, _,G5,E5,C5, _,  C5, _, _, _, _, _, _, _,
 ];

--- a/packages/client/src/shared/sound/songs/game-4.ts
+++ b/packages/client/src/shared/sound/songs/game-4.ts
@@ -35,7 +35,7 @@ const bD = bass([D3,F3],[G2,G3],[C2,C3],[C2,C3]);
 function join(...s: N[][]): N[] { return s.flat(); }
 
 const song: Song = {
-  name: 'Color Wheel', bpm: 120, stepsPerBeat: 2,
+  name: 'Color Wheel', meta: { 'author':'Claude', 'key':'C 大调', 'style':'回旋轮盘', 'wave':'方波' }, bpm: 120, stepsPerBeat: 2,
   tones: [
     { wave: 'square', gain: 0.14, dur: 0.12,
       notes: join(mA, mB, mA, mC, mA, mB, mA, mD) },

--- a/packages/client/src/shared/sound/songs/game-4.ts
+++ b/packages/client/src/shared/sound/songs/game-4.ts
@@ -1,0 +1,55 @@
+import type { N, Song } from './common';
+import { _, T, F, rep, harm, harmArp, bass, bassHalf,
+  C2, C3, F2, F3, G2, G3, A2, A3, D3,
+  B3, C4, D4, E4, F4, G4,
+  A4, B4, C5, D5, E5, F5, G5, A5, B5,
+} from './common';
+
+
+const mA: N[] = [ // C – Am – F – G  (main theme: stepwise + leaps)
+  C5, _,D5, _,E5, _,G5, _,  A4, _,C5, _,E5, _, _, _,
+  F5, _,E5, _,D5, _,C5, _,  B4, _,D5, _, _, _, _, _,
+];
+const mB: N[] = [ // Am – F – C – G  (contrast: legato descending)
+  A5, _,G5, _,E5, _,D5,C5,  F5, _,E5, _,C5, _,A4, _,
+  G5, _,E5, _,C5, _,E5, _,  D5, _, _, _, _, _, _, _,
+];
+const mC: N[] = [ // F – G – Am – F  (bridge: call & response)
+  F5, _,A5, _, _, _,G5, _,  G5, _,B5, _, _, _,A5, _,
+  A5, _,E5, _,C5, _,A4, _,  A4, _,C5, _,F5, _, _, _,
+];
+const mD: N[] = [ // Dm – G – C – C  (outro: resolving)
+  D5, _,F5, _,A5, _,G5,F5,  G5, _,B5, _,D5, _,B4, _,
+  C5, _,E5, _,G5,E5,C5, _,  C5, _, _, _, _, _, _, _,
+];
+
+const hA = harm([E4,G4],[C4,E4],[A3,C4],[B3,D4]);
+const hB = harmArp([A3,C4,E4],[F3,A3,C4],[C4,E4,G4],[B3,D4,G4]);
+const hC = harm([A3,F4],[B3,G4],[C4,E4],[A3,C4]);
+const hD = harmArp([D4,F4,A3],[B3,D4,G4],[C4,E4,G4],[C4,E4,G4]);
+
+const bA = bass([C2,C3],[A2,A3],[F2,F3],[G2,G3]);
+const bB = bass([A2,A3],[F2,F3],[C2,C3],[G2,G3]);
+const bC = bassHalf([F2,F3],[G2,G3],[A2,A3],[F2,F3]);
+const bD = bass([D3,F3],[G2,G3],[C2,C3],[C2,C3]);
+
+function join(...s: N[][]): N[] { return s.flat(); }
+
+const song: Song = {
+  name: 'Color Wheel', bpm: 120, stepsPerBeat: 2,
+  tones: [
+    { wave: 'square', gain: 0.14, dur: 0.12,
+      notes: join(mA, mB, mA, mC, mA, mB, mA, mD) },
+    { wave: 'square', gain: 0.06, dur: 0.14,
+      notes: join(hA, hB, hA, hC, hA, hB, hA, hD) },
+    { wave: 'triangle', gain: 0.17, dur: 0.16,
+      notes: join(bA, bB, bA, bC, bA, bB, bA, bD) },
+  ],
+  kick:  { gain: 0.18, hits: rep([T,F,F,F,T,F,F,F], 32) },
+  snare: { gain: 0.09, hits: rep([F,F,T,F,F,F,T,F], 32) },
+  hihat: { gain: 0.04, hits: [
+    ...rep([T,F,T,F,T,F,T,F], 16),
+    ...rep([T,T,T,T,T,T,T,T], 16),
+  ]},
+};
+export default song;

--- a/packages/client/src/shared/sound/songs/game-5.ts
+++ b/packages/client/src/shared/sound/songs/game-5.ts
@@ -1,0 +1,60 @@
+import type { N, Song } from './common';
+import { _, T, F, rep, harm, harmArp, bass,
+  C2, C3, F2, F3, G2, G3, A2, A3, B2, E3,
+  B3, C4, D4, E4, F4, G4,
+  A4, B4, C5, D5, E5, F5, G5, A5, B5, D6,
+} from './common';
+
+
+const mA: N[] = [ // Am – G – F – G  (rapid staccato)
+  E5, _,E5, _,A5, _, _, _,  D5, _,D5, _,G5, _, _, _,
+  C5, _,C5, _,F5, _, _, _,  D5, _,D5, _,G5, _, _, _,
+];
+const mB: N[] = [ // Am – F – C – G  (scalar runs)
+  A4,B4,C5,D5,E5, _,C5, _,  F5,E5,D5,C5,A4, _, _, _,
+  C5,D5,E5,G5,E5, _,C5, _,  G5, _,D5, _,B4, _, _, _,
+];
+const mC: N[] = [ // F – Am – G – C  (leaping, heroic)
+  F5, _,A5, _,F5,C5, _,A4,  A5, _,E5, _,A4,C5,E5, _,
+  G5, _,B5, _,G5,D5, _,B4,  C5,E5,G5, _,C5, _, _, _,
+];
+const mD: N[] = [ // Am – F – G – Am  (climactic resolution)
+  A5,G5,E5,C5,A4,C5,E5,G5,  F5,E5,C5,A4,F4,A4,C5,F5,
+  G5, _,B5, _,D6, _,B5,G5,  A5, _, _, _, _, _, _, _,
+];
+
+const hA = harm([C4,E4],[B3,D4],[A3,C4],[B3,D4]);
+const hB = harmArp([A3,C4,E4],[F3,A3,C4],[C4,E4,G4],[B3,D4,G4]);
+const hC = harm([A3,F4],[C4,E4],[B3,G4],[C4,E4]);
+const hD: N[] = [
+  C4, _,E4, _,C4, _,E4, _,  A3, _,C4, _,A3, _,C4, _,
+  B3, _,D4, _,B3, _,D4, _,  A3, _, _, _, _, _, _, _,
+];
+
+const bA = bass([A2,A3],[G2,G3],[F2,F3],[G2,G3]);
+const bB = bass([A2,A3],[F2,F3],[C2,C3],[G2,G3]);
+const bC = bass([F2,F3],[A2,A3],[G2,G3],[C2,C3]);
+const bD = bass([A2,A3],[F2,F3],[G2,G3],[A2,A3]);
+
+function join(...s: N[][]): N[] { return s.flat(); }
+
+const song: Song = {
+  name: 'Wild Card', bpm: 148, stepsPerBeat: 2,
+  tones: [
+    { wave: 'square', gain: 0.15, dur: 0.09,
+      notes: join(mA, mA, mB, mB, mC, mC, mD, mD) },
+    { wave: 'square', gain: 0.07, dur: 0.11,
+      notes: join(hA, hA, hB, hB, hC, hC, hD, hD) },
+    { wave: 'triangle', gain: 0.18, dur: 0.13,
+      notes: join(bA, bA, bB, bB, bC, bC, bD, bD) },
+  ],
+  kick:  { gain: 0.22, hits: [
+    ...rep([T,F,F,F,T,F,F,F], 8),
+    ...rep([T,F,T,F,T,F,F,F], 8),
+    ...rep([T,F,F,F,T,F,T,F], 8),
+    ...rep([T,F,T,F,T,F,T,F], 7), T,F,T,T,T,T,T,T,
+  ]},
+  snare: { gain: 0.10, hits: [...rep([F,F,T,F,F,F,T,F], 31), F,T,T,F,T,T,F,T] },
+  hihat: { gain: 0.04, hits: rep([T,T,T,T,T,T,T,T], 32) },
+};
+export default song;

--- a/packages/client/src/shared/sound/songs/game-5.ts
+++ b/packages/client/src/shared/sound/songs/game-5.ts
@@ -5,20 +5,19 @@ import { _, T, F, rep, harm, harmArp, bass,
   A4, B4, C5, D5, E5, F5, G5, A5, B5, D6,
 } from './common';
 
-
-const mA: N[] = [ // Am – G – F – G  (rapid staccato)
+const mA: N[] = [
   E5, _,E5, _,A5, _, _, _,  D5, _,D5, _,G5, _, _, _,
   C5, _,C5, _,F5, _, _, _,  D5, _,D5, _,G5, _, _, _,
 ];
-const mB: N[] = [ // Am – F – C – G  (scalar runs)
+const mB: N[] = [
   A4,B4,C5,D5,E5, _,C5, _,  F5,E5,D5,C5,A4, _, _, _,
   C5,D5,E5,G5,E5, _,C5, _,  G5, _,D5, _,B4, _, _, _,
 ];
-const mC: N[] = [ // F – Am – G – C  (leaping, heroic)
+const mC: N[] = [
   F5, _,A5, _,F5,C5, _,A4,  A5, _,E5, _,A4,C5,E5, _,
   G5, _,B5, _,G5,D5, _,B4,  C5,E5,G5, _,C5, _, _, _,
 ];
-const mD: N[] = [ // Am – F – G – Am  (climactic resolution)
+const mD: N[] = [
   A5,G5,E5,C5,A4,C5,E5,G5,  F5,E5,C5,A4,F4,A4,C5,F5,
   G5, _,B5, _,D6, _,B5,G5,  A5, _, _, _, _, _, _, _,
 ];

--- a/packages/client/src/shared/sound/songs/game-5.ts
+++ b/packages/client/src/shared/sound/songs/game-5.ts
@@ -38,7 +38,7 @@ const bD = bass([A2,A3],[F2,F3],[G2,G3],[A2,A3]);
 function join(...s: N[][]): N[] { return s.flat(); }
 
 const song: Song = {
-  name: 'Wild Card', bpm: 148, stepsPerBeat: 2,
+  name: 'Wild Card', meta: { 'author':'Claude', 'key':'A 小调', 'style':'极速冲刺', 'wave':'方波' }, bpm: 148, stepsPerBeat: 2,
   tones: [
     { wave: 'square', gain: 0.15, dur: 0.09,
       notes: join(mA, mA, mB, mB, mC, mC, mD, mD) },

--- a/packages/client/src/shared/sound/songs/game-6.ts
+++ b/packages/client/src/shared/sound/songs/game-6.ts
@@ -41,7 +41,7 @@ const bE = bass([E2,E3],[D2,D3],[C3,C4],[G2,G3]);
 function join(...s: N[][]): N[] { return s.flat(); }
 
 const song: Song = {
-  name: 'Blitz', bpm: 135, stepsPerBeat: 2,
+  name: 'Blitz', meta: { 'author':'Claude', 'key':'G 大调', 'style':'进行曲', 'wave':'锯齿波' }, bpm: 135, stepsPerBeat: 2,
   tones: [
     { wave: 'sawtooth', gain: 0.10, dur: 0.1,
       notes: join(mA, mB, mC, mA, mD, mA, mB, mE) },

--- a/packages/client/src/shared/sound/songs/game-6.ts
+++ b/packages/client/src/shared/sound/songs/game-6.ts
@@ -5,24 +5,23 @@ import { _, T, F, rep, harm, harmArp, bass,
   B4, C5, D5, E5, Fs5, G5, A5, B5, D6,
 } from './common';
 
-
-const mA: N[] = [ // G – D – Em – C
+const mA: N[] = [
   G5,G5,B5,B5,D6,D6,B5, _,  Fs5, _,A5, _,D5, _,A5, _,
   E5,E5,G5,G5,B5,B5,G5, _,  C5, _,E5, _,G5, _, _, _,
 ];
-const mB: N[] = [ // Em – C – G – D
+const mB: N[] = [
   B5, _,G5, _,E5, _,G5,B5,  G5, _,E5, _,C5, _,E5, _,
   D5, _,G5, _,B5, _,G5,D5,  A5, _,Fs5, _,D5, _, _, _,
 ];
-const mC: N[] = [ // G – Bm – C – D
+const mC: N[] = [
   G5, _,B5, _,D6, _, _, _,  Fs5, _,B5, _,D5, _,Fs5, _,
   E5, _,G5, _,C5,E5,G5, _,  D5, _,Fs5, _,A5, _, _, _,
 ];
-const mD: N[] = [ // C – D – Em – G
+const mD: N[] = [
   C5,E5,G5, _,E5,C5, _, _,  D5,Fs5,A5, _,Fs5,D5, _, _,
   E5,G5,B5, _,G5,E5, _, _,  G5, _,B5, _,D6, _, _, _,
 ];
-const mE: N[] = [ // Em – D – C – G
+const mE: N[] = [
   E5, _,G5, _,B5,G5,E5, _,  D5, _,Fs5, _,A5, _,D5, _,
   C5, _,E5, _,G5, _,E5,C5,  G5, _,B5, _,G5, _, _, _,
 ];

--- a/packages/client/src/shared/sound/songs/game-6.ts
+++ b/packages/client/src/shared/sound/songs/game-6.ts
@@ -1,0 +1,62 @@
+import type { N, Song } from './common';
+import { _, T, F, rep, harm, harmArp, bass,
+  B2, D2, E2, G2, C3, D3, E3, G3,
+  A3, B3, C4, D4, E4, Fs4, G4, A4,
+  B4, C5, D5, E5, Fs5, G5, A5, B5, D6,
+} from './common';
+
+
+const mA: N[] = [ // G – D – Em – C
+  G5,G5,B5,B5,D6,D6,B5, _,  Fs5, _,A5, _,D5, _,A5, _,
+  E5,E5,G5,G5,B5,B5,G5, _,  C5, _,E5, _,G5, _, _, _,
+];
+const mB: N[] = [ // Em – C – G – D
+  B5, _,G5, _,E5, _,G5,B5,  G5, _,E5, _,C5, _,E5, _,
+  D5, _,G5, _,B5, _,G5,D5,  A5, _,Fs5, _,D5, _, _, _,
+];
+const mC: N[] = [ // G – Bm – C – D
+  G5, _,B5, _,D6, _, _, _,  Fs5, _,B5, _,D5, _,Fs5, _,
+  E5, _,G5, _,C5,E5,G5, _,  D5, _,Fs5, _,A5, _, _, _,
+];
+const mD: N[] = [ // C – D – Em – G
+  C5,E5,G5, _,E5,C5, _, _,  D5,Fs5,A5, _,Fs5,D5, _, _,
+  E5,G5,B5, _,G5,E5, _, _,  G5, _,B5, _,D6, _, _, _,
+];
+const mE: N[] = [ // Em – D – C – G
+  E5, _,G5, _,B5,G5,E5, _,  D5, _,Fs5, _,A5, _,D5, _,
+  C5, _,E5, _,G5, _,E5,C5,  G5, _,B5, _,G5, _, _, _,
+];
+
+const hA = harm([B3,D4],[Fs4,A4],[G3,B3],[E4,G4]);
+const hB = harmArp([G3,B3,E4],[E4,G4,C5],[B3,D4,G4],[Fs4,A4,D4]);
+const hC = harm([B3,D4],[B3,Fs4],[E4,G4],[D4,Fs4]);
+const hD = harmArp([E4,G4,C5],[Fs4,A4,D4],[G3,B3,E4],[B3,D4,G4]);
+const hE = harm([G3,B3],[Fs4,A4],[E4,G4],[B3,D4]);
+
+const bA = bass([G2,G3],[D2,D3],[E2,E3],[C3,C4]);
+const bB = bass([E2,E3],[C3,C4],[G2,G3],[D2,D3]);
+const bC = bass([G2,G3],[B2,B3],[C3,C4],[D2,D3]);
+const bD = bass([C3,C4],[D2,D3],[E2,E3],[G2,G3]);
+const bE = bass([E2,E3],[D2,D3],[C3,C4],[G2,G3]);
+
+function join(...s: N[][]): N[] { return s.flat(); }
+
+const song: Song = {
+  name: 'Blitz', bpm: 135, stepsPerBeat: 2,
+  tones: [
+    { wave: 'sawtooth', gain: 0.10, dur: 0.1,
+      notes: join(mA, mB, mC, mA, mD, mA, mB, mE) },
+    { wave: 'square', gain: 0.06, dur: 0.12,
+      notes: join(hA, hB, hC, hA, hD, hA, hB, hE) },
+    { wave: 'triangle', gain: 0.18, dur: 0.15,
+      notes: join(bA, bB, bC, bA, bD, bA, bB, bE) },
+  ],
+  kick:  { gain: 0.20, hits: [
+    ...rep([T,F,T,F,T,F,F,F], 8),
+    ...rep([T,F,F,F,T,F,F,F], 16),
+    ...rep([T,F,T,F,T,F,T,F], 7), T,F,T,T,T,F,T,T,
+  ]},
+  snare: { gain: 0.10, hits: [...rep([F,F,T,F,F,F,T,F], 31), F,F,T,T,F,T,T,T] },
+  hihat: { gain: 0.04, hits: rep([T,T,T,T,T,T,T,T], 32) },
+};
+export default song;

--- a/packages/client/src/shared/sound/songs/game-7.ts
+++ b/packages/client/src/shared/sound/songs/game-7.ts
@@ -41,7 +41,7 @@ const bE = bass([D3,A3],[C2,C3],[Bb2,Bb3],[F2,F3]);
 function join(...s: N[][]): N[] { return s.flat(); }
 
 const song: Song = {
-  name: 'Carnival', bpm: 132, stepsPerBeat: 2,
+  name: 'Carnival', meta: { 'author':'Claude', 'key':'F 大调', 'style':'拉丁嘉年华', 'wave':'正弦波' }, bpm: 132, stepsPerBeat: 2,
   tones: [
     { wave: 'sine', gain: 0.18, dur: 0.12,
       notes: join(mA, mB, mA, mC, mD, mA, mB, mE) },

--- a/packages/client/src/shared/sound/songs/game-7.ts
+++ b/packages/client/src/shared/sound/songs/game-7.ts
@@ -1,0 +1,64 @@
+import type { N, Song } from './common';
+import { _, T, F, rep, harm, harmArp, bass,
+  C2, C3, D3, F2, F3, G2, G3, A2, A3, Bb2, Bb3,
+  Bb4, C4, D4, E4, F4, G4,
+  A4, C5, D5, E5, F5, G5, A5, Bb5,
+} from './common';
+
+
+const mA: N[] = [ // F – C – Dm – Bb
+  F5, _,A5, _,C5, _,A5,F5,  E5, _,G5, _,C5, _,E5, _,
+  D5, _,F5, _,A5, _,F5,D5,  Bb4, _,D5, _,F5, _, _, _,
+];
+const mB: N[] = [ // Dm – Bb – F – C
+  A5, _,F5, _,D5, _,F5,A5,  F5, _,D5, _,Bb4, _,D5, _,
+  F5, _,A5, _,C5,A5, _,F5,  G5, _,E5, _,C5, _, _, _,
+];
+const mC: N[] = [ // F – Gm – Bb – C
+  F5,F5, _, _,A5, _, _, _,  G5,G5, _, _,Bb5, _, _, _,
+  Bb4, _,D5, _,F5,Bb4, _, _,  C5, _,E5, _,G5, _, _, _,
+];
+const mD: N[] = [ // Bb – C – Dm – F
+  Bb4,D5,F5, _,D5,Bb4, _, _,  C5,E5,G5, _,E5,C5, _, _,
+  D5,F5,A5, _,F5,D5, _, _,  F5, _,A5, _,C5, _, _, _,
+];
+const mE: N[] = [ // Dm – C – Bb – F
+  D5, _,A5, _,F5, _,D5, _,  C5, _,G5, _,E5, _,C5, _,
+  Bb4, _,F5, _,D5, _,Bb4, _,  F5, _,A5, _,F5, _, _, _,
+];
+
+const hA = harm([A3,C4],[E4,G4],[F3,A3],[Bb3,D4]);
+const hB = harmArp([F3,A3,D4],[Bb3,D4,F4],[A3,C4,F4],[E4,G4,C4]);
+const hC = harm([A3,C4],[Bb3,D4],[Bb3,D4],[E4,G4]);
+const hD = harmArp([Bb3,D4,F4],[E4,G4,C4],[F3,A3,D4],[A3,C4,F4]);
+const hE = harm([F3,A3],[E4,G4],[Bb3,D4],[A3,C4]);
+
+const bA = bass([F2,F3],[C2,C3],[D3,A3],[Bb2,Bb3]);
+const bB = bass([D3,A3],[Bb2,Bb3],[F2,F3],[C2,C3]);
+const bC = bass([F2,F3],[G2,G3],[Bb2,Bb3],[C2,C3]);
+const bD = bass([Bb2,Bb3],[C2,C3],[D3,A3],[F2,F3]);
+const bE = bass([D3,A3],[C2,C3],[Bb2,Bb3],[F2,F3]);
+
+function join(...s: N[][]): N[] { return s.flat(); }
+
+const song: Song = {
+  name: 'Carnival', bpm: 132, stepsPerBeat: 2,
+  tones: [
+    { wave: 'sine', gain: 0.18, dur: 0.12,
+      notes: join(mA, mB, mA, mC, mD, mA, mB, mE) },
+    { wave: 'square', gain: 0.06, dur: 0.12,
+      notes: join(hA, hB, hA, hC, hD, hA, hB, hE) },
+    { wave: 'triangle', gain: 0.17, dur: 0.15,
+      notes: join(bA, bB, bA, bC, bD, bA, bB, bE) },
+  ],
+  kick:  { gain: 0.20, hits: [
+    ...rep([T,F,F,T,F,F,T,F], 16),
+    ...rep([T,F,F,F,T,F,F,F], 16),
+  ]},
+  snare: { gain: 0.09, hits: [
+    ...rep([F,F,F,T,F,F,T,F], 16),
+    ...rep([F,F,T,F,F,F,T,F], 16),
+  ]},
+  hihat: { gain: 0.04, hits: rep([T,T,T,T,T,T,T,T], 32) },
+};
+export default song;

--- a/packages/client/src/shared/sound/songs/game-7.ts
+++ b/packages/client/src/shared/sound/songs/game-7.ts
@@ -5,24 +5,23 @@ import { _, T, F, rep, harm, harmArp, bass,
   A4, C5, D5, E5, F5, G5, A5, Bb5,
 } from './common';
 
-
-const mA: N[] = [ // F – C – Dm – Bb
+const mA: N[] = [
   F5, _,A5, _,C5, _,A5,F5,  E5, _,G5, _,C5, _,E5, _,
   D5, _,F5, _,A5, _,F5,D5,  Bb4, _,D5, _,F5, _, _, _,
 ];
-const mB: N[] = [ // Dm – Bb – F – C
+const mB: N[] = [
   A5, _,F5, _,D5, _,F5,A5,  F5, _,D5, _,Bb4, _,D5, _,
   F5, _,A5, _,C5,A5, _,F5,  G5, _,E5, _,C5, _, _, _,
 ];
-const mC: N[] = [ // F – Gm – Bb – C
+const mC: N[] = [
   F5,F5, _, _,A5, _, _, _,  G5,G5, _, _,Bb5, _, _, _,
   Bb4, _,D5, _,F5,Bb4, _, _,  C5, _,E5, _,G5, _, _, _,
 ];
-const mD: N[] = [ // Bb – C – Dm – F
+const mD: N[] = [
   Bb4,D5,F5, _,D5,Bb4, _, _,  C5,E5,G5, _,E5,C5, _, _,
   D5,F5,A5, _,F5,D5, _, _,  F5, _,A5, _,C5, _, _, _,
 ];
-const mE: N[] = [ // Dm – C – Bb – F
+const mE: N[] = [
   D5, _,A5, _,F5, _,D5, _,  C5, _,G5, _,E5, _,C5, _,
   Bb4, _,F5, _,D5, _,Bb4, _,  F5, _,A5, _,F5, _, _, _,
 ];

--- a/packages/client/src/shared/sound/songs/game-8.ts
+++ b/packages/client/src/shared/sound/songs/game-8.ts
@@ -1,0 +1,58 @@
+import type { N, Song } from './common';
+import { _, T, F, rep, harm, harmArp, bass, bassHalf,
+  C2, C3, D2, D3, F2, F3, G2, G3, A2, A3, Bb2, Bb3,
+  Bb4, C4, D4, E4, F4, G4,
+  A4, C5, D5, E5, F5, G5, A5, Bb5,
+} from './common';
+
+
+const mA: N[] = [ // Dm – Am – Bb – C
+  D5, _,F5, _,A5, _,F5,D5,  E5, _,A5, _,C5, _,E5, _,
+  Bb4, _,D5, _,F5, _,Bb4, _,  C5, _,E5, _,G5, _, _, _,
+];
+const mB: N[] = [ // Dm – Gm – Am – Dm
+  A5, _,G5, _,F5, _,D5, _,  G5, _,Bb4, _,D5, _,G5, _,
+  A5, _,E5, _,C5, _,A4, _,  D5, _,F5, _,A5, _, _, _,
+];
+const mC: N[] = [ // Bb – C – Dm – Am
+  Bb4,Bb4,D5,D5,F5, _, _, _,  C5,C5,E5,E5,G5, _, _, _,
+  D5, _,F5, _,A5,F5,D5, _,  E5, _,C5, _,A4, _, _, _,
+];
+const mD: N[] = [ // Dm – Bb – C – Dm
+  D5,F5,A5,D5,F5,A5, _, _,  Bb4, _,D5, _,F5, _,D5,Bb4,
+  C5, _,E5, _,G5, _,E5,C5,  D5, _,F5, _,D5, _, _, _,
+];
+const mE: N[] = [ // Gm – Am – Bb – C
+  G5, _,Bb4, _,D5, _,G5, _,  A5, _,C5, _,E5, _,A5, _,
+  Bb4, _,D5, _,F5,D5, _,Bb4,  C5, _,G5, _,E5, _, _, _,
+];
+
+const hA = harm([F3,A3],[C4,E4],[Bb3,D4],[E4,G4]);
+const hB = harmArp([F3,A3,D4],[Bb3,D4,G4],[C4,E4,A3],[F3,A3,D4]);
+const hC = harm([Bb3,D4],[E4,G4],[F3,A3],[C4,E4]);
+const hD = harmArp([F3,A3,D4],[Bb3,D4,F4],[E4,G4,C4],[F3,A3,D4]);
+const hE = harm([Bb3,D4],[C4,E4],[Bb3,D4],[E4,G4]);
+
+const bA = bassHalf([D2,D3],[A2,A3],[Bb2,Bb3],[C2,C3]);
+const bB = bass([D2,D3],[G2,G3],[A2,A3],[D2,D3]);
+const bC = bassHalf([Bb2,Bb3],[C2,C3],[D2,D3],[A2,A3]);
+const bD = bass([D2,D3],[Bb2,Bb3],[C2,C3],[D2,D3]);
+const bE = bassHalf([G2,G3],[A2,A3],[Bb2,Bb3],[C2,C3]);
+
+function join(...s: N[][]): N[] { return s.flat(); }
+
+const song: Song = {
+  name: 'Midnight', bpm: 116, stepsPerBeat: 2,
+  tones: [
+    { wave: 'square', gain: 0.13, dur: 0.14,
+      notes: join(mA, mB, mC, mA, mD, mE, mB, mD) },
+    { wave: 'square', gain: 0.05, dur: 0.14,
+      notes: join(hA, hB, hC, hA, hD, hE, hB, hD) },
+    { wave: 'triangle', gain: 0.16, dur: 0.18,
+      notes: join(bA, bB, bC, bA, bD, bE, bB, bD) },
+  ],
+  kick:  { gain: 0.16, hits: rep([T,F,F,F,F,F,F,F], 32) },
+  snare: { gain: 0.06, hits: rep([F,F,F,F,T,F,F,F], 32) },
+  hihat: { gain: 0.03, hits: rep([T,F,T,F,T,F,T,F], 32) },
+};
+export default song;

--- a/packages/client/src/shared/sound/songs/game-8.ts
+++ b/packages/client/src/shared/sound/songs/game-8.ts
@@ -5,24 +5,23 @@ import { _, T, F, rep, harm, harmArp, bass, bassHalf,
   A4, C5, D5, E5, F5, G5, A5, Bb5,
 } from './common';
 
-
-const mA: N[] = [ // Dm – Am – Bb – C
+const mA: N[] = [
   D5, _,F5, _,A5, _,F5,D5,  E5, _,A5, _,C5, _,E5, _,
   Bb4, _,D5, _,F5, _,Bb4, _,  C5, _,E5, _,G5, _, _, _,
 ];
-const mB: N[] = [ // Dm – Gm – Am – Dm
+const mB: N[] = [
   A5, _,G5, _,F5, _,D5, _,  G5, _,Bb4, _,D5, _,G5, _,
   A5, _,E5, _,C5, _,A4, _,  D5, _,F5, _,A5, _, _, _,
 ];
-const mC: N[] = [ // Bb – C – Dm – Am
+const mC: N[] = [
   Bb4,Bb4,D5,D5,F5, _, _, _,  C5,C5,E5,E5,G5, _, _, _,
   D5, _,F5, _,A5,F5,D5, _,  E5, _,C5, _,A4, _, _, _,
 ];
-const mD: N[] = [ // Dm – Bb – C – Dm
+const mD: N[] = [
   D5,F5,A5,D5,F5,A5, _, _,  Bb4, _,D5, _,F5, _,D5,Bb4,
   C5, _,E5, _,G5, _,E5,C5,  D5, _,F5, _,D5, _, _, _,
 ];
-const mE: N[] = [ // Gm – Am – Bb – C
+const mE: N[] = [
   G5, _,Bb4, _,D5, _,G5, _,  A5, _,C5, _,E5, _,A5, _,
   Bb4, _,D5, _,F5,D5, _,Bb4,  C5, _,G5, _,E5, _, _, _,
 ];

--- a/packages/client/src/shared/sound/songs/game-8.ts
+++ b/packages/client/src/shared/sound/songs/game-8.ts
@@ -41,7 +41,7 @@ const bE = bassHalf([G2,G3],[A2,A3],[Bb2,Bb3],[C2,C3]);
 function join(...s: N[][]): N[] { return s.flat(); }
 
 const song: Song = {
-  name: 'Midnight', bpm: 116, stepsPerBeat: 2,
+  name: 'Midnight', meta: { 'author':'Claude', 'key':'D 小调', 'style':'暗夜氛围', 'wave':'方波' }, bpm: 116, stepsPerBeat: 2,
   tones: [
     { wave: 'square', gain: 0.13, dur: 0.14,
       notes: join(mA, mB, mC, mA, mD, mE, mB, mD) },

--- a/packages/client/src/shared/sound/songs/game-9.ts
+++ b/packages/client/src/shared/sound/songs/game-9.ts
@@ -43,7 +43,7 @@ const bD: N[] = [
 function join(...s: N[][]): N[] { return s.flat(); }
 
 const song: Song = {
-  name: 'Pulse', bpm: 140, stepsPerBeat: 2,
+  name: 'Pulse', meta: { 'author':'Claude', 'key':'A 小调', 'style':'纯节奏', 'wave':'方波' }, bpm: 140, stepsPerBeat: 2,
   tones: [
     { wave: 'square', gain: 0.12, dur: 0.05,
       notes: join(mA, mB, mC, mD, mA, mB, mC, mE) },

--- a/packages/client/src/shared/sound/songs/game-9.ts
+++ b/packages/client/src/shared/sound/songs/game-9.ts
@@ -1,0 +1,95 @@
+import type { N, Song } from './common';
+import { _, T, F, rep, bass,
+  C2, C3, F2, F3, G2, G3, A2, A3,
+  C4, E4, G4, A4, C5, E5,
+} from './common';
+
+
+// 旋律：极度稀疏的 stab，每段只有几个音
+const mA: N[] = [
+   _, _, _, _, _, _, _, _,   _, _, _, _,E5, _, _, _,
+   _, _, _, _, _, _, _, _,   _, _, _, _,C5, _, _, _,
+];
+const mB: N[] = [
+   _, _, _, _, _, _,A4, _,   _, _, _, _, _, _, _, _,
+   _, _, _, _, _, _,E5, _,   _, _, _, _, _, _, _, _,
+];
+const mC: N[] = [
+  E5, _, _, _, _, _, _, _,   _, _, _, _, _, _, _, _,
+   _, _, _, _, _, _, _, _,  C5, _, _, _, _, _, _, _,
+];
+const mD: N[] = [
+   _, _, _, _, _, _, _, _,   _, _, _, _, _, _, _, _,
+   _, _, _, _, _, _, _, _,   _, _, _, _, _, _, _, _,
+];
+const mE: N[] = [
+  E5, _,C5, _, _, _, _, _,  A4, _, _, _, _, _, _, _,
+   _, _, _, _, _, _, _, _,   _, _, _, _, _, _, _, _,
+];
+
+// 无和声
+const silent: N[] = Array.from({ length: 32 }, () => null);
+
+// 贝斯：短促有力的根音脉冲
+const bA = bass([A2,A3],[F2,F3],[C2,C3],[G2,G3]);
+const bB: N[] = [
+  A2, _,A2, _, _,A3, _, _,  F2, _,F2, _, _,F3, _, _,
+  C3, _,C2, _, _,C3, _, _,  G2, _,G2, _, _,G3, _, _,
+];
+const bC: N[] = [
+  A2,A2, _,A3, _,A2, _,A3,  F2,F2, _,F3, _,F2, _,F3,
+  C2,C2, _,C3, _,C2, _,C3,  G2,G2, _,G3, _,G2, _,G3,
+];
+const bD: N[] = [ // breakdown — 只有根音长音
+  A2, _, _, _, _, _, _, _,  F2, _, _, _, _, _, _, _,
+  C2, _, _, _, _, _, _, _,  G2, _, _, _, _, _, _, _,
+];
+
+function join(...s: N[][]): N[] { return s.flat(); }
+
+const song: Song = {
+  name: 'Pulse', bpm: 140, stepsPerBeat: 2,
+  tones: [
+    { wave: 'square', gain: 0.12, dur: 0.05,
+      notes: join(mA, mB, mC, mD, mA, mB, mC, mE) },
+    { wave: 'square', gain: 0.00, dur: 0.1,
+      notes: join(silent, silent, silent, silent, silent, silent, silent, silent) },
+    { wave: 'triangle', gain: 0.22, dur: 0.1,
+      notes: join(bA, bB, bC, bD, bA, bB, bC, bA) },
+  ],
+  // ── 鼓组：段落间差异极大 ──
+  kick: { gain: 0.25, hits: [
+    ...rep([T,F,F,F,T,F,F,F], 8),              // A: four-on-the-floor
+    ...rep([T,F,F,T,F,F,T,F], 8),              // B: syncopated
+    ...rep([T,F,T,F,T,F,T,F], 8),              // C: double-time
+    ...[F,F,F,F,F,F,F,F,F,F,F,F,F,F,F,F,      // D: breakdown (no kick)
+        F,F,F,F,F,F,F,F,F,F,F,F,F,F,F,F],
+    ...rep([T,F,F,F,T,F,F,F], 8),              // A
+    ...rep([T,F,F,T,F,F,T,F], 8),              // B
+    ...rep([T,F,T,F,T,F,T,F], 8),              // C
+    ...rep([T,F,F,F,T,F,F,F], 7),              // E: standard + fill
+    ...[T,T,F,T,T,F,T,T],
+  ]},
+  snare: { gain: 0.12, hits: [
+    ...rep([F,F,T,F,F,F,T,F], 8),              // A
+    ...rep([F,F,T,F,F,T,F,F], 8),              // B: off-beat
+    ...rep([F,T,F,T,F,T,F,T], 8),              // C: every off-beat
+    ...rep([F,F,T,F,F,F,T,F], 8),              // D: standard over silence
+    ...rep([F,F,T,F,F,F,T,F], 8),              // A
+    ...rep([F,F,T,F,F,T,F,F], 8),              // B
+    ...rep([F,T,F,T,F,T,F,T], 8),              // C
+    ...rep([F,F,T,F,F,F,T,F], 7),              // E + fill
+    ...[T,F,T,T,F,T,T,T],
+  ]},
+  hihat: { gain: 0.05, hits: [
+    ...rep([T,T,T,T,T,T,T,T], 8),              // A: 8ths
+    ...rep([T,T,T,T,T,T,T,T], 8),              // B
+    ...rep([T,T,T,T,T,T,T,T], 8),              // C
+    ...rep([T,F,T,F,T,F,T,F], 8),              // D: quarter (sparse)
+    ...rep([T,T,T,T,T,T,T,T], 8),              // A
+    ...rep([T,T,T,T,T,T,T,T], 8),              // B
+    ...rep([T,T,T,T,T,T,T,T], 8),              // C
+    ...rep([T,T,T,T,T,T,T,T], 8),              // E
+  ]},
+};
+export default song;

--- a/packages/client/src/shared/sound/songs/game-9.ts
+++ b/packages/client/src/shared/sound/songs/game-9.ts
@@ -4,8 +4,6 @@ import { _, T, F, rep, bass,
   C4, E4, G4, A4, C5, E5,
 } from './common';
 
-
-// 旋律：极度稀疏的 stab，每段只有几个音
 const mA: N[] = [
    _, _, _, _, _, _, _, _,   _, _, _, _,E5, _, _, _,
    _, _, _, _, _, _, _, _,   _, _, _, _,C5, _, _, _,
@@ -26,11 +24,8 @@ const mE: N[] = [
   E5, _,C5, _, _, _, _, _,  A4, _, _, _, _, _, _, _,
    _, _, _, _, _, _, _, _,   _, _, _, _, _, _, _, _,
 ];
-
-// 无和声
 const silent: N[] = Array.from({ length: 32 }, () => null);
 
-// 贝斯：短促有力的根音脉冲
 const bA = bass([A2,A3],[F2,F3],[C2,C3],[G2,G3]);
 const bB: N[] = [
   A2, _,A2, _, _,A3, _, _,  F2, _,F2, _, _,F3, _, _,
@@ -40,7 +35,7 @@ const bC: N[] = [
   A2,A2, _,A3, _,A2, _,A3,  F2,F2, _,F3, _,F2, _,F3,
   C2,C2, _,C3, _,C2, _,C3,  G2,G2, _,G3, _,G2, _,G3,
 ];
-const bD: N[] = [ // breakdown — 只有根音长音
+const bD: N[] = [
   A2, _, _, _, _, _, _, _,  F2, _, _, _, _, _, _, _,
   C2, _, _, _, _, _, _, _,  G2, _, _, _, _, _, _, _,
 ];
@@ -57,39 +52,38 @@ const song: Song = {
     { wave: 'triangle', gain: 0.22, dur: 0.1,
       notes: join(bA, bB, bC, bD, bA, bB, bC, bA) },
   ],
-  // ── 鼓组：段落间差异极大 ──
   kick: { gain: 0.25, hits: [
-    ...rep([T,F,F,F,T,F,F,F], 8),              // A: four-on-the-floor
-    ...rep([T,F,F,T,F,F,T,F], 8),              // B: syncopated
-    ...rep([T,F,T,F,T,F,T,F], 8),              // C: double-time
-    ...[F,F,F,F,F,F,F,F,F,F,F,F,F,F,F,F,      // D: breakdown (no kick)
+    ...rep([T,F,F,F,T,F,F,F], 8),
+    ...rep([T,F,F,T,F,F,T,F], 8),
+    ...rep([T,F,T,F,T,F,T,F], 8),
+    ...[F,F,F,F,F,F,F,F,F,F,F,F,F,F,F,F,
         F,F,F,F,F,F,F,F,F,F,F,F,F,F,F,F],
-    ...rep([T,F,F,F,T,F,F,F], 8),              // A
-    ...rep([T,F,F,T,F,F,T,F], 8),              // B
-    ...rep([T,F,T,F,T,F,T,F], 8),              // C
-    ...rep([T,F,F,F,T,F,F,F], 7),              // E: standard + fill
+    ...rep([T,F,F,F,T,F,F,F], 8),
+    ...rep([T,F,F,T,F,F,T,F], 8),
+    ...rep([T,F,T,F,T,F,T,F], 8),
+    ...rep([T,F,F,F,T,F,F,F], 7),
     ...[T,T,F,T,T,F,T,T],
   ]},
   snare: { gain: 0.12, hits: [
-    ...rep([F,F,T,F,F,F,T,F], 8),              // A
-    ...rep([F,F,T,F,F,T,F,F], 8),              // B: off-beat
-    ...rep([F,T,F,T,F,T,F,T], 8),              // C: every off-beat
-    ...rep([F,F,T,F,F,F,T,F], 8),              // D: standard over silence
-    ...rep([F,F,T,F,F,F,T,F], 8),              // A
-    ...rep([F,F,T,F,F,T,F,F], 8),              // B
-    ...rep([F,T,F,T,F,T,F,T], 8),              // C
-    ...rep([F,F,T,F,F,F,T,F], 7),              // E + fill
+    ...rep([F,F,T,F,F,F,T,F], 8),
+    ...rep([F,F,T,F,F,T,F,F], 8),
+    ...rep([F,T,F,T,F,T,F,T], 8),
+    ...rep([F,F,T,F,F,F,T,F], 8),
+    ...rep([F,F,T,F,F,F,T,F], 8),
+    ...rep([F,F,T,F,F,T,F,F], 8),
+    ...rep([F,T,F,T,F,T,F,T], 8),
+    ...rep([F,F,T,F,F,F,T,F], 7),
     ...[T,F,T,T,F,T,T,T],
   ]},
   hihat: { gain: 0.05, hits: [
-    ...rep([T,T,T,T,T,T,T,T], 8),              // A: 8ths
-    ...rep([T,T,T,T,T,T,T,T], 8),              // B
-    ...rep([T,T,T,T,T,T,T,T], 8),              // C
-    ...rep([T,F,T,F,T,F,T,F], 8),              // D: quarter (sparse)
-    ...rep([T,T,T,T,T,T,T,T], 8),              // A
-    ...rep([T,T,T,T,T,T,T,T], 8),              // B
-    ...rep([T,T,T,T,T,T,T,T], 8),              // C
-    ...rep([T,T,T,T,T,T,T,T], 8),              // E
+    ...rep([T,T,T,T,T,T,T,T], 8),
+    ...rep([T,T,T,T,T,T,T,T], 8),
+    ...rep([T,T,T,T,T,T,T,T], 8),
+    ...rep([T,F,T,F,T,F,T,F], 8),
+    ...rep([T,T,T,T,T,T,T,T], 8),
+    ...rep([T,T,T,T,T,T,T,T], 8),
+    ...rep([T,T,T,T,T,T,T,T], 8),
+    ...rep([T,T,T,T,T,T,T,T], 8),
   ]},
 };
 export default song;

--- a/packages/client/src/shared/sound/songs/index.ts
+++ b/packages/client/src/shared/sound/songs/index.ts
@@ -1,0 +1,24 @@
+import type { Song } from './common';
+import game1 from './game-1';
+import game2 from './game-2';
+import game3 from './game-3';
+import game4 from './game-4';
+import game5 from './game-5';
+import game6 from './game-6';
+import game7 from './game-7';
+import game8 from './game-8';
+import game9 from './game-9';
+import game10 from './game-10';
+import lobby1 from './lobby-1';
+import lobby2 from './lobby-2';
+import lobby3 from './lobby-3';
+import lobby4 from './lobby-4';
+import lobby5 from './lobby-5';
+import lobby6 from './lobby-6';
+
+export type { Song } from './common';
+
+export const PLAYLISTS: Record<string, Song[]> = {
+  game:  [game1, game2, game3, game4, game5, game6, game7, game8, game9, game10],
+  lobby: [lobby1, lobby2, lobby3, lobby4, lobby5, lobby6],
+};

--- a/packages/client/src/shared/sound/songs/lobby-1.ts
+++ b/packages/client/src/shared/sound/songs/lobby-1.ts
@@ -45,7 +45,7 @@ const bF = bassHalf([F2,F3],[G2,G3],[A2,A3],[C2,C3]);
 function join(...s: N[][]): N[] { return s.flat(); }
 
 const song: Song = {
-  name: 'Shuffle', bpm: 96, stepsPerBeat: 2,
+  name: 'Shuffle', meta: { 'author':'Claude', 'key':'C 大调', 'style':'轻快摇曳', 'wave':'方波' }, bpm: 96, stepsPerBeat: 2,
   tones: [
     { wave: 'square', gain: 0.10, dur: 0.18,
       notes: join(mA, mB, mC, mD, mE, mA, mB, mF) },

--- a/packages/client/src/shared/sound/songs/lobby-1.ts
+++ b/packages/client/src/shared/sound/songs/lobby-1.ts
@@ -1,0 +1,62 @@
+import type { N, Song } from './common';
+import { _, T, F, rep, harm, harmArp, bass, bassHalf,
+  C2, C3, F2, F3, G2, G3, A2, A3, D3,
+  B3, C4, D4, E4, F4, G4,
+  A4, B4, C5, D5, E5, F5, G5, A5, B5,
+} from './common';
+
+
+const mA: N[] = [ // C – Am – F – G
+  E5, _,G5, _,E5, _,C5,D5,  E5, _,C5, _,A4, _, _, _,
+  A4, _,C5, _,F5, _,E5,D5,  D5, _, _, _,B4, _, _, _,
+];
+const mB: N[] = [ // C – Am – F – G
+  G5, _,E5, _,C5, _,D5,E5,  A4, _,C5, _,E5, _, _, _,
+  F5, _,E5, _,D5, _,C5, _,  B4, _, _, _, _, _, _, _,
+];
+const mC: N[] = [ // C – Am – F – G
+  E5, _,G5, _,E5, _,C5,D5,  C5, _,A4, _,E4, _, _, _,
+  A4, _,C5, _,F5, _,E5,D5,  G4, _, _, _, _, _, _, _,
+];
+const mD: N[] = [ // Dm – G – C – C
+  D5, _,F5, _,A5, _,F5, _,  G5, _,D5, _,B4, _, _, _,
+  C5, _,E5, _,G5, _,E5, _,  C5, _, _, _, _, _, _, _,
+];
+const mE: N[] = [ // Am – F – G – C  (new: ascending phrases)
+  A4, _,C5, _,E5, _,A5, _,  F5, _,A5, _,C5, _, _, _,
+  D5, _,G5, _,B5, _,G5, _,  E5, _,C5, _, _, _, _, _,
+];
+const mF: N[] = [ // F – G – Am – C  (new: gentle close)
+  F5, _,E5, _,D5, _,C5, _,  D5, _,G5, _, _, _, _, _,
+  A4, _,C5, _,E5, _, _, _,  C5, _, _, _, _, _, _, _,
+];
+
+const hA = harm([C4,G4],[A3,E4],[F3,C4],[G3,D4]);
+const hB = harmArp([C4,E4,G4],[A3,C4,E4],[F3,A3,C4],[B3,D4,G4]);
+const hD = harm([D4,F4],[B3,D4],[C4,E4],[C4,E4]);
+const hE = harmArp([A3,C4,E4],[F3,A3,C4],[G3,B3,D4],[C4,E4,G4]);
+const hF = harm([A3,C4],[B3,D4],[C4,E4],[C4,G4]);
+
+const bA = bassHalf([C2,C3],[A2,A3],[F2,F3],[G2,G3]);
+const bB = bass([C2,C3],[A2,A3],[F2,F3],[G2,G3]);
+const bD = bassHalf([D3,F3],[G2,G3],[C2,C3],[C2,C3]);
+const bE = bass([A2,A3],[F2,F3],[G2,G3],[C2,C3]);
+const bF = bassHalf([F2,F3],[G2,G3],[A2,A3],[C2,C3]);
+
+function join(...s: N[][]): N[] { return s.flat(); }
+
+const song: Song = {
+  name: 'Shuffle', bpm: 96, stepsPerBeat: 2,
+  tones: [
+    { wave: 'square', gain: 0.10, dur: 0.18,
+      notes: join(mA, mB, mC, mD, mE, mA, mB, mF) },
+    { wave: 'square', gain: 0.04, dur: 0.15,
+      notes: join(hA, hB, hA, hD, hE, hA, hB, hF) },
+    { wave: 'triangle', gain: 0.15, dur: 0.2,
+      notes: join(bA, bB, bA, bD, bE, bA, bB, bF) },
+  ],
+  kick:  { gain: 0.15, hits: rep([T,F,F,F,T,F,F,F], 32) },
+  snare: { gain: 0.04, hits: rep([F,F,T,F,F,F,T,F], 32) },
+  hihat: { gain: 0.03, hits: rep([T,F,T,F,T,F,T,F], 32) },
+};
+export default song;

--- a/packages/client/src/shared/sound/songs/lobby-1.ts
+++ b/packages/client/src/shared/sound/songs/lobby-1.ts
@@ -5,28 +5,27 @@ import { _, T, F, rep, harm, harmArp, bass, bassHalf,
   A4, B4, C5, D5, E5, F5, G5, A5, B5,
 } from './common';
 
-
-const mA: N[] = [ // C – Am – F – G
+const mA: N[] = [
   E5, _,G5, _,E5, _,C5,D5,  E5, _,C5, _,A4, _, _, _,
   A4, _,C5, _,F5, _,E5,D5,  D5, _, _, _,B4, _, _, _,
 ];
-const mB: N[] = [ // C – Am – F – G
+const mB: N[] = [
   G5, _,E5, _,C5, _,D5,E5,  A4, _,C5, _,E5, _, _, _,
   F5, _,E5, _,D5, _,C5, _,  B4, _, _, _, _, _, _, _,
 ];
-const mC: N[] = [ // C – Am – F – G
+const mC: N[] = [
   E5, _,G5, _,E5, _,C5,D5,  C5, _,A4, _,E4, _, _, _,
   A4, _,C5, _,F5, _,E5,D5,  G4, _, _, _, _, _, _, _,
 ];
-const mD: N[] = [ // Dm – G – C – C
+const mD: N[] = [
   D5, _,F5, _,A5, _,F5, _,  G5, _,D5, _,B4, _, _, _,
   C5, _,E5, _,G5, _,E5, _,  C5, _, _, _, _, _, _, _,
 ];
-const mE: N[] = [ // Am – F – G – C  (new: ascending phrases)
+const mE: N[] = [
   A4, _,C5, _,E5, _,A5, _,  F5, _,A5, _,C5, _, _, _,
   D5, _,G5, _,B5, _,G5, _,  E5, _,C5, _, _, _, _, _,
 ];
-const mF: N[] = [ // F – G – Am – C  (new: gentle close)
+const mF: N[] = [
   F5, _,E5, _,D5, _,C5, _,  D5, _,G5, _, _, _, _, _,
   A4, _,C5, _,E5, _, _, _,  C5, _, _, _, _, _, _, _,
 ];

--- a/packages/client/src/shared/sound/songs/lobby-2.ts
+++ b/packages/client/src/shared/sound/songs/lobby-2.ts
@@ -39,7 +39,7 @@ const bD = bassHalf([F2,null],[G2,null],[C2,null],[C2,null]);
 function join(...s: N[][]): N[] { return s.flat(); }
 
 const song: Song = {
-  name: 'Daydream', bpm: 88, stepsPerBeat: 2,
+  name: 'Daydream', meta: { 'author':'Claude', 'key':'C 大调', 'style':'空灵梦幻', 'wave':'方波' }, bpm: 88, stepsPerBeat: 2,
   tones: [
     { wave: 'square', gain: 0.10, dur: 0.22,
       notes: join(mA, mB, mAp, mC, mA, mB, mAp, mD) },

--- a/packages/client/src/shared/sound/songs/lobby-2.ts
+++ b/packages/client/src/shared/sound/songs/lobby-2.ts
@@ -1,0 +1,56 @@
+import type { N, Song } from './common';
+import { _, T, F, rep, harm, bassHalf,
+  C2, F2, G2, A2, D3,
+  A3, B3, C4, D4, E4,
+  A4, C5, D5, E5, F5, G5, A5,
+} from './common';
+
+
+const mA: N[] = [ // C – Am – F – G
+  G5, _, _,E5, _, _,C5, _,   _, _,A4, _, _,C5, _, _,
+  F5, _, _,E5, _, _,D5, _,   _, _, _, _, _, _, _, _,
+];
+const mB: N[] = [ // Am – F – C – G
+  A4, _, _,C5, _, _,E5, _,  F5, _, _, _,C5, _, _, _,
+  E5, _, _,G5, _, _,C5, _,  D5, _, _, _, _, _, _, _,
+];
+const mAp: N[] = [ // C – Am – F – G  (A' with tail)
+  G5, _, _,E5, _, _,D5,E5,   _, _,C5, _, _,A4, _, _,
+  F5, _, _,A5, _, _,G5, _,   _, _, _, _, _, _, _, _,
+];
+const mC: N[] = [ // Dm – Am – F – C
+  D5, _, _,F5, _, _,A5, _,  E5, _, _, _,C5, _, _, _,
+  A4, _, _,C5, _, _,F5, _,  E5, _, _, _, _, _, _, _,
+];
+const mD: N[] = [ // F – G – C – C  (new: gentle resolution)
+  F5, _, _,E5, _, _,D5, _,  D5, _, _,G5, _, _, _, _,
+  E5, _, _,G5, _, _,C5, _,  C5, _, _, _, _, _, _, _,
+];
+
+const hA = harm([E4,null],[C4,null],[A3,null],[B3,null]);
+const hB = harm([C4,null],[A3,null],[E4,null],[B3,null]);
+const hC = harm([D4,null],[C4,null],[A3,null],[C4,null]);
+const hD = harm([A3,null],[B3,null],[E4,null],[C4,null]);
+
+const bA = bassHalf([C2,null],[A2,null],[F2,null],[G2,null]);
+const bB = bassHalf([A2,null],[F2,null],[C2,null],[G2,null]);
+const bC = bassHalf([D3,null],[A2,null],[F2,null],[C2,null]);
+const bD = bassHalf([F2,null],[G2,null],[C2,null],[C2,null]);
+
+function join(...s: N[][]): N[] { return s.flat(); }
+
+const song: Song = {
+  name: 'Daydream', bpm: 88, stepsPerBeat: 2,
+  tones: [
+    { wave: 'square', gain: 0.10, dur: 0.22,
+      notes: join(mA, mB, mAp, mC, mA, mB, mAp, mD) },
+    { wave: 'square', gain: 0.03, dur: 0.18,
+      notes: join(hA, hB, hA, hC, hA, hB, hA, hD) },
+    { wave: 'triangle', gain: 0.12, dur: 0.25,
+      notes: join(bA, bB, bA, bC, bA, bB, bA, bD) },
+  ],
+  kick:  { gain: 0.12, hits: rep([T,F,F,F,F,F,F,F], 32) },
+  snare: { gain: 0.00, hits: rep([F,F,F,F,F,F,F,F], 32) },
+  hihat: { gain: 0.02, hits: rep([T,F,F,F,T,F,F,F], 32) },
+};
+export default song;

--- a/packages/client/src/shared/sound/songs/lobby-2.ts
+++ b/packages/client/src/shared/sound/songs/lobby-2.ts
@@ -5,24 +5,23 @@ import { _, T, F, rep, harm, bassHalf,
   A4, C5, D5, E5, F5, G5, A5,
 } from './common';
 
-
-const mA: N[] = [ // C – Am – F – G
+const mA: N[] = [
   G5, _, _,E5, _, _,C5, _,   _, _,A4, _, _,C5, _, _,
   F5, _, _,E5, _, _,D5, _,   _, _, _, _, _, _, _, _,
 ];
-const mB: N[] = [ // Am – F – C – G
+const mB: N[] = [
   A4, _, _,C5, _, _,E5, _,  F5, _, _, _,C5, _, _, _,
   E5, _, _,G5, _, _,C5, _,  D5, _, _, _, _, _, _, _,
 ];
-const mAp: N[] = [ // C – Am – F – G  (A' with tail)
+const mAp: N[] = [
   G5, _, _,E5, _, _,D5,E5,   _, _,C5, _, _,A4, _, _,
   F5, _, _,A5, _, _,G5, _,   _, _, _, _, _, _, _, _,
 ];
-const mC: N[] = [ // Dm – Am – F – C
+const mC: N[] = [
   D5, _, _,F5, _, _,A5, _,  E5, _, _, _,C5, _, _, _,
   A4, _, _,C5, _, _,F5, _,  E5, _, _, _, _, _, _, _,
 ];
-const mD: N[] = [ // F – G – C – C  (new: gentle resolution)
+const mD: N[] = [
   F5, _, _,E5, _, _,D5, _,  D5, _, _,G5, _, _, _, _,
   E5, _, _,G5, _, _,C5, _,  C5, _, _, _, _, _, _, _,
 ];

--- a/packages/client/src/shared/sound/songs/lobby-3.ts
+++ b/packages/client/src/shared/sound/songs/lobby-3.ts
@@ -5,20 +5,19 @@ import { _, T, F, rep, harm, harmArp, bass, bassHalf,
   A4, B4, C5, D5, E5, F5, G5, A5,
 } from './common';
 
-
-const mA: N[] = [ // C – Am – F – G
+const mA: N[] = [
   C5, _,E5, _,G5, _,E5, _,  A4, _,C5, _,E5, _, _, _,
   F5, _,E5, _,D5, _,C5, _,  D5, _, _, _,B4, _, _, _,
 ];
-const mB: N[] = [ // Am – F – C – G
+const mB: N[] = [
   E5, _,C5, _,A4, _, _,C5,  F5, _,E5, _,C5, _, _, _,
   G5, _,E5, _,C5, _,E5, _,  D5, _, _, _, _, _, _, _,
 ];
-const mC: N[] = [ // F – G – C – Am
+const mC: N[] = [
   A4, _,C5, _,F5, _,E5,D5,  B4, _,D5, _,G5, _,F5,E5,
   E5, _,G5, _,C5, _, _, _,  A4, _,C5, _, _, _, _, _,
 ];
-const mD: N[] = [ // Dm – G – C – C  (gentle ending)
+const mD: N[] = [
   D5, _,F5, _,A5, _,F5,D5,  G5, _,D5, _,B4, _, _, _,
   C5, _,E5, _,G5, _, _, _,  C5, _, _, _, _, _, _, _,
 ];

--- a/packages/client/src/shared/sound/songs/lobby-3.ts
+++ b/packages/client/src/shared/sound/songs/lobby-3.ts
@@ -35,7 +35,7 @@ const bD = bassHalf([D3,F3],[G2,G3],[C2,C3],[C2,C3]);
 function join(...s: N[][]): N[] { return s.flat(); }
 
 const song: Song = {
-  name: 'Waiting Room', bpm: 92, stepsPerBeat: 2,
+  name: 'Waiting Room', meta: { 'author':'Claude', 'key':'C 大调', 'style':'温暖柔和', 'wave':'方波' }, bpm: 92, stepsPerBeat: 2,
   tones: [
     { wave: 'square', gain: 0.10, dur: 0.18,
       notes: join(mA, mB, mC, mB, mA, mB, mC, mD) },

--- a/packages/client/src/shared/sound/songs/lobby-3.ts
+++ b/packages/client/src/shared/sound/songs/lobby-3.ts
@@ -1,0 +1,55 @@
+import type { N, Song } from './common';
+import { _, T, F, rep, harm, harmArp, bass, bassHalf,
+  C2, C3, F2, F3, G2, G3, A2, A3, D3,
+  B3, C4, D4, E4, F4, G4,
+  A4, B4, C5, D5, E5, F5, G5, A5,
+} from './common';
+
+
+const mA: N[] = [ // C – Am – F – G
+  C5, _,E5, _,G5, _,E5, _,  A4, _,C5, _,E5, _, _, _,
+  F5, _,E5, _,D5, _,C5, _,  D5, _, _, _,B4, _, _, _,
+];
+const mB: N[] = [ // Am – F – C – G
+  E5, _,C5, _,A4, _, _,C5,  F5, _,E5, _,C5, _, _, _,
+  G5, _,E5, _,C5, _,E5, _,  D5, _, _, _, _, _, _, _,
+];
+const mC: N[] = [ // F – G – C – Am
+  A4, _,C5, _,F5, _,E5,D5,  B4, _,D5, _,G5, _,F5,E5,
+  E5, _,G5, _,C5, _, _, _,  A4, _,C5, _, _, _, _, _,
+];
+const mD: N[] = [ // Dm – G – C – C  (gentle ending)
+  D5, _,F5, _,A5, _,F5,D5,  G5, _,D5, _,B4, _, _, _,
+  C5, _,E5, _,G5, _, _, _,  C5, _, _, _, _, _, _, _,
+];
+
+const hA = harm([E4,G4],[C4,E4],[A3,C4],[B3,D4]);
+const hB = harmArp([A3,C4,E4],[F3,A3,C4],[C4,E4,G4],[B3,D4,G4]);
+const hC = harm([A3,F4],[B3,G4],[C4,E4],[C4,E4]);
+const hD = harm([D4,F4],[B3,D4],[C4,E4],[C4,G4]);
+
+const bA = bassHalf([C2,C3],[A2,A3],[F2,F3],[G2,G3]);
+const bB = bass([A2,A3],[F2,F3],[C2,C3],[G2,G3]);
+const bC = bassHalf([F2,F3],[G2,G3],[C2,C3],[A2,A3]);
+const bD = bassHalf([D3,F3],[G2,G3],[C2,C3],[C2,C3]);
+
+function join(...s: N[][]): N[] { return s.flat(); }
+
+const song: Song = {
+  name: 'Waiting Room', bpm: 92, stepsPerBeat: 2,
+  tones: [
+    { wave: 'square', gain: 0.10, dur: 0.18,
+      notes: join(mA, mB, mC, mB, mA, mB, mC, mD) },
+    { wave: 'square', gain: 0.04, dur: 0.15,
+      notes: join(hA, hB, hC, hB, hA, hB, hC, hD) },
+    { wave: 'triangle', gain: 0.15, dur: 0.2,
+      notes: join(bA, bB, bC, bB, bA, bB, bC, bD) },
+  ],
+  kick:  { gain: 0.14, hits: rep([T,F,F,F,T,F,F,F], 32) },
+  snare: { gain: 0.04, hits: rep([F,F,T,F,F,F,T,F], 32) },
+  hihat: { gain: 0.03, hits: [
+    ...rep([T,F,T,F,T,F,T,F], 16),
+    ...rep([T,F,T,F,T,T,T,F], 16),
+  ]},
+};
+export default song;

--- a/packages/client/src/shared/sound/songs/lobby-4.ts
+++ b/packages/client/src/shared/sound/songs/lobby-4.ts
@@ -35,7 +35,7 @@ const bD = bassHalf([C3,null],[D2,null],[G2,null],[G2,null]);
 function join(...s: N[][]): N[] { return s.flat(); }
 
 const song: Song = {
-  name: 'Breeze', bpm: 84, stepsPerBeat: 2,
+  name: 'Breeze', meta: { 'author':'Claude', 'key':'G 大调', 'style':'田园清风', 'wave':'正弦波' }, bpm: 84, stepsPerBeat: 2,
   tones: [
     { wave: 'sine', gain: 0.12, dur: 0.25,
       notes: join(mA, mB, mA, mC, mA, mB, mA, mD) },

--- a/packages/client/src/shared/sound/songs/lobby-4.ts
+++ b/packages/client/src/shared/sound/songs/lobby-4.ts
@@ -1,0 +1,52 @@
+import type { N, Song } from './common';
+import { _, T, F, rep, harm, bassHalf,
+  D2, E2, G2, C3, D3, G3,
+  A3, B3, C4, D4, E4, Fs4, G4,
+  B4, C5, D5, E5, Fs5, G5, A5, B5,
+} from './common';
+
+
+const mA: N[] = [ // G – Em – C – D
+  B5, _, _,G5, _, _,D5, _,  E5, _, _,G5, _, _,B4, _,
+  C5, _, _,E5, _, _,G5, _,  Fs5, _, _, _, _, _, _, _,
+];
+const mB: N[] = [ // Em – C – G – D
+  G5, _, _,E5, _, _,B4, _,  C5, _, _,E5, _, _,G5, _,
+  D5, _, _,G5, _, _,B5, _,  A5, _, _, _, _, _, _, _,
+];
+const mC: N[] = [ // G – Bm – C – D
+  G5, _,B5, _,G5, _,D5, _,  Fs5, _,B5, _,Fs5, _,D5, _,
+  E5, _,G5, _,C5, _,E5, _,  D5, _,Fs5, _, _, _, _, _,
+];
+const mD: N[] = [ // C – D – G – G
+  C5, _, _,E5, _, _,G5, _,  D5, _, _,Fs5, _, _,A5, _,
+  G5, _, _,B5, _, _,D5, _,  G5, _, _, _, _, _, _, _,
+];
+
+const hA = harm([D4,null],[B3,null],[E4,null],[A3,null]);
+const hB = harm([B3,null],[E4,null],[D4,null],[Fs4,null]);
+const hC = harm([D4,null],[Fs4,null],[E4,null],[Fs4,null]);
+const hD = harm([E4,null],[Fs4,null],[D4,null],[D4,null]);
+
+const bA = bassHalf([G2,null],[E2,null],[C3,null],[D2,null]);
+const bB = bassHalf([E2,null],[C3,null],[G2,null],[D2,null]);
+const bC = bassHalf([G2,null],[B3,null],[C3,null],[D2,null]);
+const bD = bassHalf([C3,null],[D2,null],[G2,null],[G2,null]);
+
+function join(...s: N[][]): N[] { return s.flat(); }
+
+const song: Song = {
+  name: 'Breeze', bpm: 84, stepsPerBeat: 2,
+  tones: [
+    { wave: 'sine', gain: 0.12, dur: 0.25,
+      notes: join(mA, mB, mA, mC, mA, mB, mA, mD) },
+    { wave: 'sine', gain: 0.04, dur: 0.2,
+      notes: join(hA, hB, hA, hC, hA, hB, hA, hD) },
+    { wave: 'triangle', gain: 0.10, dur: 0.3,
+      notes: join(bA, bB, bA, bC, bA, bB, bA, bD) },
+  ],
+  kick:  { gain: 0.10, hits: rep([T,F,F,F,F,F,F,F], 32) },
+  snare: { gain: 0.00, hits: rep([F,F,F,F,F,F,F,F], 32) },
+  hihat: { gain: 0.02, hits: rep([T,F,F,F,T,F,F,F], 32) },
+};
+export default song;

--- a/packages/client/src/shared/sound/songs/lobby-4.ts
+++ b/packages/client/src/shared/sound/songs/lobby-4.ts
@@ -5,20 +5,19 @@ import { _, T, F, rep, harm, bassHalf,
   B4, C5, D5, E5, Fs5, G5, A5, B5,
 } from './common';
 
-
-const mA: N[] = [ // G – Em – C – D
+const mA: N[] = [
   B5, _, _,G5, _, _,D5, _,  E5, _, _,G5, _, _,B4, _,
   C5, _, _,E5, _, _,G5, _,  Fs5, _, _, _, _, _, _, _,
 ];
-const mB: N[] = [ // Em – C – G – D
+const mB: N[] = [
   G5, _, _,E5, _, _,B4, _,  C5, _, _,E5, _, _,G5, _,
   D5, _, _,G5, _, _,B5, _,  A5, _, _, _, _, _, _, _,
 ];
-const mC: N[] = [ // G – Bm – C – D
+const mC: N[] = [
   G5, _,B5, _,G5, _,D5, _,  Fs5, _,B5, _,Fs5, _,D5, _,
   E5, _,G5, _,C5, _,E5, _,  D5, _,Fs5, _, _, _, _, _,
 ];
-const mD: N[] = [ // C – D – G – G
+const mD: N[] = [
   C5, _, _,E5, _, _,G5, _,  D5, _, _,Fs5, _, _,A5, _,
   G5, _, _,B5, _, _,D5, _,  G5, _, _, _, _, _, _, _,
 ];

--- a/packages/client/src/shared/sound/songs/lobby-5.ts
+++ b/packages/client/src/shared/sound/songs/lobby-5.ts
@@ -5,24 +5,23 @@ import { _, T, F, rep, harm, bassHalf,
   A4, Bb4, C5, D5, E5, F5, G5, A5,
 } from './common';
 
-
-const mA: N[] = [ // F – Dm – Bb – C
+const mA: N[] = [
   A5, _, _,F5, _, _,C5, _,  D5, _, _,F5, _, _,A4, _,
   Bb4, _, _,D5, _, _,F5, _,  _, _, _, _, _, _, _, _,
 ];
-const mB: N[] = [ // Dm – Bb – F – C
+const mB: N[] = [
   F5, _, _,D5, _, _,A4, _,  Bb4, _, _, _,D5, _, _, _,
   A4, _, _,C5, _, _,F5, _,  E5, _, _, _, _, _, _, _,
 ];
-const mC: N[] = [ // F – Gm – Bb – F
+const mC: N[] = [
   F5, _, _,A5, _, _,C5, _,  _, _,Bb4, _, _,D5, _, _,
   Bb4, _, _,D5, _, _,F5, _,  _, _, _, _, _, _, _, _,
 ];
-const mD: N[] = [ // Bb – C – Dm – F
+const mD: N[] = [
   Bb4, _, _,D5, _, _,F5, _,  C5, _, _,E5, _, _,G5, _,
   D5, _, _,F5, _, _,A5, _,  _, _, _, _, _, _, _, _,
 ];
-const mE: N[] = [ // Bb – C – F – F
+const mE: N[] = [
   Bb4, _, _,D5, _, _,F5, _,  E5, _, _,C5, _, _,G5, _,
   F5, _, _,A5, _, _,C5, _,  F5, _, _, _, _, _, _, _,
 ];

--- a/packages/client/src/shared/sound/songs/lobby-5.ts
+++ b/packages/client/src/shared/sound/songs/lobby-5.ts
@@ -41,7 +41,7 @@ const bE = bassHalf([Bb2,null],[C2,null],[F2,null],[F2,null]);
 function join(...s: N[][]): N[] { return s.flat(); }
 
 const song: Song = {
-  name: 'Sunset', bpm: 78, stepsPerBeat: 2,
+  name: 'Sunset', meta: { 'author':'Claude', 'key':'F 大调', 'style':'日落音乐盒', 'wave':'三角波' }, bpm: 78, stepsPerBeat: 2,
   tones: [
     { wave: 'triangle', gain: 0.12, dur: 0.3,
       notes: join(mA, mB, mC, mA, mD, mB, mC, mE) },

--- a/packages/client/src/shared/sound/songs/lobby-5.ts
+++ b/packages/client/src/shared/sound/songs/lobby-5.ts
@@ -1,0 +1,58 @@
+import type { N, Song } from './common';
+import { _, T, F, rep, harm, bassHalf,
+  C2, F2, G2, A2, Bb2, D3,
+  A3, Bb3, C4, D4, E4, F4,
+  A4, Bb4, C5, D5, E5, F5, G5, A5,
+} from './common';
+
+
+const mA: N[] = [ // F – Dm – Bb – C
+  A5, _, _,F5, _, _,C5, _,  D5, _, _,F5, _, _,A4, _,
+  Bb4, _, _,D5, _, _,F5, _,  _, _, _, _, _, _, _, _,
+];
+const mB: N[] = [ // Dm – Bb – F – C
+  F5, _, _,D5, _, _,A4, _,  Bb4, _, _, _,D5, _, _, _,
+  A4, _, _,C5, _, _,F5, _,  E5, _, _, _, _, _, _, _,
+];
+const mC: N[] = [ // F – Gm – Bb – F
+  F5, _, _,A5, _, _,C5, _,  _, _,Bb4, _, _,D5, _, _,
+  Bb4, _, _,D5, _, _,F5, _,  _, _, _, _, _, _, _, _,
+];
+const mD: N[] = [ // Bb – C – Dm – F
+  Bb4, _, _,D5, _, _,F5, _,  C5, _, _,E5, _, _,G5, _,
+  D5, _, _,F5, _, _,A5, _,  _, _, _, _, _, _, _, _,
+];
+const mE: N[] = [ // Bb – C – F – F
+  Bb4, _, _,D5, _, _,F5, _,  E5, _, _,C5, _, _,G5, _,
+  F5, _, _,A5, _, _,C5, _,  F5, _, _, _, _, _, _, _,
+];
+
+const hA = harm([F4,null],[A3,null],[Bb3,null],[E4,null]);
+const hB = harm([A3,null],[Bb3,null],[C4,null],[E4,null]);
+const hC = harm([C4,null],[Bb3,null],[Bb3,null],[C4,null]);
+const hD = harm([Bb3,null],[E4,null],[A3,null],[C4,null]);
+const hE = harm([Bb3,null],[E4,null],[C4,null],[C4,null]);
+
+const bA = bassHalf([F2,null],[D3,null],[Bb2,null],[C2,null]);
+const bB = bassHalf([D3,null],[Bb2,null],[F2,null],[C2,null]);
+const bC = bassHalf([F2,null],[G2,null],[Bb2,null],[F2,null]);
+const bD = bassHalf([Bb2,null],[C2,null],[D3,null],[F2,null]);
+const bE = bassHalf([Bb2,null],[C2,null],[F2,null],[F2,null]);
+
+function join(...s: N[][]): N[] { return s.flat(); }
+
+const song: Song = {
+  name: 'Sunset', bpm: 78, stepsPerBeat: 2,
+  tones: [
+    { wave: 'triangle', gain: 0.12, dur: 0.3,
+      notes: join(mA, mB, mC, mA, mD, mB, mC, mE) },
+    { wave: 'sine', gain: 0.03, dur: 0.22,
+      notes: join(hA, hB, hC, hA, hD, hB, hC, hE) },
+    { wave: 'triangle', gain: 0.08, dur: 0.35,
+      notes: join(bA, bB, bC, bA, bD, bB, bC, bE) },
+  ],
+  kick:  { gain: 0.00, hits: rep([F,F,F,F,F,F,F,F], 32) },
+  snare: { gain: 0.00, hits: rep([F,F,F,F,F,F,F,F], 32) },
+  hihat: { gain: 0.02, hits: rep([T,F,F,F,F,F,F,F], 32) },
+};
+export default song;

--- a/packages/client/src/shared/sound/songs/lobby-6.ts
+++ b/packages/client/src/shared/sound/songs/lobby-6.ts
@@ -1,0 +1,59 @@
+import type { N, Song } from './common';
+import { _, T, F, rep, harm, harmArp, bassHalf,
+  C2, D2, E2, F2, G2, A2,
+  C3, D3, E3, F3, G3, A3, B3,
+  C4, D4, E4, F4, G4, A4, B4,
+  C5, D5, E5, F5, G5, A5, B5, C6,
+} from './common';
+
+
+const mA: N[] = [ // Am – Em – F – G  (忧郁主题)
+  A4, _,C5, _,E5, _, _,D5,  E5, _,B4, _, _,G4, _, _,
+  A4, _,C5, _,F5, _, _,E5,  D5, _, _, _, _, _, _, _,
+];
+const mB: N[] = [ // Am – F – C – G  (展开)
+  E5, _,A5, _, _,G5, _,E5,  F5, _, _,C5, _, _,A4, _,
+  G5, _, _,E5, _,C5, _, _,  D5, _, _, _, _, _, _, _,
+];
+const mC: N[] = [ // C – G – Am – F  (转大调，明亮)
+  C5, _,E5, _,G5, _, _,A5,  B5, _,G5, _, _,D5, _, _,
+  A5, _, _,E5, _,C5, _, _,  F5, _, _,E5, _,D5, _,C5,
+];
+const mD: N[] = [ // Dm – G – C – Am  (属准备 → 解决)
+  D5, _,F5, _,A5, _, _,G5,  G5, _,B5, _, _,A5, _,G5,
+  C5, _,E5, _,G5, _, _,C6,  A5, _, _,E5, _, _, _, _,
+];
+const mE: N[] = [ // F – G – Am – Am  (终止)
+  F5, _, _,A5, _, _,C6, _,  G5, _, _,B5, _, _,D5, _,
+  A5, _, _,E5, _, _,C5, _,  A4, _, _, _, _, _, _, _,
+];
+
+const hA = harmArp([C4,E4,A4],[B3,E4,G4],[A3,C4,F4],[B3,D4,G4]);
+const hB = harmArp([C4,E4,A4],[A3,C4,F4],[E4,G4,C5],[B3,D4,G4]);
+const hC = harmArp([E4,G4,C5],[D4,G4,B4],[C4,E4,A4],[A3,C4,F4]);
+const hD = harmArp([A3,D4,F4],[B3,D4,G4],[E4,G4,C5],[C4,E4,A4]);
+const hE = harmArp([A3,C4,F4],[B3,D4,G4],[C4,E4,A4],[C4,E4,A4]);
+
+const bA = bassHalf([A2,A3],[E2,E3],[F2,F3],[G2,G3]);
+const bB = bassHalf([A2,A3],[F2,F3],[C2,C3],[G2,G3]);
+const bC = bassHalf([C2,C3],[G2,G3],[A2,A3],[F2,F3]);
+const bD = bassHalf([D2,D3],[G2,G3],[C2,C3],[A2,A3]);
+const bE = bassHalf([F2,F3],[G2,G3],[A2,A3],[A2,A3]);
+
+function join(...s: N[][]): N[] { return s.flat(); }
+
+const song: Song = {
+  name: 'Nocturne', bpm: 72, stepsPerBeat: 2,
+  tones: [
+    { wave: 'sine', gain: 0.14, dur: 0.3,
+      notes: join(mA, mB, mC, mA, mD, mB, mC, mE) },
+    { wave: 'sine', gain: 0.05, dur: 0.35,
+      notes: join(hA, hB, hC, hA, hD, hB, hC, hE) },
+    { wave: 'triangle', gain: 0.10, dur: 0.4,
+      notes: join(bA, bB, bC, bA, bD, bB, bC, bE) },
+  ],
+  kick:  { gain: 0.00, hits: rep([F,F,F,F,F,F,F,F], 32) },
+  snare: { gain: 0.00, hits: rep([F,F,F,F,F,F,F,F], 32) },
+  hihat: { gain: 0.00, hits: rep([F,F,F,F,F,F,F,F], 32) },
+};
+export default song;

--- a/packages/client/src/shared/sound/songs/lobby-6.ts
+++ b/packages/client/src/shared/sound/songs/lobby-6.ts
@@ -6,24 +6,23 @@ import { _, T, F, rep, harm, harmArp, bassHalf,
   C5, D5, E5, F5, G5, A5, B5, C6,
 } from './common';
 
-
-const mA: N[] = [ // Am – Em – F – G  (忧郁主题)
+const mA: N[] = [
   A4, _,C5, _,E5, _, _,D5,  E5, _,B4, _, _,G4, _, _,
   A4, _,C5, _,F5, _, _,E5,  D5, _, _, _, _, _, _, _,
 ];
-const mB: N[] = [ // Am – F – C – G  (展开)
+const mB: N[] = [
   E5, _,A5, _, _,G5, _,E5,  F5, _, _,C5, _, _,A4, _,
   G5, _, _,E5, _,C5, _, _,  D5, _, _, _, _, _, _, _,
 ];
-const mC: N[] = [ // C – G – Am – F  (转大调，明亮)
+const mC: N[] = [
   C5, _,E5, _,G5, _, _,A5,  B5, _,G5, _, _,D5, _, _,
   A5, _, _,E5, _,C5, _, _,  F5, _, _,E5, _,D5, _,C5,
 ];
-const mD: N[] = [ // Dm – G – C – Am  (属准备 → 解决)
+const mD: N[] = [
   D5, _,F5, _,A5, _, _,G5,  G5, _,B5, _, _,A5, _,G5,
   C5, _,E5, _,G5, _, _,C6,  A5, _, _,E5, _, _, _, _,
 ];
-const mE: N[] = [ // F – G – Am – Am  (终止)
+const mE: N[] = [
   F5, _, _,A5, _, _,C6, _,  G5, _, _,B5, _, _,D5, _,
   A5, _, _,E5, _, _,C5, _,  A4, _, _, _, _, _, _, _,
 ];

--- a/packages/client/src/shared/sound/songs/lobby-6.ts
+++ b/packages/client/src/shared/sound/songs/lobby-6.ts
@@ -42,7 +42,7 @@ const bE = bassHalf([F2,F3],[G2,G3],[A2,A3],[A2,A3]);
 function join(...s: N[][]): N[] { return s.flat(); }
 
 const song: Song = {
-  name: 'Nocturne', bpm: 72, stepsPerBeat: 2,
+  name: 'Nocturne', meta: { 'author':'Claude', 'key':'Am/C', 'style':'浪漫夜曲', 'wave':'正弦波' }, bpm: 72, stepsPerBeat: 2,
   tones: [
     { wave: 'sine', gain: 0.14, dur: 0.3,
       notes: join(mA, mB, mC, mA, mD, mB, mC, mE) },

--- a/packages/client/src/shared/sound/sound-manager.ts
+++ b/packages/client/src/shared/sound/sound-manager.ts
@@ -1,4 +1,5 @@
 import { useSettingsStore } from '../stores/settings-store';
+import { getAudioContext } from './audio-context';
 
 type SoundName =
   | 'play_card'
@@ -53,8 +54,6 @@ const FREQUENCIES: Record<SoundName, { freq: number; duration: number; type: Osc
   danger:       { freq: 280, duration: 0.1, type: 'sawtooth' },
 };
 
-let audioCtx: AudioContext | null = null;
-
 const THROW_HIT_SOUND_BY_ITEM: Record<string, string> = {
   '🍅': '/sounds/throw-tomato-squish.mp3',
   '💩': '/sounds/throw-slime-impact.mp3',
@@ -64,19 +63,12 @@ const THROW_HIT_SOUND_BY_ITEM: Record<string, string> = {
   '💖': '/sounds/throw-boing.mp3',
 };
 
-function getAudioCtx(): AudioContext {
-  if (!audioCtx) {
-    audioCtx = new AudioContext();
-  }
-  return audioCtx;
-}
-
 export function playSound(name: SoundName): void {
   const { soundEnabled, soundVolume } = useSettingsStore.getState();
   if (!soundEnabled || soundVolume <= 0) return;
 
   const config = FREQUENCIES[name];
-  const ctx = getAudioCtx();
+  const ctx = getAudioContext();
 
   const osc = ctx.createOscillator();
   const gain = ctx.createGain();

--- a/packages/client/src/shared/sound/useBgm.ts
+++ b/packages/client/src/shared/sound/useBgm.ts
@@ -1,21 +1,21 @@
 import { useEffect, useState } from 'react';
 import { useSettingsStore } from '../stores/settings-store';
-import { bgm } from './bgm-engine';
+import { bgm, type SongInfo } from './bgm-engine';
 
-export function useBgm(scene: string): string | null {
+export function useBgm(scene: string): SongInfo | null {
   const enabled = useSettingsStore((s) => s.bgmEnabled);
   const volume = useSettingsStore((s) => s.bgmVolume);
-  const [songName, setSongName] = useState<string | null>(null);
+  const [song, setSong] = useState<SongInfo | null>(null);
 
   useEffect(() => {
-    bgm.onSongChange = setSongName;
+    bgm.onSongChange = setSong;
     return () => { bgm.onSongChange = null; };
   }, []);
 
   useEffect(() => {
     if (!enabled) {
       bgm.stop();
-      setSongName(null);
+      setSong(null);
       return;
     }
     bgm.setVolume(volume);
@@ -27,5 +27,5 @@ export function useBgm(scene: string): string | null {
     bgm.setVolume(volume);
   }, [volume]);
 
-  return songName;
+  return song;
 }

--- a/packages/client/src/shared/sound/useBgm.ts
+++ b/packages/client/src/shared/sound/useBgm.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+import { useSettingsStore } from '../stores/settings-store';
+import { bgm } from './bgm-engine';
+
+export function useBgm(scene: string): string | null {
+  const enabled = useSettingsStore((s) => s.bgmEnabled);
+  const volume = useSettingsStore((s) => s.bgmVolume);
+  const [songName, setSongName] = useState<string | null>(null);
+
+  useEffect(() => {
+    bgm.onSongChange = setSongName;
+    return () => { bgm.onSongChange = null; };
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) {
+      bgm.stop();
+      setSongName(null);
+      return;
+    }
+    bgm.setVolume(volume);
+    bgm.start(scene);
+    return () => bgm.stop();
+  }, [enabled, scene]);
+
+  useEffect(() => {
+    bgm.setVolume(volume);
+  }, [volume]);
+
+  return songName;
+}

--- a/packages/client/src/shared/stores/settings-store.ts
+++ b/packages/client/src/shared/stores/settings-store.ts
@@ -13,6 +13,8 @@ export const FONT_OPTIONS: Record<FontOption, { label: string; value: string }> 
 interface SettingsState {
   soundVolume: number;
   soundEnabled: boolean;
+  bgmEnabled: boolean;
+  bgmVolume: number;
   colorBlindMode: boolean;
   fontFamily: FontOption;
   cardImagePack: boolean; // whether a card image pack is loaded
@@ -20,6 +22,8 @@ interface SettingsState {
   uiTheme: UiTheme;
   setSoundVolume: (v: number) => void;
   toggleSound: () => void;
+  toggleBgm: () => void;
+  setBgmVolume: (v: number) => void;
   toggleColorBlind: () => void;
   setFontFamily: (f: FontOption) => void;
   setCardImagePack: (loaded: boolean) => void;
@@ -30,6 +34,8 @@ interface SettingsState {
 export const useSettingsStore = create<SettingsState>((set) => ({
   soundVolume: parseFloat(localStorage.getItem('soundVolume') ?? '0.7'),
   soundEnabled: localStorage.getItem('soundEnabled') !== 'false',
+  bgmEnabled: localStorage.getItem('bgmEnabled') !== 'false',
+  bgmVolume: parseFloat(localStorage.getItem('bgmVolume') ?? '0.3'),
   colorBlindMode: localStorage.getItem('colorBlindMode') === 'true',
   fontFamily: (localStorage.getItem('fontFamily') as FontOption) || 'default',
   cardImagePack: localStorage.getItem('cardImagePack') === 'true',
@@ -44,6 +50,15 @@ export const useSettingsStore = create<SettingsState>((set) => ({
     localStorage.setItem('soundEnabled', String(next));
     return { soundEnabled: next };
   }),
+  toggleBgm: () => set((s) => {
+    const next = !s.bgmEnabled;
+    localStorage.setItem('bgmEnabled', String(next));
+    return { bgmEnabled: next };
+  }),
+  setBgmVolume: (v) => {
+    localStorage.setItem('bgmVolume', String(v));
+    set({ bgmVolume: v });
+  },
   toggleColorBlind: () => set((s) => {
     const next = !s.colorBlindMode;
     localStorage.setItem('colorBlindMode', String(next));


### PR DESCRIPTION
## Summary
- Web Audio API 8-bit 合成器引擎，持久化 Oscillator 优化性能
- 16 首 32 小节编曲（Game 10 + Lobby 6），覆盖 C/G/F 大调、A/D 小调，方波/锯齿波/正弦波/三角波多种音色
- 播放列表随机洗牌，切歌 Toast 提示
- 音乐厅弹窗：浏览全部曲目、点击试听
- 游戏教程弹窗：每次进入大厅弹出，引导交互绕过浏览器自动播放限制
- BGM 默认开启，TopBar 独立开关，大厅/游戏自动切换场景

## Test plan
- [ ] 进入大厅，教程弹窗弹出，点击后 BGM 自动播放
- [ ] 切歌时左上角 Toast 显示曲名
- [ ] 大厅底部「音乐厅」按钮打开曲目列表，点击可试听
- [ ] 进入游戏，BGM 自动切换为 game 场景
- [ ] TopBar 音乐按钮可开关 BGM
- [ ] 移动端低性能设备无卡顿

🤖 Generated with [Claude Code](https://claude.com/claude-code)