### PR TITLE
fix: 构建时复制 MumbleServer.js 到 dist 目录

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "start": "tsx dist/index.js",
-    "build": "tsc",
+    "build": "tsc && mkdir -p dist/voice/generated && cp src/voice/generated/MumbleServer.js dist/voice/generated/MumbleServer.js",
     "test": "vitest run",
     "test:watch": "vitest",
     "db:generate": "echo 'No codegen needed with Kysely'",


### PR DESCRIPTION
## Summary

- tsc 不复制已有的 .js 文件，导致 Docker 运行时找不到 `dist/voice/generated/MumbleServer.js`
- build 脚本加 `mkdir -p` + `cp` 步骤

## Test plan

- [x] `pnpm --filter server build` 后确认 `dist/voice/generated/MumbleServer.js` 存在

🤖 Generated with [Claude Code](https://claude.com/claude-code)