### PR TITLE
feat: 游戏体验改善 — 房间BGM、观战修复、快捷键、聊天布局

### DIFF
--- a/packages/client/src/features/game/components/ChatBox.tsx
+++ b/packages/client/src/features/game/components/ChatBox.tsx
@@ -51,8 +51,8 @@ export default function ChatBox({ embedded = false }: ChatBoxProps) {
 
   if (embedded) {
     return (
-      <div className="w-full flex flex-col gap-2 select-text" data-allow-selection>
-        <div className="max-h-48 overflow-y-auto text-xs">
+      <div className="w-full flex flex-col flex-1 min-h-0 gap-2 select-text" data-allow-selection>
+        <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin text-xs">
           {messages.map((m) => (
             <div key={m.id} className="mb-1">
               <span className="font-bold" style={{ color: getRoleColor(m.role) || 'var(--accent)' }}>{m.nickname}{players.find(p => p.id === m.userId)?.isBot && <AiBadge className="mx-0.5" />}: </span>
@@ -61,7 +61,7 @@ export default function ChatBox({ embedded = false }: ChatBoxProps) {
           ))}
           <div ref={bottomRef} />
         </div>
-        <div className="flex gap-0.5 flex-wrap">
+        <div className="flex gap-0.5 flex-wrap shrink-0">
           {['👍', '😂', '😭', '🎉', '💪', '😱', '🤔', '❤️'].map((emoji) => (
             <button key={emoji} onClick={() => sendPhrase(emoji)}
               className="bg-transparent border-none text-sm cursor-pointer p-0.5">
@@ -69,7 +69,7 @@ export default function ChatBox({ embedded = false }: ChatBoxProps) {
             </button>
           ))}
         </div>
-        <div className="flex gap-1 flex-wrap">
+        <div className="flex gap-1 flex-wrap shrink-0">
           {QUICK_PHRASES.map((phrase) => (
             <button key={phrase} onClick={() => sendPhrase(phrase)}
               className="bg-white/10 rounded-lg text-2xs px-2 py-0.5 text-foreground cursor-pointer transition-colors duration-150 hover:bg-white/20">
@@ -77,7 +77,7 @@ export default function ChatBox({ embedded = false }: ChatBoxProps) {
             </button>
           ))}
         </div>
-        <div className="flex gap-1">
+        <div className="flex gap-1 shrink-0">
           <input ref={inputRef} value={input} onChange={(e) => setInput(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && send()}
             placeholder="发送消息..."
             className="flex-1 px-2.5 py-1.5 rounded-lg border border-white/20 bg-muted text-foreground text-xs"

--- a/packages/client/src/features/game/components/HotkeySettingsModal.tsx
+++ b/packages/client/src/features/game/components/HotkeySettingsModal.tsx
@@ -1,0 +1,122 @@
+import { useState, useEffect, useRef } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { X, RotateCcw } from 'lucide-react';
+import { HOTKEY_ACTIONS, formatBinding, useHotkeyStore } from '../stores/hotkey-store';
+import type { HotkeyOverride } from '../stores/hotkey-store';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+const IGNORED_KEYS = new Set(['Shift', 'Control', 'Alt', 'Meta', 'CapsLock']);
+
+export default function HotkeySettingsModal({ open, onClose }: Props) {
+  const { overrides, setHotkey, resetHotkey, resetAll } = useHotkeyStore();
+  const [listening, setListening] = useState<string | null>(null);
+  const listenerRef = useRef<((e: KeyboardEvent) => void) | null>(null);
+
+  useEffect(() => {
+    if (!listening) return;
+
+    const handler = (e: KeyboardEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      if (IGNORED_KEYS.has(e.key)) return;
+
+      if (e.key === 'Escape') {
+        setListening(null);
+        return;
+      }
+
+      const override: HotkeyOverride = e.key.length === 1
+        ? { key: e.key.toLowerCase() }
+        : { code: e.code };
+
+      setHotkey(listening, override);
+      setListening(null);
+    };
+
+    listenerRef.current = handler;
+    window.addEventListener('keydown', handler, true);
+    return () => {
+      window.removeEventListener('keydown', handler, true);
+      listenerRef.current = null;
+    };
+  }, [listening, setHotkey]);
+
+  useEffect(() => {
+    if (!open) setListening(null);
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        className="fixed inset-0 z-modal flex items-center justify-center bg-black/60 backdrop-blur-sm"
+        onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+      >
+        <motion.div
+          initial={{ scale: 0.95, opacity: 0 }}
+          animate={{ scale: 1, opacity: 1 }}
+          exit={{ scale: 0.95, opacity: 0 }}
+          className="bg-card rounded-panel-ui shadow-card border border-white/10 w-full max-w-sm mx-4"
+        >
+          <div className="flex items-center justify-between px-5 py-4 border-b border-white/10">
+            <h3 className="text-sm font-bold text-foreground">快捷键设置</h3>
+            <button onClick={onClose} className="text-muted-foreground hover:text-foreground transition-colors cursor-pointer">
+              <X size={16} />
+            </button>
+          </div>
+
+          <div className="px-5 py-3 space-y-1">
+            {HOTKEY_ACTIONS.map((action) => {
+              const isListening = listening === action.id;
+              const hasOverride = action.id in overrides;
+              return (
+                <div key={action.id} className="flex items-center justify-between py-2">
+                  <span className="text-sm text-foreground">{action.label}</span>
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={() => setListening(isListening ? null : action.id)}
+                      className={`min-w-[72px] px-3 py-1.5 rounded-lg text-xs font-mono font-bold transition-all cursor-pointer border ${
+                        isListening
+                          ? 'bg-accent/20 border-accent text-accent animate-pulse'
+                          : 'bg-white/5 border-white/15 text-foreground hover:bg-white/10'
+                      }`}
+                    >
+                      {isListening ? '按下按键…' : formatBinding(action, overrides)}
+                    </button>
+                    {hasOverride && (
+                      <button
+                        onClick={() => resetHotkey(action.id)}
+                        className="text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+                        title="恢复默认"
+                      >
+                        <RotateCcw size={12} />
+                      </button>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          <div className="px-5 py-3 border-t border-white/10 flex justify-between items-center">
+            <button
+              onClick={resetAll}
+              className="text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+            >
+              全部恢复默认
+            </button>
+            <span className="text-2xs text-muted-foreground/50">按 Esc 取消录入</span>
+          </div>
+        </motion.div>
+      </motion.div>
+    </AnimatePresence>
+  );
+}

--- a/packages/client/src/features/game/components/InfoDrawer.tsx
+++ b/packages/client/src/features/game/components/InfoDrawer.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { X } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
@@ -22,28 +21,17 @@ export default function InfoDrawer() {
   const toggleInfoDrawer = useGameStore((s) => s.toggleInfoDrawer);
   const setInfoDrawerTab = useGameStore((s) => s.setInfoDrawerTab);
 
-  const openInfoDrawer = useGameStore((s) => s.openInfoDrawer);
-
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      const target = e.target as HTMLElement;
-      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) return;
-      if (e.key === 'h' || e.key === 'H' || e.key === '?') {
-        e.preventDefault();
-        toggleInfoDrawer();
-      }
-      if (e.key === 'Enter') {
-        e.preventDefault();
-        openInfoDrawer('chat');
-      }
-    };
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [toggleInfoDrawer, openInfoDrawer]);
-
   return (
     <AnimatePresence>
       {open && (
+        <>
+        <motion.div
+          className="hidden md:block fixed inset-0 z-fab"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          onClick={toggleInfoDrawer}
+        />
         <motion.div
           className="hidden md:flex fixed right-0 top-0 bottom-0 w-[360px] z-fab flex-col border-l border-white/15 bg-slate-950/85 backdrop-blur-xl"
           initial={{ x: '100%' }}
@@ -81,13 +69,17 @@ export default function InfoDrawer() {
           </div>
 
           {/* Content */}
-          <div className="flex-1 overflow-y-auto scrollbar-thin p-4">
+          <div className={cn(
+            'flex-1 min-h-0 p-4',
+            activeTab === 'chat' ? 'flex flex-col' : 'overflow-y-auto scrollbar-thin',
+          )}>
             {activeTab === 'rules' && <GameRulesPanel />}
             {activeTab === 'house-rules' && <HouseRulesCard embedded />}
             {activeTab === 'log' && <GameLog embedded />}
             {activeTab === 'chat' && <ChatBox embedded />}
           </div>
         </motion.div>
+        </>
       )}
     </AnimatePresence>
   );

--- a/packages/client/src/features/game/components/PlayerListPanel.tsx
+++ b/packages/client/src/features/game/components/PlayerListPanel.tsx
@@ -1,4 +1,4 @@
-import { Eye } from 'lucide-react';
+import { Eye, UserPlus } from 'lucide-react';
 import { useGameStore } from '../stores/game-store';
 import { useSpectatorStore } from '../stores/spectator-store';
 import { useEffectiveUserId } from '../hooks/useEffectiveUserId';
@@ -12,6 +12,7 @@ export default function PlayerListPanel() {
   const players = useGameStore((s) => s.players);
   const currentPlayerIndex = useGameStore((s) => s.currentPlayerIndex);
   const spectators = useSpectatorStore((s) => s.spectators);
+  const pendingJoinQueue = useSpectatorStore((s) => s.pendingJoinQueue);
   const userId = useEffectiveUserId();
 
   if (players.length === 0) return null;
@@ -80,12 +81,16 @@ export default function PlayerListPanel() {
               观众 ({spectators.length})
             </div>
             <div className="py-1">
-              {spectators.map((name) => (
-                <div key={name} className="flex items-center gap-2 px-3 py-1 text-xs text-muted-foreground">
-                  <Eye size={12} className="shrink-0" />
-                  <span className="truncate">{name}</span>
-                </div>
-              ))}
+              {spectators.map((name) => {
+                const queued = pendingJoinQueue.includes(name);
+                return (
+                  <div key={name} className="flex items-center gap-2 px-3 py-1 text-xs text-muted-foreground">
+                    {queued ? <UserPlus size={12} className="shrink-0 text-accent" /> : <Eye size={12} className="shrink-0" />}
+                    <span className={cn('truncate', queued && 'text-accent')}>{name}</span>
+                    {queued && <span className="text-2xs text-accent ml-auto shrink-0">加入中</span>}
+                  </div>
+                );
+              })}
             </div>
           </>
         )}

--- a/packages/client/src/features/game/components/ScoreBoard.tsx
+++ b/packages/client/src/features/game/components/ScoreBoard.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect } from 'react';
-import { Trophy, BarChart3, Crown, Check, UserX } from 'lucide-react';
+import { Trophy, BarChart3, Crown, Check, UserX, UserPlus } from 'lucide-react';
 import { useGameStore } from '../stores/game-store';
 import { useEffectiveUserId } from '../hooks/useEffectiveUserId';
 import { useRoomStore } from '@/shared/stores/room-store';
+import { useSpectatorStore } from '../stores/spectator-store';
 import { cn } from '@/shared/lib/utils';
 import { Button } from '@/shared/components/ui/Button';
 import { AiBadge } from '@/shared/components/ui/AiBadge';
@@ -37,6 +38,7 @@ export default function ScoreBoard({ onPlayAgain, onRematch, onBackToLobby, onKi
     }, 1000);
     return () => clearInterval(interval);
   }, [phase]);
+  const pendingJoinQueue = useSpectatorStore((s) => s.pendingJoinQueue);
   const ownerId = useRoomStore((s) => s.room?.ownerId);
   const userId = useEffectiveUserId();
   const sorted = [...players].sort((a, b) => b.score - a.score);
@@ -97,6 +99,11 @@ export default function ScoreBoard({ onPlayAgain, onRematch, onBackToLobby, onKi
             })}
           </tbody>
         </table>
+        {!isGameOver && pendingJoinQueue.length > 0 && (
+          <p className="mb-2 text-xs text-accent flex items-center justify-center gap-1">
+            <UserPlus size={12} /> {pendingJoinQueue.join('、')} 将在下一轮加入
+          </p>
+        )}
         {!isGameOver && (
           <p className="mb-3 text-xs text-muted-foreground">
             {allAgreed ? '所有玩家已同意，等待房主开始下一轮' : `已有 ${votes}/${required} 人同意继续下一轮`}

--- a/packages/client/src/features/game/components/TopBar.tsx
+++ b/packages/client/src/features/game/components/TopBar.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Eye, Volume2, VolumeX, Music, Spade, DoorOpen, Bot, HelpCircle } from 'lucide-react';
+import { Eye, Volume2, VolumeX, Music, Spade, DoorOpen, Bot, HelpCircle, Keyboard } from 'lucide-react';
 import type { Card, Color } from '@uno-online/shared';
 import TurnTimer from './TurnTimer';
 import { useSettingsStore } from '@/shared/stores/settings-store';
@@ -78,9 +78,9 @@ function GameStatus() {
   );
 }
 
-interface TopBarProps { roomCode: string; }
+interface TopBarProps { roomCode: string; onOpenHotkeys: () => void; }
 
-export default function TopBar({ roomCode }: TopBarProps) {
+export default function TopBar({ roomCode, onOpenHotkeys }: TopBarProps) {
   const { colorBlindMode, toggleColorBlind, soundEnabled, toggleSound, bgmEnabled, toggleBgm } = useSettingsStore();
   const ownerId = useRoomStore((s) => s.room?.ownerId);
   const userId = useEffectiveUserId();
@@ -111,6 +111,13 @@ export default function TopBar({ roomCode }: TopBarProps) {
       </div>
       <GameStatus />
       <div className="flex items-center gap-3 justify-end">
+        <button
+          onClick={onOpenHotkeys}
+          className="hidden md:inline bg-transparent border-none text-sm cursor-pointer text-muted-foreground hover:text-accent transition-colors"
+          title="快捷键设置"
+        >
+          <Keyboard size={16} />
+        </button>
         <button
           onClick={toggleInfoDrawer}
           className="hidden md:inline bg-transparent border-none text-sm cursor-pointer text-muted-foreground hover:text-accent transition-colors"

--- a/packages/client/src/features/game/hooks/useGameHotkeys.ts
+++ b/packages/client/src/features/game/hooks/useGameHotkeys.ts
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from 'react';
+import { HOTKEY_ACTIONS, getBinding, useHotkeyStore } from '../stores/hotkey-store';
+
+type HandlerMap = Record<string, () => void>;
+
+function isInputFocused(e: KeyboardEvent): boolean {
+  const t = e.target as HTMLElement;
+  return t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable;
+}
+
+export function useGameHotkeys(handlers: HandlerMap): void {
+  const overrides = useHotkeyStore((s) => s.overrides);
+  const ref = useRef({ handlers, overrides });
+  ref.current = { handlers, overrides };
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (isInputFocused(e)) return;
+      const { handlers: h, overrides: o } = ref.current;
+      for (const action of HOTKEY_ACTIONS) {
+        if (!h[action.id]) continue;
+        const b = getBinding(action, o);
+        if (b.code && e.code !== b.code) continue;
+        if (b.key && e.key.toLowerCase() !== b.key.toLowerCase()) continue;
+        if (!b.code && !b.key) continue;
+        if (!b.repeat && e.repeat) continue;
+        e.preventDefault();
+        h[action.id]();
+        return;
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
+}

--- a/packages/client/src/features/game/hooks/useGameSocket.ts
+++ b/packages/client/src/features/game/hooks/useGameSocket.ts
@@ -5,6 +5,7 @@ import { useChatStore } from '../stores/chat-store';
 import { useSpectatorStore } from '../stores/spectator-store';
 import { useRoomStore } from '@/shared/stores/room-store';
 import { getSocket, connectSocket, onConnectionStatus, refreshVoicePresence } from '@/shared/socket';
+import { useToastStore } from '@/shared/stores/toast-store';
 
 export function useGameSocket(roomCode: string | undefined) {
   const phase = useGameStore((s) => s.phase);
@@ -13,6 +14,7 @@ export function useGameSocket(roomCode: string | undefined) {
   const addChatMessage = useChatStore((s) => s.addMessage);
   const clearChatMessages = useChatStore((s) => s.clearMessages);
   const setSpectators = useSpectatorStore((s) => s.setSpectators);
+  const setPendingJoinQueue = useSpectatorStore((s) => s.setPendingJoinQueue);
   const setRoom = useRoomStore((s) => s.setRoom);
   const navigate = useNavigate();
   const [connectionStatus, setConnectionStatus] = useState<
@@ -44,14 +46,31 @@ export function useGameSocket(roomCode: string | undefined) {
     socket.on('chat:message', addChatMessage);
     socket.on('chat:cleared', clearChatMessages);
 
-    const onSpectatorUpdate = (data: { spectators?: string[] }) => { if (data.spectators) setSpectators(data.spectators); };
+    const onSpectatorUpdate = (data: { spectators?: string[] }) => {
+      if (data.spectators) {
+        setSpectators(data.spectators);
+        const spectatorSet = new Set(data.spectators);
+        const { pendingJoinQueue } = useSpectatorStore.getState();
+        if (pendingJoinQueue.some((n) => !spectatorSet.has(n))) {
+          setPendingJoinQueue(pendingJoinQueue.filter((n) => spectatorSet.has(n)));
+        }
+      }
+    };
     const onSpectatorLeft = (data: { spectators?: string[]; nickname?: string }) => {
       if (data.spectators) setSpectators(data.spectators);
       else if (data.nickname) useSpectatorStore.getState().removeSpectator(data.nickname);
     };
+    const onSpectatorQueue = (data: { queue: string[]; nickname: string; joined: boolean }) => {
+      setPendingJoinQueue(data.queue);
+      useToastStore.getState().addToast(
+        data.joined ? `${data.nickname} 将在下一轮加入游戏` : `${data.nickname} 取消了加入`,
+        'info',
+      );
+    };
     socket.on('room:spectator_list', onSpectatorUpdate);
     socket.on('room:spectator_joined', onSpectatorUpdate);
     socket.on('room:spectator_left', onSpectatorLeft);
+    socket.on('game:spectator_queue', onSpectatorQueue);
 
     return () => {
       socket.off('chat:history', setChatHistory);
@@ -60,8 +79,9 @@ export function useGameSocket(roomCode: string | undefined) {
       socket.off('room:spectator_list', onSpectatorUpdate);
       socket.off('room:spectator_joined', onSpectatorUpdate);
       socket.off('room:spectator_left', onSpectatorLeft);
+      socket.off('game:spectator_queue', onSpectatorQueue);
     };
-  }, [setChatHistory, addChatMessage, clearChatMessages, setSpectators]);
+  }, [setChatHistory, addChatMessage, clearChatMessages, setSpectators, setPendingJoinQueue]);
 
   // Reconnection status tracking + auto-rejoin on reconnect
   useEffect(() => {

--- a/packages/client/src/features/game/pages/GamePage.tsx
+++ b/packages/client/src/features/game/pages/GamePage.tsx
@@ -10,6 +10,7 @@ import { useGameSocket } from '../hooks/useGameSocket';
 import { useGameLogTracker } from '../hooks/useGameLogTracker';
 import { useAutoPlay } from '../hooks/useAutoPlay';
 import { useGameActions } from '../hooks/useGameActions';
+import { useGameHotkeys } from '../hooks/useGameHotkeys';
 import { playSound } from '@/shared/sound/sound-manager';
 import { useBgm } from '@/shared/sound/useBgm';
 import BgmToast from '@/shared/components/BgmToast';
@@ -35,6 +36,7 @@ import CheatOverlay from '../components/CheatOverlay';
 import { useSpectatorStore } from '../stores/spectator-store';
 import GameStartRulesModal from '../components/GameStartRulesModal';
 import ColorWave from '../components/ColorWave';
+import HotkeySettingsModal from '../components/HotkeySettingsModal';
 
 export default function GamePage() {
   const { roomCode } = useParams<{ roomCode: string }>();
@@ -42,6 +44,7 @@ export default function GamePage() {
   const phase = useGameStore((s) => s.phase);
   const roundNumber = useGameStore((s) => s.roundNumber);
   const settings = useGameStore((s) => s.settings);
+  const toggleInfoDrawer = useGameStore((s) => s.toggleInfoDrawer);
   const openInfoDrawer = useGameStore((s) => s.openInfoDrawer);
   const clearGame = useGameStore((s) => s.clearGame);
   const clearRoom = useRoomStore((s) => s.clearRoom);
@@ -57,6 +60,7 @@ export default function GamePage() {
   useGameLogTracker();
   const bgmSongName = useBgm('game');
   const [showStartRules, setShowStartRules] = useState(false);
+  const [showHotkeys, setShowHotkeys] = useState(false);
   const shownStartRulesRef = useRef<string | null>(null);
   const [antiCheatKey, setAntiCheatKey] = useState<string | null>(null);
   const shownAntiCheatRef = useRef<string | null>(null);
@@ -126,6 +130,16 @@ export default function GamePage() {
     prevTurnRef.current = isMyTurn && phase === 'playing';
   }, [isMyTurn, phase]);
 
+  useGameHotkeys({
+    autopilot_once: () => {
+      getSocket().emit('game:autopilot_once', (res: { success?: boolean; error?: string }) => {
+        if (!res?.success && res?.error) useToastStore.getState().addToast(res.error, 'error');
+      });
+    },
+    toggle_info: () => toggleInfoDrawer(),
+    open_chat: () => openInfoDrawer('chat'),
+  });
+
   const isSelectionAllowed = (target: EventTarget | null) => {
     if (!(target instanceof HTMLElement)) return false;
     return Boolean(target.closest('[data-allow-selection], input, textarea, select, [contenteditable="true"]'));
@@ -172,7 +186,7 @@ export default function GamePage() {
           </p>
         </div>
       )}
-      <TopBar roomCode={roomCode ?? ''} />
+      <TopBar roomCode={roomCode ?? ''} onOpenHotkeys={() => setShowHotkeys(true)} />
       <PlayerListPanel />
       <LayoutGroup>
       <div className="relative flex flex-col flex-1 min-h-0">
@@ -229,6 +243,7 @@ export default function GamePage() {
       )}
       {cheatDetected && <CheatOverlay />}
       <BgmToast song={bgmSongName} />
+      <HotkeySettingsModal open={showHotkeys} onClose={() => setShowHotkeys(false)} />
     </div>
   );
 }

--- a/packages/client/src/features/game/pages/RoomPage.tsx
+++ b/packages/client/src/features/game/pages/RoomPage.tsx
@@ -16,6 +16,8 @@ import PlayerActionMenu from '../components/PlayerActionMenu';
 import { DEFAULT_HOUSE_RULES } from '@uno-online/shared';
 import type { HouseRules } from '@uno-online/shared';
 import { Button } from '@/shared/components/ui/Button';
+import { useBgm } from '@/shared/sound/useBgm';
+import BgmToast from '@/shared/components/BgmToast';
 
 export default function RoomPage() {
   const { roomCode } = useParams<{ roomCode: string }>();
@@ -23,6 +25,7 @@ export default function RoomPage() {
   const { players, room, clearRoom, setRoom, updateRoom } = useRoomStore();
   const setGameState = useGameStore((s) => s.setGameState);
   const navigate = useNavigate();
+  const songName = useBgm('lobby');
 
   useEffect(() => {
     connectSocket();
@@ -191,6 +194,7 @@ export default function RoomPage() {
         <Button variant="danger" onClick={leaveRoom} sound="danger">离开房间</Button>
       </div>
       <VoicePanel />
+      <BgmToast song={songName} />
     </div>
   );
 }

--- a/packages/client/src/features/game/stores/game-store.ts
+++ b/packages/client/src/features/game/stores/game-store.ts
@@ -93,6 +93,8 @@ export const useGameStore = create<GameState>((set) => ({
         lastAction?.type === 'DRAW_CARD' &&
         lastAction.playerId === currentPlayerId;
 
+      const becamePlayer = state.isSpectator && viewerId !== '__spectator__';
+
       return {
         phase,
         viewerId,
@@ -115,6 +117,7 @@ export const useGameStore = create<GameState>((set) => ({
         lastDrawnCard: hasDrawnThisTurn ? state.lastDrawnCard : null,
         deckHash: view.deckHash ?? state.deckHash,
         nextRoundVote: phase === 'round_end' ? state.nextRoundVote : null,
+        ...(becamePlayer ? { isSpectator: false } : {}),
       };
     }),
   setNextRoundVote: (vote) => set({ nextRoundVote: vote }),

--- a/packages/client/src/features/game/stores/hotkey-store.ts
+++ b/packages/client/src/features/game/stores/hotkey-store.ts
@@ -1,0 +1,91 @@
+import { create } from 'zustand';
+
+export interface HotkeyAction {
+  id: string;
+  label: string;
+  defaultKey?: string;
+  defaultCode?: string;
+  repeat?: boolean;
+}
+
+export const HOTKEY_ACTIONS: HotkeyAction[] = [
+  { id: 'autopilot_once', label: '单步托管', defaultCode: 'Space' },
+  { id: 'toggle_info', label: '信息面板', defaultKey: 'h' },
+  { id: 'open_chat', label: '打开聊天', defaultKey: 'Enter', repeat: true },
+];
+
+export interface HotkeyOverride {
+  key?: string;
+  code?: string;
+}
+
+const STORAGE_KEY = 'hotkeyOverrides';
+
+function loadOverrides(): Record<string, HotkeyOverride> {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) return JSON.parse(raw) as Record<string, HotkeyOverride>;
+  } catch { /* ignore */ }
+  return {};
+}
+
+function saveOverrides(overrides: Record<string, HotkeyOverride>): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(overrides));
+}
+
+interface HotkeyState {
+  overrides: Record<string, HotkeyOverride>;
+  setHotkey: (actionId: string, override: HotkeyOverride) => void;
+  resetHotkey: (actionId: string) => void;
+  resetAll: () => void;
+}
+
+export const useHotkeyStore = create<HotkeyState>((set) => ({
+  overrides: loadOverrides(),
+  setHotkey: (actionId, override) =>
+    set((s) => {
+      const next = { ...s.overrides, [actionId]: override };
+      saveOverrides(next);
+      return { overrides: next };
+    }),
+  resetHotkey: (actionId) =>
+    set((s) => {
+      const { [actionId]: _, ...rest } = s.overrides;
+      saveOverrides(rest);
+      return { overrides: rest };
+    }),
+  resetAll: () => {
+    saveOverrides({});
+    set({ overrides: {} });
+  },
+}));
+
+export function getBinding(action: HotkeyAction, overrides: Record<string, HotkeyOverride>): { key?: string; code?: string; repeat?: boolean } {
+  const override = overrides[action.id];
+  if (override) return { ...override, repeat: action.repeat };
+  return { key: action.defaultKey, code: action.defaultCode, repeat: action.repeat };
+}
+
+export function formatBinding(action: HotkeyAction, overrides: Record<string, HotkeyOverride>): string {
+  const b = getBinding(action, overrides);
+  if (b.code) return CODE_LABELS[b.code] ?? b.code;
+  if (b.key) return KEY_LABELS[b.key] ?? b.key.toUpperCase();
+  return '未绑定';
+}
+
+const CODE_LABELS: Record<string, string> = {
+  Space: '空格',
+  Backspace: '退格',
+  Delete: '删除',
+  ArrowUp: '↑',
+  ArrowDown: '↓',
+  ArrowLeft: '←',
+  ArrowRight: '→',
+  Tab: 'Tab',
+  Escape: 'Esc',
+};
+
+const KEY_LABELS: Record<string, string> = {
+  Enter: '回车',
+  ' ': '空格',
+};

--- a/packages/client/src/features/game/stores/spectator-store.ts
+++ b/packages/client/src/features/game/stores/spectator-store.ts
@@ -2,18 +2,22 @@ import { create } from 'zustand';
 
 interface SpectatorState {
   spectators: string[];
+  pendingJoinQueue: string[];
   setSpectators: (list: string[]) => void;
   addSpectator: (nickname: string) => void;
   removeSpectator: (nickname: string) => void;
+  setPendingJoinQueue: (list: string[]) => void;
   clearSpectators: () => void;
 }
 
 export const useSpectatorStore = create<SpectatorState>((set) => ({
   spectators: [],
+  pendingJoinQueue: [],
   setSpectators: (list) => set({ spectators: list }),
   addSpectator: (nickname) =>
     set((s) => s.spectators.includes(nickname) ? s : { spectators: [...s.spectators, nickname] }),
   removeSpectator: (nickname) =>
     set((s) => ({ spectators: s.spectators.filter((n) => n !== nickname) })),
-  clearSpectators: () => set({ spectators: [] }),
+  setPendingJoinQueue: (list) => set({ pendingJoinQueue: list }),
+  clearSpectators: () => set({ spectators: [], pendingJoinQueue: [] }),
 }));

--- a/packages/server/src/plugins/core/spectate/ws.ts
+++ b/packages/server/src/plugins/core/spectate/ws.ts
@@ -7,7 +7,7 @@ import { loadGameState } from '../game/state-store.js';
 
 const roomSpectators = new Map<string, Set<string>>();
 
-function getSpectatorNames(roomCode: string): string[] {
+export function getSpectatorNames(roomCode: string): string[] {
   return [...(roomSpectators.get(roomCode) ?? [])];
 }
 

--- a/packages/server/src/ws/game-events.ts
+++ b/packages/server/src/ws/game-events.ts
@@ -12,7 +12,7 @@ import { recordGameResult } from '../db/user-repo.js';
 import { saveGameEvents, saveDeckInfo } from '../plugins/core/game-history/service.js';
 import { getRoom, setRoomStatus, touchRoomActivity, removePlayerFromRoom, addPlayerToRoom } from '../plugins/core/room/store.js';
 import { MAX_PLAYERS } from '@uno-online/shared';
-import { removeSpectator } from '../plugins/core/spectate/ws.js';
+import { removeSpectator, getSpectatorNames } from '../plugins/core/spectate/ws.js';
 import type { SocketData } from './types.js';
 
 function getSession(socket: Socket, sessions: Map<string, GameSession>): { session: GameSession; roomCode: string } | null {
@@ -279,6 +279,7 @@ async function processPendingSpectatorJoins(
     });
   }
   pendingSpectatorJoins.delete(roomCode);
+  io.to(roomCode).emit('room:spectator_list', { spectators: getSpectatorNames(roomCode) });
 }
 
 async function startNextRound(
@@ -676,6 +677,13 @@ export function registerGameEvents(
       });
       callback?.({ success: true, queued: true });
     }
+
+    const joined = pending.has(data.user.userId);
+    io.to(roomCode).emit('game:spectator_queue', {
+      queue: [...pending.values()].map((p) => p.nickname),
+      nickname: data.user.nickname,
+      joined,
+    });
   });
 
   socket.on('game:kick_player', async (payload: { targetId?: string }, callback) => {

--- a/packages/server/src/ws/socket-handler.ts
+++ b/packages/server/src/ws/socket-handler.ts
@@ -252,6 +252,30 @@ export function setupSocketHandlers(
       callback?.({ success: true, autopilot: nextAutopilot });
     });
 
+    socket.on('game:autopilot_once', async (callback) => {
+      const roomCode = socket.data.roomCode;
+      if (!roomCode) return callback?.({ success: false, error: '不在房间中' });
+      const session = sessions.get(roomCode);
+      if (!session) return callback?.({ success: false, error: '游戏未开始' });
+      const state = session.getFullState();
+      const player = state.players.find(p => p.id === userId);
+      if (!player) return callback?.({ success: false, error: '玩家不在游戏中' });
+      if (player.autopilot) return callback?.({ success: false, error: '已在托管中' });
+      if (getAutopilotActionPlayerId(state) !== userId) return callback?.({ success: false, error: '不是你的回合' });
+
+      const acted = await executeAutopilot(session, userId, async () => {
+        persister.markDirty(roomCode, session.getFullState());
+        await emitGameUpdate(io, roomCode, session, redis);
+      }, (action) => notifyAutopilotAction(roomCode, session, action));
+
+      if (acted) {
+        persister.markDirty(roomCode, session.getFullState());
+        await emitGameUpdate(io, roomCode, session, redis);
+        startTurnTimer(io, redis, roomCode, session, turnTimer, sessions, persister);
+      }
+      callback?.({ success: true });
+    });
+
     socket.on('disconnect', async () => {
       clearRateLimit(socket.id);
       clearThrowTimestamp(userId);

--- a/packages/shared/src/types/socket-events.ts
+++ b/packages/shared/src/types/socket-events.ts
@@ -47,6 +47,7 @@ export interface ServerToClientEvents {
   'room:spectator_joined': (data: { nickname: string; spectators: string[] }) => void;
   'room:spectator_left': (data: { nickname: string; spectators: string[] }) => void;
   'room:spectator_list': (data: { spectators: string[] }) => void;
+  'game:spectator_queue': (data: { queue: string[]; nickname: string; joined: boolean }) => void;
   'game:cheat_detected': () => void;
   'voice:presence': (presence: Record<string, unknown>) => void;
   'server:version': (data: { version: string }) => void;
@@ -84,4 +85,5 @@ export interface ClientToServerEvents {
   'throw:item': (payload: { targetId: string; item: string }, callback?: (res: SocketCallbackResult) => void) => void;
   'player:toggle-autopilot': (callback?: (res: SocketCallbackResult & { autopilot?: boolean }) => void) => void;
   'game:spectator_join': (callback?: (res: SocketCallbackResult & { queued?: boolean }) => void) => void;
+  'game:autopilot_once': (callback?: (res: SocketCallbackResult) => void) => void;
 }


### PR DESCRIPTION
## Summary
- **房间 BGM**：组队房间播放大厅背景音乐，进入游戏后自动切换
- **观战加入修复**：观众申请下一轮加入时广播通知全房间，计分板/玩家列表显示排队状态；修复加入后身份未切换、观众列表未清除的 bug
- **快捷键系统**：`useGameHotkeys` 管理器 + `hotkey-store` 持久化，支持自定义绑定；新增单步托管（空格键）；TopBar 键盘图标入口打开设置弹窗
- **聊天布局**：嵌入式聊天消息列表自适应填满可用空间，输入区固定底部
- **InfoDrawer**：点击抽屉外部区域可关闭

## Test plan
- [ ] 进入组队房间，确认大厅 BGM 正常播放
- [ ] 观战者点击"下一把加入"，其他玩家收到 toast 通知，计分板和右侧玩家列表显示排队状态
- [ ] 下一轮开始后，观战者正确切换为玩家，不再显示在观众列表
- [ ] 游戏中按空格键触发单步托管
- [ ] TopBar 点击键盘图标打开快捷键设置，可自定义绑定并持久化
- [ ] InfoDrawer 聊天 tab 消息列表填满空间，输入框固定底部
- [ ] 打开 InfoDrawer 后点击左侧游戏区域可关闭

🤖 Generated with [Claude Code](https://claude.com/claude-code)