### PR TITLE
fix: 观战席同步、表情连发、摸牌音效、抓UNO日志修复

### DIFF
--- a/packages/client/src/features/game/components/DrawPile.tsx
+++ b/packages/client/src/features/game/components/DrawPile.tsx
@@ -49,18 +49,6 @@ function DrawPile({ side, isPortrait, onDraw, drawTargetX, drawTargetY, drawAnim
   return (
     <div className="flex flex-col items-center gap-1.5 z-card relative min-w-draw-pile-min">
       <DrawCardAnimation trigger={drawAnimTrigger} targetX={drawTargetX} targetY={drawTargetY} />
-      <AnimatePresence>
-        {showNoPlayableHint && side === 'left' && (
-          <motion.div
-            className="absolute bottom-hint-bottom left-1/2 -translate-x-1/2 whitespace-nowrap font-game text-caption text-primary text-shadow-glow"
-            initial={{ opacity: 0, y: 6 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: 6 }}
-          >
-            无牌可出，摸牌
-          </motion.div>
-        )}
-      </AnimatePresence>
       <CardBack
         onClick={canDraw ? handleClick : undefined}
         className={cn(

--- a/packages/client/src/features/game/components/GameEffects.tsx
+++ b/packages/client/src/features/game/components/GameEffects.tsx
@@ -197,7 +197,7 @@ export default function GameEffects() {
       addEffect({
         type: 'catch_uno',
         text: '抓 UNO!',
-        catcherName: catcher?.name,
+        catcherName: catcher?.name ?? lastAction.catcherName ?? '观众',
         catcherIndex: catcherIdx >= 0 ? catcherIdx : undefined,
         catcherAvatarUrl: catcher?.avatarUrl,
         targetName: target?.name,

--- a/packages/client/src/features/game/components/GameTable.tsx
+++ b/packages/client/src/features/game/components/GameTable.tsx
@@ -10,6 +10,8 @@ import DirectionIndicator from './DirectionIndicator';
 import ThrowAnimation from './ThrowAnimation';
 import { useGameStore } from '../stores/game-store';
 import { useEffectiveUserId } from '../hooks/useEffectiveUserId';
+import { useIsMyTurn } from '../hooks/useIsMyTurn';
+import { usePlayableCardIds } from '../hooks/usePlayableCardIds';
 import { useRoomStore } from '@/shared/stores/room-store';
 import { getSocket } from '@/shared/socket';
 import { useToastStore } from '@/shared/stores/toast-store';
@@ -239,7 +241,11 @@ export default function GameTable({ onDraw }: GameTableProps) {
 
   const pendingPenaltyDraws = useGameStore((s) => s.pendingPenaltyDraws);
   const drawStack = useGameStore((s) => s.drawStack);
+  const hasDrawnThisTurn = useGameStore((s) => s.hasDrawnThisTurn);
   const remainingPenaltyDraws = pendingPenaltyDraws > 0 ? pendingPenaltyDraws : drawStack;
+  const isMyTurn = useIsMyTurn();
+  const playableIds = usePlayableCardIds();
+  const showNoPlayableHint = isMyTurn && phase === 'playing' && !hasDrawnThisTurn && remainingPenaltyDraws === 0 && playableIds.size === 0 && !settings?.houseRules?.noHints;
 
   const isClockwise = direction === 'clockwise';
 
@@ -329,17 +335,30 @@ export default function GameTable({ onDraw }: GameTableProps) {
         );
       })()}
 
-      {/* Penalty draw hint centered above table */}
+      {/* Draw hint centered above table */}
       <AnimatePresence>
         {remainingPenaltyDraws > 0 && dimensions.width > 0 && (
           <motion.div
+            key="penalty"
             className="absolute left-1/2 -translate-x-1/2 z-card pointer-events-none whitespace-nowrap font-game text-lg font-bold text-destructive text-shadow-glow"
             style={{ top: dimensions.height / 2 - 130 }}
             initial={{ opacity: 0, y: 6 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: 6 }}
           >
-            还要摸 {remainingPenaltyDraws} 张
+            {players[currentPlayerIndex]?.id === userId ? '' : `${players[currentPlayerIndex]?.name} `}还要摸 {remainingPenaltyDraws} 张
+          </motion.div>
+        )}
+        {showNoPlayableHint && dimensions.width > 0 && (
+          <motion.div
+            key="no-playable"
+            className="absolute left-1/2 -translate-x-1/2 z-card pointer-events-none whitespace-nowrap font-game text-lg font-bold text-primary text-shadow-glow"
+            style={{ top: dimensions.height / 2 - 130 }}
+            initial={{ opacity: 0, y: 6 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 6 }}
+          >
+            无牌可出，摸牌
           </motion.div>
         )}
       </AnimatePresence>

--- a/packages/client/src/features/game/components/PlayerNode.tsx
+++ b/packages/client/src/features/game/components/PlayerNode.tsx
@@ -93,7 +93,6 @@ function PlayerNode({
 
   const handleThrowSelect = useCallback((item: string) => {
     onThrowItem?.(item);
-    setShowThrowPicker(false);
   }, [onThrowItem]);
 
   const closeReaction = useCallback(() => setShowReaction(false), []);

--- a/packages/client/src/features/game/components/ThrowItemPicker.tsx
+++ b/packages/client/src/features/game/components/ThrowItemPicker.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 
@@ -11,6 +11,9 @@ const ITEMS = [
   { emoji: '💖', label: '爱心' },
 ];
 
+const REPEAT_INTERVAL_MS = 300;
+const MAX_HOLD_MS = 10_000;
+
 interface ThrowItemPickerProps {
   onSelect: (item: string) => void;
   onClose: () => void;
@@ -21,13 +24,21 @@ interface ThrowItemPickerProps {
 export default function ThrowItemPicker({ onSelect, onClose, anchorX, anchorY }: ThrowItemPickerProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout>>();
+  const intervalRef = useRef<ReturnType<typeof setInterval>>();
+  const maxTimerRef = useRef<ReturnType<typeof setTimeout>>();
+
+  const stopRepeat = useCallback(() => {
+    if (intervalRef.current) { clearInterval(intervalRef.current); intervalRef.current = undefined; }
+    if (maxTimerRef.current) { clearTimeout(maxTimerRef.current); maxTimerRef.current = undefined; }
+  }, []);
 
   useEffect(() => {
-    timerRef.current = setTimeout(onClose, 5000);
+    timerRef.current = setTimeout(onClose, 15_000);
     return () => {
       if (timerRef.current) clearTimeout(timerRef.current);
+      stopRepeat();
     };
-  }, [onClose]);
+  }, [onClose, stopRepeat]);
 
   useEffect(() => {
     const handleClick = (e: MouseEvent) => {
@@ -39,10 +50,22 @@ export default function ThrowItemPicker({ onSelect, onClose, anchorX, anchorY }:
     return () => document.removeEventListener('mousedown', handleClick);
   }, [onClose]);
 
-  const handleSelect = (item: string) => {
+  const startRepeat = useCallback((item: string) => {
+    stopRepeat();
     onSelect(item);
-    onClose();
-  };
+    intervalRef.current = setInterval(() => onSelect(item), REPEAT_INTERVAL_MS);
+    maxTimerRef.current = setTimeout(stopRepeat, MAX_HOLD_MS);
+  }, [onSelect, stopRepeat]);
+
+  useEffect(() => {
+    const handleUp = () => stopRepeat();
+    window.addEventListener('pointerup', handleUp);
+    window.addEventListener('pointercancel', handleUp);
+    return () => {
+      window.removeEventListener('pointerup', handleUp);
+      window.removeEventListener('pointercancel', handleUp);
+    };
+  }, [stopRepeat]);
 
   return createPortal(
     <AnimatePresence>
@@ -59,14 +82,16 @@ export default function ThrowItemPicker({ onSelect, onClose, anchorX, anchorY }:
           {ITEMS.map(({ emoji, label }) => (
             <button
               key={emoji}
-              onClick={() => handleSelect(emoji)}
-              className="flex flex-col items-center gap-0.5 bg-transparent cursor-pointer transition-transform duration-150 hover:scale-125"
+              onPointerDown={(e) => { e.preventDefault(); startRepeat(emoji); }}
+              onClick={() => onSelect(emoji)}
+              className="flex flex-col items-center gap-0.5 bg-transparent cursor-pointer transition-transform duration-150 hover:scale-125 select-none touch-none"
             >
               <span className="text-2xl">{emoji}</span>
               <span className="text-2xs text-muted-foreground">{label}</span>
             </button>
           ))}
         </div>
+        <p className="text-center text-2xs text-muted-foreground/50 mb-1">长按连发</p>
       </motion.div>
     </AnimatePresence>,
     document.body,

--- a/packages/client/src/features/game/hooks/useDrawAnimation.ts
+++ b/packages/client/src/features/game/hooks/useDrawAnimation.ts
@@ -3,6 +3,7 @@ import type { GameAction, HouseRules } from '@uno-online/shared';
 import { useGameStore } from '../stores/game-store';
 import type { PlayerInfo } from '../stores/game-store';
 import type { Position } from './usePlayerLayout';
+import { playSound } from '@/shared/sound/sound-manager';
 
 interface HandGainBump {
   id: number;
@@ -193,6 +194,7 @@ export function useDrawAnimation(
         const drawSide = (lastAction as { side?: string }).side;
         const setAnim = drawSide === 'right' ? setDrawAnimRight : setDrawAnimLeft;
         for (let i = 0; i < added; i++) {
+          playSound('draw_card');
           const target = computeDrawTarget(player.id);
           const timer = window.setTimeout(() => {
             setAnim((prev) => ({

--- a/packages/client/src/features/game/hooks/useGameLogTracker.ts
+++ b/packages/client/src/features/game/hooks/useGameLogTracker.ts
@@ -100,11 +100,12 @@ export function useGameLogTracker(): void {
     } else if (lastAction.type === 'CATCH_UNO') {
       const catcher = findPlayer(lastAction.catcherId);
       const target = findPlayer(lastAction.targetId);
-      if (!catcher || !target) return;
+      if (!target) return;
+      const catcherName = catcher?.name ?? lastAction.catcherName ?? '观众';
       addLogEntry({
         type: 'catch_uno',
         playerId: lastAction.catcherId,
-        playerName: catcher.name,
+        playerName: catcherName,
         targetId: lastAction.targetId,
         targetName: target.name,
         extra: '未喊 UNO!',

--- a/packages/server/src/plugins/core/spectate/ws.ts
+++ b/packages/server/src/plugins/core/spectate/ws.ts
@@ -68,11 +68,12 @@ export function setupSpectateHandlers(
       const view = session.getSpectatorView(room.settings.spectatorMode);
       socket.emit('game:state', view);
       socket.emit('chat:history', session.getChatHistory());
-      socket.emit('room:spectator_list', { spectators: getSpectatorNames(roomCode) });
 
+      const spectators = getSpectatorNames(roomCode);
+      io.to(roomCode).emit('room:spectator_list', { spectators });
       socket.to(roomCode).emit('room:spectator_joined', {
         nickname: data.user.nickname,
-        spectators: getSpectatorNames(roomCode),
+        spectators,
       });
 
       callback?.({ success: true });
@@ -85,9 +86,11 @@ export function setupSpectateHandlers(
         if (nickname) {
           roomSpectators.get(data.roomCode)?.delete(nickname);
         }
-        socket.to(data.roomCode).emit('room:spectator_left', {
+        const spectators = getSpectatorNames(data.roomCode);
+        io.to(data.roomCode).emit('room:spectator_list', { spectators });
+        io.to(data.roomCode).emit('room:spectator_left', {
           nickname: nickname ?? '',
-          spectators: getSpectatorNames(data.roomCode),
+          spectators,
         });
       }
     });

--- a/packages/server/src/ws/game-events.ts
+++ b/packages/server/src/ws/game-events.ts
@@ -499,7 +499,7 @@ export function registerGameEvents(
     const ctx = getSession(socket, sessions);
     if (!ctx) return callback?.({ success: false });
     const { session, roomCode } = ctx;
-    const result = session.applyAction({ type: 'CATCH_UNO', catcherId: data.user.userId, targetId: payload.targetPlayerId });
+    const result = session.applyAction({ type: 'CATCH_UNO', catcherId: data.user.userId, targetId: payload.targetPlayerId, catcherName: data.user.nickname });
     if (!result.success) return callback?.({ success: false, error: result.error });
     session.recordEvent(GameEventType.CATCH_UNO, { targetPlayerId: payload.targetPlayerId }, data.user.userId);
     persister.markDirty(roomCode, session.getFullState());

--- a/packages/server/src/ws/socket-handler.ts
+++ b/packages/server/src/ws/socket-handler.ts
@@ -11,7 +11,7 @@ import { getRoom, getRoomPlayers, setRoomOwner } from '../plugins/core/room/stor
 import { loadGameState, GameStatePersister } from '../plugins/core/game/state-store.js';
 import { checkRateLimit, clearRateLimit } from './rate-limiter.js';
 import { registerInteractionEvents, clearThrowTimestamp } from '../plugins/core/interaction/ws.js';
-import { setupSpectateHandlers } from '../plugins/core/spectate/ws.js';
+import { setupSpectateHandlers, getSpectatorNames } from '../plugins/core/spectate/ws.js';
 import { getDb } from '../db/database.js';
 import { dissolveRoom } from './room-lifecycle.js';
 import { registerVoicePresenceEvents, removeVoicePresence } from './voice-presence.js';
@@ -195,6 +195,7 @@ export function setupSocketHandlers(
         const players = await getRoomPlayers(redis, roomCode);
         callback?.({ success: true, gameState: session.getPlayerView(userId), players, room });
         socket.emit('chat:history', session.getChatHistory());
+        socket.emit('room:spectator_list', { spectators: getSpectatorNames(roomCode) });
         const state = session.getFullState();
         const connectedCount = state.players.filter(p => p.connected).length;
         if (connectedCount >= 2 && state.phase === 'playing') {

--- a/packages/shared/src/types/game.ts
+++ b/packages/shared/src/types/game.ts
@@ -84,7 +84,7 @@ export type GameAction =
   | { type: 'DRAW_CARD'; playerId: string; side: DrawSide }
   | { type: 'PASS'; playerId: string }
   | { type: 'CALL_UNO'; playerId: string }
-  | { type: 'CATCH_UNO'; catcherId: string; targetId: string }
+  | { type: 'CATCH_UNO'; catcherId: string; targetId: string; catcherName?: string }
   | { type: 'CHALLENGE'; playerId: string; succeeded?: boolean; penaltyPlayerId?: string; penaltyCount?: number }
   | { type: 'ACCEPT'; playerId: string }
   | { type: 'CHOOSE_COLOR'; playerId: string; color: Color }


### PR DESCRIPTION
## Summary
- **观战席同步**：改用 `io.to()` 广播观众列表，修复玩家看不到观众的问题；`room:rejoin` 时发送当前观众列表
- **表情投掷**：支持长按连发（300ms 间隔），松手停止，最长 10 秒自动停止
- **摸牌提示**："无牌可出，摸牌"移至弃牌堆上方中央；"还要摸X张"对其他玩家显示玩家名
- **摸牌音效**：每张牌到手立即播放 `draw_card` 音效，跟随实际摸牌速度
- **抓UNO**：`CATCH_UNO` action 携带 `catcherName`，修复观众抓 UNO 时日志和特效不显示抓人者的问题

## Test plan
- [ ] 观众加入观战后，所有玩家右侧列表显示观众；刷新页面后观众列表仍在
- [ ] 长按表情按钮连续投掷，松手停止，超过 10 秒自动停止
- [ ] 无牌可出时提示显示在弃牌堆上方中央
- [ ] 罚摸时其他玩家看到 "XXX 还要摸 N 张"，自己看到 "还要摸 N 张"
- [ ] 摸牌时每张牌到手播放音效，快速连点跟随点击速度
- [ ] 观众抓 UNO 时日志和特效正确显示观众昵称

🤖 Generated with [Claude Code](https://claude.com/claude-code)