### PR TITLE
fix: 观众列表同步移至全局 handler，表情节流

### DIFF
--- a/packages/client/src/features/game/components/ThrowItemPicker.tsx
+++ b/packages/client/src/features/game/components/ThrowItemPicker.tsx
@@ -50,12 +50,21 @@ export default function ThrowItemPicker({ onSelect, onClose, anchorX, anchorY }:
     return () => document.removeEventListener('mousedown', handleClick);
   }, [onClose]);
 
+  const lastSendRef = useRef(0);
+
+  const throttledSelect = useCallback((item: string) => {
+    const now = Date.now();
+    if (now - lastSendRef.current < REPEAT_INTERVAL_MS) return;
+    lastSendRef.current = now;
+    onSelect(item);
+  }, [onSelect]);
+
   const startRepeat = useCallback((item: string) => {
     stopRepeat();
-    onSelect(item);
-    intervalRef.current = setInterval(() => onSelect(item), REPEAT_INTERVAL_MS);
+    throttledSelect(item);
+    intervalRef.current = setInterval(() => throttledSelect(item), REPEAT_INTERVAL_MS);
     maxTimerRef.current = setTimeout(stopRepeat, MAX_HOLD_MS);
-  }, [onSelect, stopRepeat]);
+  }, [throttledSelect, stopRepeat]);
 
   useEffect(() => {
     const handleUp = () => stopRepeat();
@@ -83,7 +92,6 @@ export default function ThrowItemPicker({ onSelect, onClose, anchorX, anchorY }:
             <button
               key={emoji}
               onPointerDown={(e) => { e.preventDefault(); startRepeat(emoji); }}
-              onClick={() => onSelect(emoji)}
               className="flex flex-col items-center gap-0.5 bg-transparent cursor-pointer transition-transform duration-150 hover:scale-125 select-none touch-none"
             >
               <span className="text-2xl">{emoji}</span>

--- a/packages/client/src/features/game/hooks/useGameSocket.ts
+++ b/packages/client/src/features/game/hooks/useGameSocket.ts
@@ -13,8 +13,6 @@ export function useGameSocket(roomCode: string | undefined) {
   const setChatHistory = useChatStore((s) => s.setHistory);
   const addChatMessage = useChatStore((s) => s.addMessage);
   const clearChatMessages = useChatStore((s) => s.clearMessages);
-  const setSpectators = useSpectatorStore((s) => s.setSpectators);
-  const setPendingJoinQueue = useSpectatorStore((s) => s.setPendingJoinQueue);
   const setRoom = useRoomStore((s) => s.setRoom);
   const navigate = useNavigate();
   const [connectionStatus, setConnectionStatus] = useState<
@@ -46,42 +44,22 @@ export function useGameSocket(roomCode: string | undefined) {
     socket.on('chat:message', addChatMessage);
     socket.on('chat:cleared', clearChatMessages);
 
-    const onSpectatorUpdate = (data: { spectators?: string[] }) => {
-      if (data.spectators) {
-        setSpectators(data.spectators);
-        const spectatorSet = new Set(data.spectators);
-        const { pendingJoinQueue } = useSpectatorStore.getState();
-        if (pendingJoinQueue.some((n) => !spectatorSet.has(n))) {
-          setPendingJoinQueue(pendingJoinQueue.filter((n) => spectatorSet.has(n)));
-        }
-      }
-    };
-    const onSpectatorLeft = (data: { spectators?: string[]; nickname?: string }) => {
-      if (data.spectators) setSpectators(data.spectators);
-      else if (data.nickname) useSpectatorStore.getState().removeSpectator(data.nickname);
-    };
     const onSpectatorQueue = (data: { queue: string[]; nickname: string; joined: boolean }) => {
-      setPendingJoinQueue(data.queue);
+      useSpectatorStore.getState().setPendingJoinQueue(data.queue);
       useToastStore.getState().addToast(
         data.joined ? `${data.nickname} 将在下一轮加入游戏` : `${data.nickname} 取消了加入`,
         'info',
       );
     };
-    socket.on('room:spectator_list', onSpectatorUpdate);
-    socket.on('room:spectator_joined', onSpectatorUpdate);
-    socket.on('room:spectator_left', onSpectatorLeft);
     socket.on('game:spectator_queue', onSpectatorQueue);
 
     return () => {
       socket.off('chat:history', setChatHistory);
       socket.off('chat:message', addChatMessage);
       socket.off('chat:cleared', clearChatMessages);
-      socket.off('room:spectator_list', onSpectatorUpdate);
-      socket.off('room:spectator_joined', onSpectatorUpdate);
-      socket.off('room:spectator_left', onSpectatorLeft);
       socket.off('game:spectator_queue', onSpectatorQueue);
     };
-  }, [setChatHistory, addChatMessage, clearChatMessages, setSpectators, setPendingJoinQueue]);
+  }, [setChatHistory, addChatMessage, clearChatMessages]);
 
   // Reconnection status tracking + auto-rejoin on reconnect
   useEffect(() => {

--- a/packages/client/src/shared/socket.ts
+++ b/packages/client/src/shared/socket.ts
@@ -9,6 +9,7 @@ import { useGatewayStore, type PlayerVoicePresence } from './voice/gateway-store
 import { leaveVoiceSession } from './voice/voice-runtime';
 import { sendNotification } from './utils/notification';
 import { useServerVersionStore } from './stores/server-version-store';
+import { useSpectatorStore } from '@/features/game/stores/spectator-store';
 
 type TypedSocket = SocketType<ServerToClientEvents, ClientToServerEvents>;
 
@@ -139,12 +140,26 @@ export function getSocket(): TypedSocket {
       }
     });
 
+    socket.on('room:spectator_list', (data) => {
+      if (data.spectators) {
+        const store = useSpectatorStore.getState();
+        store.setSpectators(data.spectators);
+        const spectatorSet = new Set(data.spectators);
+        if (store.pendingJoinQueue.some((n) => !spectatorSet.has(n))) {
+          store.setPendingJoinQueue(store.pendingJoinQueue.filter((n) => spectatorSet.has(n)));
+        }
+      }
+    });
+
     socket.on('room:spectator_joined', (data) => {
       useToastStore.getState().addToast(`${data.nickname} 开始观战`, 'info');
+      if (data.spectators) useSpectatorStore.getState().setSpectators(data.spectators);
     });
 
     socket.on('room:spectator_left', (data) => {
       useToastStore.getState().addToast(`${data.nickname} 离开观战`, 'info');
+      if (data.spectators) useSpectatorStore.getState().setSpectators(data.spectators);
+      else if (data.nickname) useSpectatorStore.getState().removeSpectator(data.nickname);
     });
 
     socket.on('server:version', (data) => {


### PR DESCRIPTION
## Summary
- **观众列表同步**：`room:spectator_list`/`joined`/`left` 的 store 更新从 `useGameSocket` useEffect 移至 `socket.ts` 全局 handler，从 socket 创建时就注册，彻底解决事件丢失问题
- **表情投掷节流**：去掉 `onClick`，统一走 `onPointerDown` + 300ms 客户端节流，防止快速点击绕过连发间隔

## Test plan
- [ ] 观众加入/离开，所有玩家立即看到观众列表更新和 toast 通知
- [ ] 玩家刷新页面后观众列表仍正确显示
- [ ] 表情快速点击被限制为最快 300ms 一次

🤖 Generated with [Claude Code](https://claude.com/claude-code)