### PR TITLE
fix: 回合结束记分板倒计时改用服务器时间、踢出转观战席

### DIFF
--- a/packages/client/src/features/game/components/ScoreBoard.tsx
+++ b/packages/client/src/features/game/components/ScoreBoard.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import { Trophy, BarChart3, Crown, Check, UserX, UserPlus, WifiOff } from 'lucide-react';
+import { Trophy, BarChart3, Crown, Check, UserX, UserPlus, WifiOff, Eye } from 'lucide-react';
 import { useGameStore } from '../stores/game-store';
 import { useEffectiveUserId } from '../hooks/useEffectiveUserId';
 import { useRoomStore } from '@/shared/stores/room-store';
@@ -37,25 +37,33 @@ interface ScoreBoardProps {
   onRematch: () => void;
   onBackToLobby: () => void;
   onKickPlayer: (targetId: string) => void;
+  onLeaveToSpectate: () => void;
 }
 
-export default function ScoreBoard({ onPlayAgain, onRematch, onBackToLobby, onKickPlayer }: ScoreBoardProps) {
+export default function ScoreBoard({ onPlayAgain, onRematch, onBackToLobby, onKickPlayer, onLeaveToSpectate }: ScoreBoardProps) {
   const players = useGameStore((s) => s.players);
   const winnerId = useGameStore((s) => s.winnerId);
   const phase = useGameStore((s) => s.phase);
   const vote = useGameStore((s) => s.nextRoundVote);
-  const [kickCountdown, setKickCountdown] = useState(KICK_DELAY_S);
+  const roundEndAt = vote?.roundEndAt ?? null;
+  const [kickCountdown, setKickCountdown] = useState(() => {
+    if (!roundEndAt) return KICK_DELAY_S;
+    return Math.max(0, KICK_DELAY_S - Math.floor((Date.now() - roundEndAt) / 1000));
+  });
   const [leaveCountdown, setLeaveCountdown] = useState(5);
   const kickTimerRef = useRef<ReturnType<typeof setInterval>>();
 
   useEffect(() => {
-    if (phase !== 'round_end') { setKickCountdown(KICK_DELAY_S); return; }
-    setKickCountdown(KICK_DELAY_S);
+    if (phase !== 'round_end' || !roundEndAt) { setKickCountdown(KICK_DELAY_S); return; }
+    const calc = () => Math.max(0, KICK_DELAY_S - Math.floor((Date.now() - roundEndAt) / 1000));
+    setKickCountdown(calc());
     kickTimerRef.current = setInterval(() => {
-      setKickCountdown((c) => { if (c <= 1) { clearInterval(kickTimerRef.current); return 0; } return c - 1; });
+      const v = calc();
+      setKickCountdown(v);
+      if (v <= 0) clearInterval(kickTimerRef.current);
     }, 1000);
     return () => clearInterval(kickTimerRef.current);
-  }, [phase]);
+  }, [phase, roundEndAt]);
 
   useEffect(() => {
     setLeaveCountdown(5);
@@ -122,11 +130,15 @@ export default function ScoreBoard({ onPlayAgain, onRematch, onBackToLobby, onKi
                     <td className="px-2 py-1.5 text-center whitespace-nowrap">
                       {ready
                         ? <Check size={14} className="inline text-green-400" />
-                        : isHost && canKick && !isSelf
-                          ? <button onClick={() => onKickPlayer(p.id)} className="text-xs text-destructive hover:text-destructive/80 cursor-pointer bg-transparent border-none" title="踢出游戏"><UserX size={14} className="inline" /></button>
-                          : isSelf
-                            ? <span className="text-xs text-muted-foreground">等待中</span>
-                            : <KickCountdownRing remaining={kickCountdown} total={KICK_DELAY_S} />}
+                        : isSelf
+                          ? <span className="text-xs text-muted-foreground">等待中</span>
+                          : isHost && canKick
+                            ? <button onClick={() => onKickPlayer(p.id)} className="text-xs text-destructive hover:text-destructive/80 cursor-pointer bg-transparent border-none" title="移至观战席"><UserX size={14} className="inline" /></button>
+                            : disconnected
+                              ? canKick
+                                ? <span className="text-xs text-destructive">已超时</span>
+                                : <KickCountdownRing remaining={kickCountdown} total={KICK_DELAY_S} />
+                              : <span className="text-xs text-muted-foreground">等待中</span>}
                     </td>
                   )}
                   <td className="px-2 py-1.5 text-right font-bold">{p.score}</td>
@@ -145,10 +157,11 @@ export default function ScoreBoard({ onPlayAgain, onRematch, onBackToLobby, onKi
             {allAgreed ? '所有玩家已同意，等待房主开始下一轮' : `已有 ${votes}/${required} 人同意继续下一轮`}
           </p>
         )}
-        <div className="flex gap-3 justify-center">
+        <div className="flex gap-3 justify-center flex-wrap">
           {!isGameOver && <Button variant="primary" onClick={onPlayAgain} disabled={isNextRoundDisabled} sound="ready">{nextRoundButtonText}</Button>}
           {isGameOver && isHost && <Button variant="primary" onClick={onRematch} sound="ready">再来一局</Button>}
           {isGameOver && !isHost && <Button variant="primary" disabled>等待房主再来一局…</Button>}
+          {!isHost && <Button variant="secondary" onClick={onLeaveToSpectate} sound="click"><Eye size={14} className="inline align-middle mr-1" />进入观战席</Button>}
           <Button variant="secondary" onClick={onBackToLobby} sound="click" disabled={leaveCountdown > 0}>{leaveCountdown > 0 ? `返回大厅 (${leaveCountdown}s)` : '返回大厅'}</Button>
         </div>
       </div>

--- a/packages/client/src/features/game/hooks/useGameActions.ts
+++ b/packages/client/src/features/game/hooks/useGameActions.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import type { Color } from '@uno-online/shared';
 import { getSocket } from '@/shared/socket';
 import { useToastStore } from '@/shared/stores/toast-store';
+import { useGameStore } from '../stores/game-store';
 
 export function useGameActions() {
   const playCard = useCallback((cardId: string, chosenColor?: Color) => {
@@ -73,6 +74,16 @@ export function useGameActions() {
     });
   }, []);
 
+  const leaveToSpectate = useCallback(() => {
+    getSocket().emit('game:leave_to_spectate', (res: { success?: boolean; error?: string }) => {
+      if (res?.success) {
+        useGameStore.getState().setSpectator(true);
+      } else {
+        useToastStore.getState().addToast(res?.error || '操作失败', 'error');
+      }
+    });
+  }, []);
+
   return {
     playCard,
     drawCard,
@@ -86,5 +97,6 @@ export function useGameActions() {
     playAgain,
     rematch,
     kickPlayer,
+    leaveToSpectate,
   };
 }

--- a/packages/client/src/features/game/pages/GamePage.tsx
+++ b/packages/client/src/features/game/pages/GamePage.tsx
@@ -52,10 +52,12 @@ export default function GamePage() {
   const clearSpectators = useSpectatorStore((s) => s.clearSpectators);
   const cheatDetected = useGameStore((s) => s.cheatDetected);
 
+  const isSpectator = useGameStore((s) => s.isSpectator);
+  const setSpectator = useGameStore((s) => s.setSpectator);
   const isMyTurn = useIsMyTurn();
   const playableIds = usePlayableCardIds();
   const needsColorPick = phase === 'choosing_color' && isMyTurn;
-  const showScoreBoard = phase === 'round_end' || phase === 'game_over';
+  const showScoreBoard = !isSpectator && (phase === 'round_end' || phase === 'game_over');
 
   const connectionStatus = useGameSocket(roomCode);
   useGameLogTracker();
@@ -103,13 +105,12 @@ export default function GamePage() {
     playAgain,
     rematch,
     kickPlayer,
+    leaveToSpectate,
   } = useGameActions();
 
   useAutoPlay();
 
   const [searchParams] = useSearchParams();
-  const isSpectator = useGameStore((s) => s.isSpectator);
-  const setSpectator = useGameStore((s) => s.setSpectator);
 
   useEffect(() => {
     if (searchParams.get('spectate') === 'true') {
@@ -243,7 +244,7 @@ export default function GamePage() {
       {(phase === 'round_end' || phase === 'game_over') && <Confetti />}
       {needsColorPick && <ColorPicker onPick={chooseColor} />}
       {showScoreBoard && (
-        <ScoreBoard onPlayAgain={playAgain} onRematch={rematch} onBackToLobby={backToLobby} onKickPlayer={kickPlayer} />
+        <ScoreBoard onPlayAgain={playAgain} onRematch={rematch} onBackToLobby={backToLobby} onKickPlayer={kickPlayer} onLeaveToSpectate={leaveToSpectate} />
       )}
       {cheatDetected && <CheatOverlay />}
       <BgmToast song={bgmSongName} />

--- a/packages/client/src/features/game/stores/game-store.ts
+++ b/packages/client/src/features/game/stores/game-store.ts
@@ -9,6 +9,7 @@ export interface NextRoundVoteState {
   votes: number;
   required: number;
   voters: string[];
+  roundEndAt: number;
 }
 
 interface GameState {

--- a/packages/client/src/shared/socket.ts
+++ b/packages/client/src/shared/socket.ts
@@ -203,6 +203,11 @@ export function getSocket(): TypedSocket {
     });
 
     socket.on('game:kicked', (data) => {
+      if (data.toSpectator) {
+        useGameStore.getState().setSpectator(true);
+        useToastStore.getState().addToast(data.reason || '你已被移至观战席', 'info');
+        return;
+      }
       useRoomStore.getState().clearRoom();
       useGameStore.getState().clearGame();
       leaveVoiceSession();

--- a/packages/server/src/plugins/core/spectate/ws.ts
+++ b/packages/server/src/plugins/core/spectate/ws.ts
@@ -19,6 +19,11 @@ export function removeSpectator(roomCode: string, nickname: string): void {
   roomSpectators.get(roomCode)?.delete(nickname);
 }
 
+export function addSpectator(roomCode: string, nickname: string): void {
+  if (!roomSpectators.has(roomCode)) roomSpectators.set(roomCode, new Set());
+  roomSpectators.get(roomCode)!.add(nickname);
+}
+
 export function setupSpectateHandlers(
   io: SocketIOServer,
   kv: KvStore,

--- a/packages/server/src/ws/game-events.ts
+++ b/packages/server/src/ws/game-events.ts
@@ -8,7 +8,7 @@ import { emitGameUpdate, setAutopilotActionHandler, startTurnTimer, resetPlayerT
 import type { TurnTimer } from '../plugins/core/game/turn-timer.js';
 import { getRoom, setRoomStatus, touchRoomActivity, removePlayerFromRoom, addPlayerToRoom } from '../plugins/core/room/store.js';
 import { MAX_PLAYERS } from '@uno-online/shared';
-import { removeSpectator, getSpectatorNames } from '../plugins/core/spectate/ws.js';
+import { removeSpectator, addSpectator, getSpectatorNames } from '../plugins/core/spectate/ws.js';
 import type { SocketData } from './types.js';
 
 function getSession(socket: Socket, sessions: Map<string, GameSession>): { session: GameSession; roomCode: string } | null {
@@ -52,6 +52,7 @@ function buildChatMessage(user: SocketData['user'], text: string, isSpectator = 
 }
 
 const nextRoundVotes = new Map<string, Set<string>>();
+const roundEndTimestamps = new Map<string, number>();
 const pendingSpectatorJoins = new Map<string, Map<string, { userId: string; nickname: string; avatarUrl?: string | null; role?: string; isBot?: boolean; socketId: string }>>();
 const AUTOPILOT_JUMP_IN_DELAY_MS = 2_000;
 const autopilotJumpInTimers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -60,6 +61,7 @@ interface NextRoundVoteState {
   votes: number;
   required: number;
   voters: string[];
+  roundEndAt: number;
 }
 
 export function addAutopilotVote(roomCode: string, playerId: string, session: GameSession, io: SocketIOServer): void {
@@ -170,7 +172,13 @@ function getNextRoundVoteState(roomCode: string, session: GameSession): NextRoun
     votes: voters.length,
     required: playerIds.size,
     voters,
+    roundEndAt: roundEndTimestamps.get(roomCode) ?? Date.now(),
   };
+}
+
+export function getRoundEndVoteState(roomCode: string, session: GameSession): NextRoundVoteState | null {
+  if (!session.isRoundEnd()) return null;
+  return getNextRoundVoteState(roomCode, session);
 }
 
 async function processPendingSpectatorJoins(
@@ -235,6 +243,7 @@ async function startNextRound(
   persister: GameStatePersister,
 ): Promise<void> {
   nextRoundVotes.delete(roomCode);
+  roundEndTimestamps.delete(roomCode);
   await processPendingSpectatorJoins(io, redis, roomCode, session);
   session.startNextRound();
   persister.markDirty(roomCode, session.getFullState());
@@ -274,6 +283,7 @@ async function emitTerminalStateIfNeeded(
 
   if (state.phase === 'round_end') {
     nextRoundVotes.delete(roomCode);
+    roundEndTimestamps.set(roomCode, Date.now());
 
     const connectedAutopilotIds = state.players.filter((p) => p.autopilot && p.connected).map((p) => p.id);
     if (connectedAutopilotIds.length > 0) {
@@ -637,17 +647,18 @@ export function registerGameEvents(
       return callback?.({ success: false, error: '玩家不在游戏中' });
     }
 
+    const targetPlayer = state.players.find((p) => p.id === targetId);
     session.removePlayer(targetId);
     await removePlayerFromRoom(redis, roomCode, targetId);
 
     const targetSockets = await io.in(roomCode).fetchSockets();
     for (const s of targetSockets) {
       if ((s.data as SocketData).user.userId === targetId) {
-        s.emit('game:kicked', { reason: '你已被房主移出游戏' });
-        s.leave(roomCode);
-        (s.data as SocketData).roomCode = null;
+        (s.data as SocketData).isSpectator = true;
+        s.emit('game:kicked', { reason: '你已被房主移至观战席', toSpectator: true });
       }
     }
+    if (targetPlayer) addSpectator(roomCode, targetPlayer.name);
 
     voters.delete(targetId);
     const voteState = getNextRoundVoteState(roomCode, session);
@@ -658,7 +669,50 @@ export function registerGameEvents(
       persister.flushNow(roomCode),
       emitGameUpdate(io, roomCode, session, redis),
     ]);
+    const spectators = getSpectatorNames(roomCode);
+    io.to(roomCode).emit('room:spectator_list', { spectators });
     io.to(roomCode).emit('room:updated', { players: state.players.filter((p) => p.id !== targetId).map((p) => ({ userId: p.id, name: p.name })) });
+
+    callback?.({ success: true });
+  });
+
+  socket.on('game:leave_to_spectate', async (callback) => {
+    const ctx = getSession(socket, sessions);
+    if (!ctx) return callback?.({ success: false, error: 'No active game' });
+    const { session, roomCode } = ctx;
+
+    if (!session.isRoundEnd()) {
+      return callback?.({ success: false, error: '只能在回合结束阶段切换观战' });
+    }
+
+    const state = session.getFullState();
+    const player = state.players.find((p) => p.id === data.user.userId);
+    if (!player) return callback?.({ success: false, error: '玩家不在游戏中' });
+
+    const room = await getRoom(redis, roomCode);
+    if (room?.ownerId === data.user.userId) {
+      return callback?.({ success: false, error: '房主不能离开对局' });
+    }
+
+    session.removePlayer(data.user.userId);
+    await removePlayerFromRoom(redis, roomCode, data.user.userId);
+
+    (socket.data as SocketData).isSpectator = true;
+    addSpectator(roomCode, player.name);
+
+    const voters = nextRoundVotes.get(roomCode) ?? new Set<string>();
+    voters.delete(data.user.userId);
+    const voteState = getNextRoundVoteState(roomCode, session);
+    io.to(roomCode).emit('game:next_round_vote', voteState);
+
+    persister.markDirty(roomCode, session.getFullState());
+    await Promise.all([
+      persister.flushNow(roomCode),
+      emitGameUpdate(io, roomCode, session, redis),
+    ]);
+    const spectators = getSpectatorNames(roomCode);
+    io.to(roomCode).emit('room:spectator_list', { spectators });
+    io.to(roomCode).emit('room:updated', { players: state.players.filter((p) => p.id !== data.user.userId).map((p) => ({ userId: p.id, name: p.name })) });
 
     callback?.({ success: true });
   });
@@ -675,6 +729,7 @@ export function registerGameEvents(
       return callback?.({ success: false, error: '只有房主可以发起再来一局' });
     }
     nextRoundVotes.delete(roomCode);
+    roundEndTimestamps.delete(roomCode);
     await processPendingSpectatorJoins(io, redis, roomCode, session);
     session.resetForRematch();
     sessions.set(roomCode, session);

--- a/packages/server/src/ws/socket-handler.ts
+++ b/packages/server/src/ws/socket-handler.ts
@@ -6,7 +6,7 @@ import { TurnTimer } from '../plugins/core/game/turn-timer.js';
 import { GameSession } from '../plugins/core/game/session.js';
 import { registerRoomEvents, emitGameUpdate, startTurnTimer, executeAutopilot, notifyAutopilotAction, resetPlayerTimeout } from './room-events.js';
 import { getAutopilotActionPlayerId, canPlayerAutopilotOnce } from './autopilot-action-player.js';
-import { registerGameEvents, addAutopilotVote, clearChatTimestamps } from './game-events.js';
+import { registerGameEvents, addAutopilotVote, clearChatTimestamps, getRoundEndVoteState } from './game-events.js';
 import { getRoom, getRoomPlayers, setRoomOwner } from '../plugins/core/room/store.js';
 import { loadGameState, GameStatePersister } from '../plugins/core/game/state-store.js';
 import { checkRateLimit, clearRateLimit } from './rate-limiter.js';
@@ -195,6 +195,8 @@ export function setupSocketHandlers(
         callback?.({ success: true, gameState: session.getPlayerView(userId), players, room });
         socket.emit('chat:history', session.getChatHistory());
         socket.emit('room:spectator_list', { spectators: getSpectatorNames(roomCode) });
+        const voteState = getRoundEndVoteState(roomCode, session);
+        if (voteState) socket.emit('game:next_round_vote', voteState);
         const state = session.getFullState();
         const connectedCount = state.players.filter(p => p.connected).length;
         if (connectedCount >= 2 && state.phase === 'playing') {

--- a/packages/shared/src/types/socket-events.ts
+++ b/packages/shared/src/types/socket-events.ts
@@ -27,10 +27,10 @@ export interface ServerToClientEvents {
   'game:update': (view: PlayerView) => void;
   'game:card_drawn': (data: { card: Card }) => void;
   'game:action_rejected': (data: { action?: string; reason: string }) => void;
-  'game:next_round_vote': (data: { votes: number; required: number; voters: string[] }) => void;
+  'game:next_round_vote': (data: { votes: number; required: number; voters: string[]; roundEndAt: number }) => void;
   'game:over': (data: { winnerId: string | null; scores: Record<string, number>; reason?: string }) => void;
   'game:round_end': (data: { winnerId: string | null; scores: Record<string, number> }) => void;
-  'game:kicked': (data: { reason: string }) => void;
+  'game:kicked': (data: { reason: string; toSpectator?: boolean }) => void;
   'auth:kicked': (data: { reason: string }) => void;
   'player:timeout': (data: { playerId: string }) => void;
   'player:disconnected': (data: { playerId: string }) => void;
@@ -85,5 +85,6 @@ export interface ClientToServerEvents {
   'throw:item': (payload: { targetId: string; item: string }, callback?: (res: SocketCallbackResult) => void) => void;
   'player:toggle-autopilot': (callback?: (res: SocketCallbackResult & { autopilot?: boolean }) => void) => void;
   'game:spectator_join': (callback?: (res: SocketCallbackResult & { queued?: boolean }) => void) => void;
+  'game:leave_to_spectate': (callback?: (res: SocketCallbackResult) => void) => void;
   'game:autopilot_once': (callback?: (res: SocketCallbackResult) => void) => void;
 }


### PR DESCRIPTION
## Summary
- 倒计时基于服务端 `roundEndAt` 时间戳，刷新页面不再重置 30 秒
- 重连时重发 vote state，保证状态同步
- 掉线玩家超时后非房主看到"已超时"，房主可踢任何未准备玩家（不限掉线）
- 被踢玩家转入观战席而非移出房间，可通过"下局加入"按钮重新排队
- 非房主新增"进入观战席"按钮，可主动退出对局转为观战
- 房主受保护，不能离开对局

## Test plan
- [ ] 回合结束后刷新页面，倒计时应从正确时间继续而非重置
- [ ] 掉线玩家 30 秒后，非房主看到"已超时"标识
- [ ] 房主 30 秒后看到所有未准备玩家的踢出按钮
- [ ] 踢出玩家后，该玩家进入观战席而非回到大厅
- [ ] 被踢玩家可通过 SpectatorBar "下局加入"按钮重新排队
- [ ] 非房主点击"进入观战席"后切换为观战模式
- [ ] 房主不显示"进入观战席"按钮

🤖 Generated with [Claude Code](https://claude.com/claude-code)