### PR TITLE
fix: 观众抓UNO、排队上限、记分板倒计时、音乐厅改版

### DIFF
--- a/packages/client/src/features/game/components/ScoreBoard.tsx
+++ b/packages/client/src/features/game/components/ScoreBoard.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect } from 'react';
-import { Trophy, BarChart3, Crown, Check, UserX, UserPlus } from 'lucide-react';
+import { useState, useEffect, useRef } from 'react';
+import { Trophy, BarChart3, Crown, Check, UserX, UserPlus, WifiOff } from 'lucide-react';
 import { useGameStore } from '../stores/game-store';
 import { useEffectiveUserId } from '../hooks/useEffectiveUserId';
 import { useRoomStore } from '@/shared/stores/room-store';
@@ -8,7 +8,29 @@ import { cn } from '@/shared/lib/utils';
 import { Button } from '@/shared/components/ui/Button';
 import { AiBadge } from '@/shared/components/ui/AiBadge';
 
-const KICK_DELAY_MS = 30_000;
+const KICK_DELAY_S = 30;
+
+function KickCountdownRing({ remaining, total }: { remaining: number; total: number }) {
+  const r = 7;
+  const circumference = 2 * Math.PI * r;
+  const progress = Math.max(0, remaining / total);
+
+  return (
+    <svg width="18" height="18" viewBox="0 0 18 18" className="inline align-middle">
+      <circle cx="9" cy="9" r={r} fill="none" stroke="currentColor" strokeWidth="2" className="text-muted-foreground/20" />
+      <circle
+        cx="9" cy="9" r={r} fill="none" stroke="currentColor" strokeWidth="2"
+        className="text-destructive"
+        strokeDasharray={circumference}
+        strokeDashoffset={circumference * (1 - progress)}
+        strokeLinecap="round"
+        transform="rotate(-90 9 9)"
+        style={{ transition: 'stroke-dashoffset 1s linear' }}
+      />
+      <text x="9" y="9" textAnchor="middle" dominantBaseline="central" className="fill-muted-foreground" fontSize="7">{remaining}</text>
+    </svg>
+  );
+}
 
 interface ScoreBoardProps {
   onPlayAgain: () => void;
@@ -22,13 +44,17 @@ export default function ScoreBoard({ onPlayAgain, onRematch, onBackToLobby, onKi
   const winnerId = useGameStore((s) => s.winnerId);
   const phase = useGameStore((s) => s.phase);
   const vote = useGameStore((s) => s.nextRoundVote);
-  const [canKick, setCanKick] = useState(false);
+  const [kickCountdown, setKickCountdown] = useState(KICK_DELAY_S);
   const [leaveCountdown, setLeaveCountdown] = useState(5);
+  const kickTimerRef = useRef<ReturnType<typeof setInterval>>();
 
   useEffect(() => {
-    if (phase !== 'round_end') { setCanKick(false); return; }
-    const timer = setTimeout(() => setCanKick(true), KICK_DELAY_MS);
-    return () => clearTimeout(timer);
+    if (phase !== 'round_end') { setKickCountdown(KICK_DELAY_S); return; }
+    setKickCountdown(KICK_DELAY_S);
+    kickTimerRef.current = setInterval(() => {
+      setKickCountdown((c) => { if (c <= 1) { clearInterval(kickTimerRef.current); return 0; } return c - 1; });
+    }, 1000);
+    return () => clearInterval(kickTimerRef.current);
   }, [phase]);
 
   useEffect(() => {
@@ -49,6 +75,7 @@ export default function ScoreBoard({ onPlayAgain, onRematch, onBackToLobby, onKi
   const votes = vote?.votes ?? 0;
   const required = vote?.required ?? fallbackRequired;
   const allAgreed = votes >= required;
+  const canKick = kickCountdown === 0;
   const nextRoundButtonText = isHost
     ? allAgreed
       ? '开始下一轮'
@@ -81,16 +108,25 @@ export default function ScoreBoard({ onPlayAgain, onRematch, onBackToLobby, onKi
           <tbody>
             {sorted.map((p) => {
               const ready = !!vote?.voters.includes(p.id);
+              const disconnected = !p.connected;
+              const isSelf = p.id === userId;
               return (
                 <tr key={p.id} className={cn(p.id === winnerId ? 'text-accent' : 'text-foreground')}>
-                  <td className="px-2 py-1.5 text-left">{p.id === winnerId && <Crown size={14} className="inline align-middle mr-1" />}{p.name}{p.isBot && <AiBadge className="ml-1" />}</td>
+                  <td className="px-2 py-1.5 text-left">
+                    {p.id === winnerId && <Crown size={14} className="inline align-middle mr-1" />}
+                    <span className={cn(disconnected && 'opacity-50')}>{p.name}</span>
+                    {p.isBot && <AiBadge className="ml-1" />}
+                    {disconnected && <WifiOff size={12} className="inline align-middle ml-1 text-destructive" />}
+                  </td>
                   {!isGameOver && (
                     <td className="px-2 py-1.5 text-center whitespace-nowrap">
                       {ready
                         ? <Check size={14} className="inline text-green-400" />
-                        : isHost && canKick && p.id !== userId
+                        : isHost && canKick && !isSelf
                           ? <button onClick={() => onKickPlayer(p.id)} className="text-xs text-destructive hover:text-destructive/80 cursor-pointer bg-transparent border-none" title="踢出游戏"><UserX size={14} className="inline" /></button>
-                          : <span className="text-xs text-muted-foreground">等待中</span>}
+                          : isSelf
+                            ? <span className="text-xs text-muted-foreground">等待中</span>
+                            : <KickCountdownRing remaining={kickCountdown} total={KICK_DELAY_S} />}
                     </td>
                   )}
                   <td className="px-2 py-1.5 text-right font-bold">{p.score}</td>

--- a/packages/client/src/shared/components/MusicHallModal.tsx
+++ b/packages/client/src/shared/components/MusicHallModal.tsx
@@ -1,14 +1,30 @@
 import { useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
-import { Music, X, Play, Square } from 'lucide-react';
+import { Music, X, Play, Square, Volume2 } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
 import { bgm } from '@/shared/sound/bgm-engine';
 import { PLAYLISTS } from '@/shared/sound/songs/index';
+import { useSettingsStore } from '@/shared/stores/settings-store';
 
 const TABS = [
   { key: 'game' as const, label: '游戏曲目' },
   { key: 'lobby' as const, label: '大厅曲目' },
 ];
+
+function SoundBars({ className }: { className?: string }) {
+  return (
+    <span className={cn('flex items-end gap-[2px] h-3', className)}>
+      {[0, 1, 2, 3].map((j) => (
+        <motion.span
+          key={j}
+          className="inline-block w-[3px] bg-accent rounded-full"
+          animate={{ height: [3, 12, 5, 10, 3] }}
+          transition={{ duration: 0.8, repeat: Infinity, delay: j * 0.12, ease: 'easeInOut' }}
+        />
+      ))}
+    </span>
+  );
+}
 
 interface Props {
   open: boolean;
@@ -19,6 +35,8 @@ interface Props {
 export default function MusicHallModal({ open, onClose, currentScene }: Props) {
   const [tab, setTab] = useState<'game' | 'lobby'>('game');
   const [playing, setPlaying] = useState<string | null>(null);
+  const bgmVolume = useSettingsStore((s) => s.bgmVolume);
+  const setBgmVolume = useSettingsStore((s) => s.setBgmVolume);
 
   const songs = PLAYLISTS[tab] ?? [];
 
@@ -39,110 +57,144 @@ export default function MusicHallModal({ open, onClose, currentScene }: Props) {
     onClose();
   };
 
+  const handleVolumeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const v = parseFloat(e.target.value);
+    setBgmVolume(v);
+    bgm.setVolume(v);
+  };
+
   if (!open) return null;
 
   return (
     <AnimatePresence>
       {open && (
-        <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          transition={{ duration: 0.3 }}
-          className="fixed inset-0 z-modal flex flex-col bg-gradient-to-b from-slate-950 via-slate-900 to-slate-950"
-        >
-          <div className="flex items-center justify-between px-6 py-5 shrink-0">
-            <div className="flex items-center gap-3 text-xl sm:text-2xl font-bold font-game text-foreground">
-              <Music size={24} className="text-accent" /> 音乐厅
-            </div>
-            <button onClick={close} className="p-2 rounded-lg text-muted-foreground hover:text-foreground hover:bg-white/5 transition-colors">
-              <X size={20} />
-            </button>
-          </div>
+        <>
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 z-modal bg-black/60 backdrop-blur-sm"
+            onClick={close}
+          />
+          <motion.div
+            initial={{ opacity: 0, scale: 0.95, y: 20 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.95, y: 20 }}
+            transition={{ duration: 0.25 }}
+            className="fixed inset-0 z-modal flex items-center justify-center pointer-events-none"
+          >
+            <div
+              className="pointer-events-auto flex flex-col bg-card border border-white/10 rounded-2xl shadow-2xl w-[90vw] max-w-xl max-h-[80vh]"
+              onClick={(e) => e.stopPropagation()}
+            >
+              {/* Header */}
+              <div className="flex items-center justify-between px-5 pt-5 pb-3 shrink-0">
+                <div className="flex items-center gap-2.5 text-lg font-bold font-game text-foreground">
+                  <Music size={20} className="text-accent" />
+                  音乐厅
+                  <span className="text-xs font-normal text-muted-foreground">({songs.length} 首)</span>
+                </div>
+                <button onClick={close} className="p-1.5 rounded-lg text-muted-foreground hover:text-foreground hover:bg-white/5 transition-colors">
+                  <X size={18} />
+                </button>
+              </div>
 
-          <div className="flex justify-center gap-1 px-6 mb-4 shrink-0">
-            {TABS.map((t) => (
-              <button
-                key={t.key}
-                onClick={() => setTab(t.key)}
-                className={cn(
-                  'px-6 py-2.5 rounded-lg text-sm font-bold transition-all',
-                  tab === t.key
-                    ? 'bg-accent/15 text-accent'
-                    : 'text-muted-foreground hover:text-foreground hover:bg-white/5',
-                )}
-              >
-                {t.label}
-                <span className="ml-1.5 text-xs opacity-50">({(PLAYLISTS[t.key] ?? []).length})</span>
-              </button>
-            ))}
-          </div>
-
-          <div className="flex-1 overflow-y-auto px-6 py-2 scrollbar-thin">
-            <div className="max-w-2xl mx-auto grid gap-2 sm:grid-cols-2">
-              {songs.map((song, i) => {
-                const key = `${tab}:${i}`;
-                const isPlaying = playing === key;
-                return (
-                  <motion.button
-                    key={key}
-                    layout
-                    onClick={() => play(tab, i)}
+              {/* Tabs */}
+              <div className="flex gap-4 px-5 shrink-0 border-b border-white/5">
+                {TABS.map((t) => (
+                  <button
+                    key={t.key}
+                    onClick={() => setTab(t.key)}
                     className={cn(
-                      'flex items-center gap-4 rounded-xl px-5 py-4 text-left transition-all w-full',
-                      isPlaying
-                        ? 'bg-accent/10 border border-accent/25'
-                        : 'bg-white/[0.03] border border-white/[0.06] hover:bg-white/[0.06]',
+                      'pb-2.5 text-sm font-medium transition-all relative',
+                      tab === t.key
+                        ? 'text-accent'
+                        : 'text-muted-foreground hover:text-foreground',
                     )}
                   >
-                    <div className={cn(
-                      'flex items-center justify-center w-11 h-11 rounded-full shrink-0 transition-colors',
-                      isPlaying ? 'bg-accent text-white' : 'bg-white/10 text-muted-foreground',
-                    )}>
-                      {isPlaying ? <Square size={14} /> : <Play size={14} className="ml-0.5" />}
-                    </div>
+                    {t.label}
+                    {tab === t.key && (
+                      <motion.div layoutId="music-tab-indicator" className="absolute bottom-0 left-0 right-0 h-0.5 bg-accent rounded-full" />
+                    )}
+                  </button>
+                ))}
+              </div>
 
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2">
-                        <span className={cn('text-sm font-bold truncate', isPlaying && 'text-accent')}>
-                          {song.name}
-                        </span>
-                        <span className="text-2xs text-muted-foreground shrink-0">— {song.meta.author}</span>
-                        {isPlaying && (
-                          <span className="flex gap-0.5 shrink-0">
-                            {[0, 1, 2].map((j) => (
-                              <motion.span
-                                key={j}
-                                className="inline-block w-0.5 bg-accent rounded-full"
-                                animate={{ height: [4, 14, 4] }}
-                                transition={{ duration: 0.6, repeat: Infinity, delay: j * 0.15 }}
-                              />
-                            ))}
-                          </span>
+              {/* Song list */}
+              <div className="flex-1 overflow-y-auto px-3 py-3 scrollbar-thin">
+                <div className="flex flex-col gap-1">
+                  {songs.map((song, i) => {
+                    const key = `${tab}:${i}`;
+                    const isPlaying = playing === key;
+                    return (
+                      <button
+                        key={key}
+                        onClick={() => play(tab, i)}
+                        className={cn(
+                          'flex items-center gap-3 rounded-xl px-3 py-2.5 text-left transition-all w-full group',
+                          isPlaying
+                            ? 'bg-accent/10'
+                            : 'hover:bg-white/[0.04]',
                         )}
-                      </div>
-                      <div className="flex items-center gap-2 mt-1 text-xs text-muted-foreground">
-                        <span>{song.bpm} BPM</span>
-                        <span className="opacity-30">·</span>
-                        <span>{song.meta.key}</span>
-                        <span className="opacity-30">·</span>
-                        <span>{song.meta.style}</span>
-                        <span className="opacity-30">·</span>
-                        <span>{song.meta.wave}</span>
-                      </div>
-                    </div>
-                  </motion.button>
-                );
-              })}
-            </div>
-          </div>
+                      >
+                        {/* Index / Play indicator */}
+                        <div className="w-8 h-8 flex items-center justify-center shrink-0">
+                          {isPlaying ? (
+                            <SoundBars />
+                          ) : (
+                            <>
+                              <span className="text-xs text-muted-foreground group-hover:hidden">
+                                {String(i + 1).padStart(2, '0')}
+                              </span>
+                              <Play size={14} className="text-muted-foreground hidden group-hover:block" />
+                            </>
+                          )}
+                        </div>
 
-          <div className="shrink-0 px-6 py-4">
-            <p className="text-center text-xs text-muted-foreground/60">
-              点击曲目试听 · 关闭后自动恢复背景音乐
-            </p>
-          </div>
-        </motion.div>
+                        {/* Song info */}
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center gap-2">
+                            <span className={cn('text-sm font-medium truncate', isPlaying ? 'text-accent' : 'text-foreground')}>
+                              {song.name}
+                            </span>
+                            <span className="text-2xs text-muted-foreground/60 shrink-0">{song.meta.author}</span>
+                          </div>
+                          <div className="flex items-center gap-1.5 mt-0.5">
+                            {[`${song.bpm} BPM`, song.meta.key, song.meta.style, song.meta.wave].map((tag, ti) => (
+                              <span key={ti} className="text-2xs text-muted-foreground/50 bg-white/[0.04] rounded px-1.5 py-0.5">{tag}</span>
+                            ))}
+                          </div>
+                        </div>
+
+                        {/* Stop button when playing */}
+                        {isPlaying && (
+                          <div className="shrink-0 p-1">
+                            <Square size={12} className="text-accent" />
+                          </div>
+                        )}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              {/* Footer with volume control */}
+              <div className="shrink-0 px-5 py-3 border-t border-white/5 flex items-center gap-3">
+                <Volume2 size={14} className="text-muted-foreground shrink-0" />
+                <input
+                  type="range"
+                  min="0"
+                  max="1"
+                  step="0.01"
+                  value={bgmVolume}
+                  onChange={handleVolumeChange}
+                  className="flex-1 h-1 accent-accent bg-white/10 rounded-full appearance-none cursor-pointer [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-3 [&::-webkit-slider-thumb]:h-3 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-accent"
+                />
+                <span className="text-2xs text-muted-foreground/60 w-8 text-right shrink-0">{Math.round(bgmVolume * 100)}%</span>
+              </div>
+            </div>
+          </motion.div>
+        </>
       )}
     </AnimatePresence>
   );

--- a/packages/server/src/ws/game-events.ts
+++ b/packages/server/src/ws/game-events.ts
@@ -255,9 +255,13 @@ async function processPendingSpectatorJoins(
   const pending = pendingSpectatorJoins.get(roomCode);
   if (!pending || pending.size === 0) return;
 
+  const joined: string[] = [];
   for (const [userId, info] of pending) {
     if (session.getPlayerCount() >= MAX_PLAYERS) break;
-    if (session.getFullState().players.some((p) => p.id === userId)) continue;
+    if (session.getFullState().players.some((p) => p.id === userId)) {
+      joined.push(userId);
+      continue;
+    }
 
     const sock = io.sockets.sockets.get(info.socketId);
     if (sock) (sock.data as SocketData).isSpectator = false;
@@ -277,8 +281,20 @@ async function processPendingSpectatorJoins(
       role: info.role,
       isBot: info.isBot,
     });
+    joined.push(userId);
   }
-  pendingSpectatorJoins.delete(roomCode);
+
+  for (const id of joined) pending.delete(id);
+
+  if (pending.size === 0) {
+    pendingSpectatorJoins.delete(roomCode);
+  } else {
+    io.to(roomCode).emit('game:spectator_queue', {
+      queue: [...pending.values()].map((p) => p.nickname),
+      nickname: '',
+      joined: true,
+    });
+  }
   io.to(roomCode).emit('room:spectator_list', { spectators: getSpectatorNames(roomCode) });
 }
 
@@ -496,9 +512,10 @@ export function registerGameEvents(
   });
 
   socket.on('game:catch_uno', async (payload: { targetPlayerId: string }, callback) => {
-    const ctx = getSession(socket, sessions);
-    if (!ctx) return callback?.({ success: false });
-    const { session, roomCode } = ctx;
+    const roomCode = data.roomCode;
+    if (!roomCode) return callback?.({ success: false });
+    const session = sessions.get(roomCode);
+    if (!session) return callback?.({ success: false });
     const result = session.applyAction({ type: 'CATCH_UNO', catcherId: data.user.userId, targetId: payload.targetPlayerId, catcherName: data.user.nickname });
     if (!result.success) return callback?.({ success: false, error: result.error });
     session.recordEvent(GameEventType.CATCH_UNO, { targetPlayerId: payload.targetPlayerId }, data.user.userId);
@@ -667,6 +684,11 @@ export function registerGameEvents(
       pending.delete(data.user.userId);
       callback?.({ success: true, queued: false });
     } else {
+      const currentCount = session.getPlayerCount();
+      const queuedCount = pending.size;
+      if (currentCount + queuedCount >= MAX_PLAYERS) {
+        return callback?.({ success: false, error: `房间人数已达上限 (${MAX_PLAYERS})，无法排队` });
+      }
       pending.set(data.user.userId, {
         userId: data.user.userId,
         nickname: data.user.nickname,


### PR DESCRIPTION
## Summary
- 修复观众无法抓UNO（`getSession` 的 `isSpectator` 检查拦截了合法操作）
- 观战"下局加入"排队时检查 `玩家数+排队数 >= 10` 上限，超额者保留队列等下局
- 记分板未投票玩家显示 30 秒圆环倒计时，掉线玩家名字半透明+断连图标
- 音乐厅 UI 改版：居中弹窗、下划线 Tab、紧凑列表、音波动画、底部音量控制

## Test plan
- [ ] 观众模式下点击抓 UNO 按钮能正常抓取并显示日志
- [ ] 房间 10 人时观众排队提示"房间人数已达上限"
- [ ] 回合结束时未投票玩家旁显示圆环倒计时，掉线玩家有断连图标
- [ ] 音乐厅弹窗布局、音量滑块、试听功能正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)