### PR TITLE
fix: 服务端表情投掷全局最小间隔 300ms

### DIFF
--- a/packages/server/src/plugins/core/interaction/ws.ts
+++ b/packages/server/src/plugins/core/interaction/ws.ts
@@ -2,6 +2,7 @@ import type { Server as SocketIOServer, Socket } from 'socket.io';
 import { ROLE_CONFIG, type UserRole } from '@uno-online/shared';
 
 const VALID_ITEMS = ['🥚', '🍅', '🌹', '💩', '👍', '💖'];
+const MIN_THROW_INTERVAL_MS = 300;
 
 const throwTimestamps = new Map<string, number>();
 
@@ -16,13 +17,11 @@ export function registerInteractionEvents(socket: Socket, io: SocketIOServer) {
     }
 
     const role = (socket.data.user?.role ?? 'normal') as UserRole;
-    const cooldownMs = ROLE_CONFIG[role].cooldownMs;
+    const cooldownMs = Math.max(ROLE_CONFIG[role].cooldownMs, MIN_THROW_INTERVAL_MS);
 
-    if (cooldownMs > 0) {
-      const lastThrow = throwTimestamps.get(userId);
-      if (lastThrow && Date.now() - lastThrow < cooldownMs) {
-        return callback?.({ success: false, error: '扔太快了' });
-      }
+    const lastThrow = throwTimestamps.get(userId);
+    if (lastThrow && Date.now() - lastThrow < cooldownMs) {
+      return callback?.({ success: false, error: '扔太快了' });
     }
 
     throwTimestamps.set(userId, Date.now());


### PR DESCRIPTION
## Summary
- 服务端投掷 cooldown 改用 `Math.max(roleCooldown, 300ms)` 保底，所有角色不低于 300ms
- 移除 `cooldownMs > 0` 的条件判断，统一走节流逻辑

## Test plan
- [ ] 普通用户投掷间隔仍为 1s
- [ ] VIP/管理员投掷间隔限制为 300ms（不再是 0）
- [ ] 快速请求被服务端拒绝

🤖 Generated with [Claude Code](https://claude.com/claude-code)