### PR TITLE
feat: 观众席可视化、观众丢表情与抓UNO

### DIFF
--- a/packages/client/src/features/game/components/GameActions.tsx
+++ b/packages/client/src/features/game/components/GameActions.tsx
@@ -1,8 +1,8 @@
-import { useState } from 'react';
 import { useGameStore } from '../stores/game-store';
 import { useEffectiveUserId } from '../hooks/useEffectiveUserId';
 import { useIsMyTurn } from '../hooks/useIsMyTurn';
 import { usePlayableCardIds } from '../hooks/usePlayableCardIds';
+import { useCooldown } from '../hooks/useCooldown';
 import { Button } from '@/shared/components/ui/Button';
 
 interface GameActionsProps {
@@ -23,7 +23,7 @@ export default function GameActions({ onCallUno, onCatchUno, onChallenge, onAcce
   const drawStack = useGameStore((s) => s.drawStack);
   const hasDrawnThisTurn = useGameStore((s) => s.hasDrawnThisTurn);
   const settings = useGameStore((s) => s.settings);
-  const [cooldown, setCooldown] = useState(false);
+  const { cooldown, withCooldown } = useCooldown();
 
   const me = players.find((p) => p.id === userId);
   const isMyTurn = useIsMyTurn();
@@ -44,13 +44,6 @@ export default function GameActions({ onCallUno, onCatchUno, onChallenge, onAcce
   const mustDrawUntilPlayable = Boolean(settings?.houseRules?.drawUntilPlayable || settings?.houseRules?.deathDraw);
   const canPassAfterDraw = pendingPenaltyDraws === 0 && drawStack === 0 && hasDrawnThisTurn && (!mustDrawUntilPlayable || playableIds.size > 0);
   const canPass = canPassAfterDraw || noCardsAvailable;
-
-  const withCooldown = (fn: () => void) => () => {
-    if (cooldown) return;
-    setCooldown(true);
-    fn();
-    setTimeout(() => setCooldown(false), 1000);
-  };
 
   return (
     <div className="relative z-actions flex justify-center gap-2.5 py-2 pointer-events-auto">

--- a/packages/client/src/features/game/components/GameTable.tsx
+++ b/packages/client/src/features/game/components/GameTable.tsx
@@ -8,6 +8,7 @@ import TurnIndicator from './TurnIndicator';
 import HandSwapAnimation from './HandSwapAnimation';
 import DirectionIndicator from './DirectionIndicator';
 import ThrowAnimation from './ThrowAnimation';
+import SpectatorSeats from './SpectatorSeats';
 import { useGameStore } from '../stores/game-store';
 import { useEffectiveUserId } from '../hooks/useEffectiveUserId';
 import { useIsMyTurn } from '../hooks/useIsMyTurn';
@@ -191,11 +192,16 @@ export default function GameTable({ onDraw }: GameTableProps) {
     currentPlayerIndex,
   );
 
+  const spectatorFallbackPos = useMemo(() => {
+    if (dimensions.width === 0) return null;
+    return { x: dimensions.width / 2, y: dimensions.height - 24 };
+  }, [dimensions]);
+
   // Listen for throw:item events from socket
   useEffect(() => {
     const socket = getSocket();
     const handler = (data: { fromId: string; targetId: string; item: string }) => {
-      const fromPos = getPlayerPosition(data.fromId);
+      const fromPos = getPlayerPosition(data.fromId) ?? spectatorFallbackPos;
       const toPos = getPlayerPosition(data.targetId);
       if (!fromPos || !toPos) return;
       if (data.targetId === userId) {
@@ -218,7 +224,7 @@ export default function GameTable({ onDraw }: GameTableProps) {
     socket.on('throw:item', handler);
     return () => { socket.off('throw:item', handler); };
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [players, dimensions]);
+  }, [players, dimensions]); // spectatorFallbackPos derives from dimensions
 
   // Handle reaction from quick reaction menu
   const handleReaction = useCallback((emoji: string) => {
@@ -418,6 +424,9 @@ export default function GameTable({ onDraw }: GameTableProps) {
           />
         ))}
       </AnimatePresence>
+
+      {/* Spectator seats */}
+      <SpectatorSeats />
     </div>
   );
 }

--- a/packages/client/src/features/game/components/SpectatorActions.tsx
+++ b/packages/client/src/features/game/components/SpectatorActions.tsx
@@ -1,0 +1,24 @@
+import { useGameStore } from '../stores/game-store';
+import { useCooldown } from '../hooks/useCooldown';
+import { Button } from '@/shared/components/ui/Button';
+
+interface SpectatorActionsProps {
+  onCatchUno: (targetId: string) => void;
+}
+
+export default function SpectatorActions({ onCatchUno }: SpectatorActionsProps) {
+  const players = useGameStore((s) => s.players);
+  const { cooldown, withCooldown } = useCooldown();
+
+  const catchTargets = players.filter((p) => p.handCount === 1 && !p.calledUno && !p.unoCaught);
+
+  if (catchTargets.length === 0) return null;
+
+  return (
+    <div className="relative z-actions flex justify-center gap-2.5 py-2 pointer-events-auto">
+      {catchTargets.map((t) => (
+        <Button key={t.id} variant="danger" onClick={withCooldown(() => onCatchUno(t.id))} disabled={cooldown} sound="danger">抓 {t.name}!</Button>
+      ))}
+    </div>
+  );
+}

--- a/packages/client/src/features/game/components/SpectatorSeats.tsx
+++ b/packages/client/src/features/game/components/SpectatorSeats.tsx
@@ -1,0 +1,38 @@
+import { memo } from 'react';
+import { Eye } from 'lucide-react';
+import { useSpectatorStore } from '../stores/spectator-store';
+import { cn } from '@/shared/lib/utils';
+
+function SpectatorSeats() {
+  const spectators = useSpectatorStore((s) => s.spectators);
+  const pendingJoinQueue = useSpectatorStore((s) => s.pendingJoinQueue);
+
+  if (spectators.length === 0) return null;
+
+  return (
+    <div className="absolute bottom-2 left-1/2 -translate-x-1/2 z-10 flex items-center gap-2 bg-card/60 backdrop-blur-sm rounded-full px-3 py-1.5 border border-white/5">
+      <Eye size={12} className="text-muted-foreground shrink-0" />
+      <div className="flex items-center gap-1">
+        {spectators.map((name) => {
+          const queued = pendingJoinQueue.includes(name);
+          return (
+            <div
+              key={name}
+              className={cn(
+                'w-7 h-7 rounded-full flex items-center justify-center text-xs border-2 shrink-0',
+                queued
+                  ? 'bg-accent/20 border-accent/40 text-accent'
+                  : 'bg-white/10 border-white/10 text-muted-foreground',
+              )}
+              title={name + (queued ? ' (下局加入)' : '')}
+            >
+              {name.charAt(0).toUpperCase()}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export default memo(SpectatorSeats);

--- a/packages/client/src/features/game/hooks/useCooldown.ts
+++ b/packages/client/src/features/game/hooks/useCooldown.ts
@@ -1,0 +1,14 @@
+import { useState, useCallback } from 'react';
+
+export function useCooldown(ms = 1000) {
+  const [active, setActive] = useState(false);
+
+  const wrap = useCallback((fn: () => void) => () => {
+    if (active) return;
+    setActive(true);
+    fn();
+    setTimeout(() => setActive(false), ms);
+  }, [active, ms]);
+
+  return { cooldown: active, withCooldown: wrap } as const;
+}

--- a/packages/client/src/features/game/pages/GamePage.tsx
+++ b/packages/client/src/features/game/pages/GamePage.tsx
@@ -31,6 +31,7 @@ import MobileFAB from '../components/MobileFAB';
 import InfoDrawer from '../components/InfoDrawer';
 import PlayerListPanel from '../components/PlayerListPanel';
 import DanmakuLayer from '../components/DanmakuLayer';
+import SpectatorActions from '../components/SpectatorActions';
 import AntiCheatToast from '../components/AntiCheatToast';
 import CheatOverlay from '../components/CheatOverlay';
 import { useSpectatorStore } from '../stores/spectator-store';
@@ -219,11 +220,14 @@ export default function GamePage() {
       {!isSpectator && <PlayerHand onPlayCard={playCard} />}
       </LayoutGroup>
       {isSpectator && (
-        <SpectatorBar
-          phase={phase}
-          onBackToLobby={backToLobby}
-          onJoined={() => { setSpectator(false); clearSpectators(); }}
-        />
+        <>
+          <SpectatorActions onCatchUno={catchUno} />
+          <SpectatorBar
+            phase={phase}
+            onBackToLobby={backToLobby}
+            onJoined={() => { setSpectator(false); clearSpectators(); }}
+          />
+        </>
       )}
       <VoicePanel />
       <InfoDrawer />


### PR DESCRIPTION
## Summary
- 游戏场地底部新增观众席头像栏，所有人可见，排队加入的观众金色高亮
- 观众点击场上玩家头像可丢表情，动画从观众席（底部中央）飞出
- 观众可看到并使用"抓 UNO"按钮（SpectatorActions 组件）
- 提取 `useCooldown` hook 消除 GameActions / SpectatorActions 间的重复代码

## Test plan
- [ ] 有观众时场地底部显示观众席头像
- [ ] 观众点击玩家头像丢表情，动画从底部飞向目标
- [ ] 其他玩家也能看到观众丢出的表情动画
- [ ] 观众能看到并点击"抓 UNO"按钮
- [ ] GameActions 的 cooldown 行为不变

🤖 Generated with [Claude Code](https://claude.com/claude-code)