### PR TITLE
feat: 新手教程与大厅音乐联动

### DIFF
--- a/packages/client/src/features/lobby/pages/LobbyPage.tsx
+++ b/packages/client/src/features/lobby/pages/LobbyPage.tsx
@@ -13,6 +13,7 @@ import { BUILD_VERSION } from '@/shared/build-info';
 import { ServerButton } from '@/shared/components/ServerButton';
 import { ServerSelectModal } from '@/shared/components/ServerSelectModal';
 import { useBgm } from '@/shared/sound/useBgm';
+import { getAudioContext } from '@/shared/sound/audio-context';
 import TutorialModal from '@/shared/components/TutorialModal';
 import BgmToast from '@/shared/components/BgmToast';
 import MusicHallModal from '@/shared/components/MusicHallModal';
@@ -30,6 +31,16 @@ export default function LobbyPage() {
   const { activeRooms, recentGames, fetchActiveRooms, fetchRecentGames } = useLobbyStore();
   const songName = useBgm('lobby');
   const [musicHall, setMusicHall] = useState(false);
+  const [showTutorial, setShowTutorial] = useState(false);
+
+  useEffect(() => {
+    const ctx = getAudioContext();
+    if (ctx.state === 'suspended') {
+      setShowTutorial(true);
+    } else if (!localStorage.getItem('tutorialShown')) {
+      setShowTutorial(true);
+    }
+  }, []);
 
   useEffect(() => {
     fetchActiveRooms();
@@ -291,7 +302,7 @@ export default function LobbyPage() {
       </div>
 
       <ServerSelectModal />
-      <TutorialModal />
+      <TutorialModal open={showTutorial} onClose={() => { setShowTutorial(false); localStorage.setItem('tutorialShown', 'true'); }} />
       <BgmToast song={songName} />
       <MusicHallModal open={musicHall} onClose={() => setMusicHall(false)} currentScene="lobby" />
     </div>

--- a/packages/client/src/shared/components/TutorialModal.tsx
+++ b/packages/client/src/shared/components/TutorialModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { Spade, ChevronRight, ChevronLeft, Megaphone, Trophy } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
@@ -160,14 +160,11 @@ const PAGES: PageDef[] = [
   },
 ];
 
-export default function TutorialModal() {
-  const [open, setOpen] = useState(false);
+export default function TutorialModal({ open, onClose }: { open: boolean; onClose: () => void }) {
   const [page, setPage] = useState(0);
   const [dir, setDir] = useState(1);
 
-  useEffect(() => { setOpen(true); }, []);
-
-  const close = () => { setOpen(false); setPage(0); };
+  const close = () => { setPage(0); onClose(); };
   const go = (next: number) => { setDir(next > page ? 1 : -1); setPage(next); };
 
   if (!open) return null;


### PR DESCRIPTION
## Summary
- 检测浏览器 AudioContext 状态，若 `suspended`（autoplay 被阻止）则弹出新手教程，用户交互后自动解锁音频播放
- 音频已可播放时，教程仅首次展示，通过 `localStorage('tutorialShown')` 记录，之后不再弹出
- `TutorialModal` 改为受控组件，由父组件决定显示时机

## Test plan
- [ ] 清除 localStorage，首次进入大厅 → 教程弹出，关闭后音乐开始播放
- [ ] 刷新页面 → 教程不再弹出（已记录 tutorialShown）
- [ ] 清除 localStorage，用隐私模式打开 → 教程弹出（autoplay 被阻止）
- [ ] 教程翻页、关闭按钮均正常工作

🤖 Generated with [Claude Code](https://claude.com/claude-code)