### PR TITLE
refactor: 移除字体选择与圆角切换，大厅增加音乐开关

### DIFF
--- a/packages/client/src/app/App.tsx
+++ b/packages/client/src/app/App.tsx
@@ -1,21 +1,10 @@
-import { useEffect } from 'react';
 import AppRouter from './router';
 import ToastContainer from '@/shared/components/Toast';
 import ChangelogModal from '@/shared/components/ChangelogModal';
 import NotificationPermissionDialog from '@/shared/components/NotificationPermissionDialog';
 import ServerUpdateDialog from '@/shared/components/ServerUpdateDialog';
-import { useSettingsStore, FONT_OPTIONS } from '@/shared/stores/settings-store';
 
 export default function App() {
-  const fontFamily = useSettingsStore((s) => s.fontFamily);
-  const uiTheme = useSettingsStore((s) => s.uiTheme);
-  useEffect(() => {
-    document.documentElement.style.setProperty('--font-game', FONT_OPTIONS[fontFamily].value);
-  }, [fontFamily]);
-
-  useEffect(() => {
-    document.documentElement.classList.toggle('theme-tech', uiTheme === 'tech');
-  }, [uiTheme]);
 
   return (
     <div className="flex min-h-svh flex-col font-game bg-background text-foreground">

--- a/packages/client/src/features/auth/pages/HomePage.tsx
+++ b/packages/client/src/features/auth/pages/HomePage.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useSearchParams, Link } from 'react-router-dom';
-import { LogIn, Spade, Type, Upload, X } from 'lucide-react';
+import { LogIn, Spade, Upload, X } from 'lucide-react';
 import { useAuthStore } from '../stores/auth-store';
-import { useSettingsStore, FONT_OPTIONS, type FontOption } from '@/shared/stores/settings-store';
+import { useSettingsStore } from '@/shared/stores/settings-store';
 import { loadCardPack, clearCardPack, isPackLoaded } from '@/shared/utils/card-images';
 import { apiGet } from '@/shared/api';
 import { Button } from '@/shared/components/ui/Button';
@@ -18,7 +18,7 @@ interface AuthConfig {
 
 export default function HomePage() {
   const { user, token, loading, loadUser, devLogin, passwordLogin } = useAuthStore();
-  const { fontFamily, setFontFamily, cardImagePack, setCardImagePack } = useSettingsStore();
+  const { cardImagePack, setCardImagePack } = useSettingsStore();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const [devUsername, setDevUsername] = useState('');
@@ -183,19 +183,6 @@ export default function HomePage() {
               />
             </label>
           )}
-        </div>
-        <div className="flex items-center gap-2">
-          <Type size={16} className="text-muted-foreground" />
-          <select
-            value={fontFamily}
-            onChange={(e) => setFontFamily(e.target.value as FontOption)}
-            className="bg-card text-foreground border border-white/20 rounded-lg px-2.5 py-1.5 text-sm cursor-pointer"
-            style={{ fontFamily: FONT_OPTIONS[fontFamily].value }}
-          >
-            {(Object.keys(FONT_OPTIONS) as FontOption[]).map((k) => (
-              <option key={k} value={k}>{FONT_OPTIONS[k].label}</option>
-            ))}
-          </select>
         </div>
       </div>
 

--- a/packages/client/src/features/lobby/pages/LobbyPage.tsx
+++ b/packages/client/src/features/lobby/pages/LobbyPage.tsx
@@ -1,10 +1,10 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Spade, LogOut, User, Hexagon, Circle, Upload, X, Type, Eye, Users, ClipboardPaste, Music } from 'lucide-react';
+import { Spade, LogOut, User, Upload, X, Eye, Users, ClipboardPaste, Music, Volume2, VolumeX } from 'lucide-react';
 import { useAuthStore } from '@/features/auth/stores/auth-store';
 import { getRoleColor } from '@/shared/lib/utils';
 import { useRoomStore } from '@/shared/stores/room-store';
-import { useSettingsStore, FONT_OPTIONS, type FontOption } from '@/shared/stores/settings-store';
+import { useSettingsStore } from '@/shared/stores/settings-store';
 import { loadCardPack, clearCardPack, isPackLoaded } from '@/shared/utils/card-images';
 import { getSocket, connectSocket } from '@/shared/socket';
 import { Button } from '@/shared/components/ui/Button';
@@ -23,7 +23,7 @@ export default function LobbyPage() {
   const user = useAuthStore((s) => s.user);
   const logout = useAuthStore((s) => s.logout);
   const setRoom = useRoomStore((s) => s.setRoom);
-  const { uiTheme, setUiTheme, fontFamily, setFontFamily, cardImagePack, setCardImagePack } = useSettingsStore();
+  const { bgmEnabled, toggleBgm, cardImagePack, setCardImagePack } = useSettingsStore();
   const navigate = useNavigate();
   const [joinCode, setJoinCode] = useState('');
   const [error, setError] = useState('');
@@ -202,6 +202,13 @@ export default function LobbyPage() {
       {/* Settings + version */}
       <div className="absolute bottom-6 right-6 flex items-center gap-3">
         <button
+          onClick={toggleBgm}
+          className="bg-card text-foreground border border-white/20 rounded-lg px-2.5 py-1.5 text-sm cursor-pointer flex items-center gap-1"
+          title={bgmEnabled ? '关闭背景音乐' : '开启背景音乐'}
+        >
+          {bgmEnabled ? <Volume2 size={14} /> : <VolumeX size={14} />}
+        </button>
+        <button
           onClick={() => setMusicHall(true)}
           className="bg-card text-foreground border border-white/20 rounded-lg px-2.5 py-1.5 text-sm cursor-pointer flex items-center gap-1"
           title="音乐厅"
@@ -236,35 +243,6 @@ export default function LobbyPage() {
             />
           </label>
         )}
-        <div className="flex items-center gap-2">
-          <Type size={16} className="text-muted-foreground" />
-          <select
-            value={fontFamily}
-            onChange={(e) => setFontFamily(e.target.value as FontOption)}
-            className="bg-card text-foreground border border-white/20 rounded-lg px-2.5 py-1.5 text-sm cursor-pointer"
-            style={{ fontFamily: FONT_OPTIONS[fontFamily].value }}
-          >
-            {(Object.keys(FONT_OPTIONS) as FontOption[]).map((k) => (
-              <option key={k} value={k}>{FONT_OPTIONS[k].label}</option>
-            ))}
-          </select>
-        </div>
-        <div className="flex items-center gap-1 rounded-btn bg-card/60 p-1">
-          <button
-            onClick={() => setUiTheme('rounded')}
-            className={`p-1.5 rounded-full transition-colors ${uiTheme === 'rounded' ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground'}`}
-            title="圆角风格"
-          >
-            <Circle size={14} />
-          </button>
-          <button
-            onClick={() => setUiTheme('tech')}
-            className={`p-1.5 rounded-sm transition-colors ${uiTheme === 'tech' ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground'}`}
-            title="科技风格"
-          >
-            <Hexagon size={14} />
-          </button>
-        </div>
       </div>
 
       <div className="absolute bottom-6 left-6 flex items-center gap-3">

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -179,14 +179,6 @@
   --border-glow: none;
 }
 
-.theme-tech {
-  --radius-btn: 4px;
-  --radius-input: 4px;
-  --radius-card-ui: 6px;
-  --radius-panel-ui: 8px;
-  --border-glow: 0 0 8px rgba(68, 136, 255, 0.3);
-}
-
 @layer base {
   * {
     @apply border-border;

--- a/packages/client/src/shared/stores/settings-store.ts
+++ b/packages/client/src/shared/stores/settings-store.ts
@@ -1,34 +1,20 @@
 import { create } from 'zustand';
 
-export type FontOption = 'default' | 'rounded' | 'serif' | 'mono';
-export type UiTheme = 'rounded' | 'tech';
-
-export const FONT_OPTIONS: Record<FontOption, { label: string; value: string }> = {
-  default: { label: '默认', value: "'Comic Sans MS', 'Chalkboard SE', 'Comic Neue', 'Microsoft YaHei', 'PingFang SC', cursive, sans-serif" },
-  rounded: { label: '圆体', value: "system-ui, -apple-system, 'Noto Sans SC', sans-serif" },
-  serif: { label: '衬线', value: "'Georgia', 'Noto Serif SC', 'Times New Roman', serif" },
-  mono: { label: '等宽', value: "'Fira Code', 'Cascadia Code', 'Consolas', monospace" },
-};
-
 interface SettingsState {
   soundVolume: number;
   soundEnabled: boolean;
   bgmEnabled: boolean;
   bgmVolume: number;
   colorBlindMode: boolean;
-  fontFamily: FontOption;
-  cardImagePack: boolean; // whether a card image pack is loaded
+  cardImagePack: boolean;
   autoPlay: boolean;
-  uiTheme: UiTheme;
   setSoundVolume: (v: number) => void;
   toggleSound: () => void;
   toggleBgm: () => void;
   setBgmVolume: (v: number) => void;
   toggleColorBlind: () => void;
-  setFontFamily: (f: FontOption) => void;
   setCardImagePack: (loaded: boolean) => void;
   toggleAutoPlay: () => void;
-  setUiTheme: (t: UiTheme) => void;
 }
 
 export const useSettingsStore = create<SettingsState>((set) => ({
@@ -37,10 +23,8 @@ export const useSettingsStore = create<SettingsState>((set) => ({
   bgmEnabled: localStorage.getItem('bgmEnabled') !== 'false',
   bgmVolume: parseFloat(localStorage.getItem('bgmVolume') ?? '0.3'),
   colorBlindMode: localStorage.getItem('colorBlindMode') === 'true',
-  fontFamily: (localStorage.getItem('fontFamily') as FontOption) || 'default',
   cardImagePack: localStorage.getItem('cardImagePack') === 'true',
   autoPlay: localStorage.getItem('autoPlay') === 'true',
-  uiTheme: (localStorage.getItem('uiTheme') as UiTheme) || 'rounded',
   setSoundVolume: (v) => {
     localStorage.setItem('soundVolume', String(v));
     set({ soundVolume: v });
@@ -64,12 +48,6 @@ export const useSettingsStore = create<SettingsState>((set) => ({
     localStorage.setItem('colorBlindMode', String(next));
     return { colorBlindMode: next };
   }),
-  setFontFamily: (f) => {
-    localStorage.setItem('fontFamily', f);
-    document.documentElement.style.setProperty('--font-game', FONT_OPTIONS[f].value);
-    document.documentElement.style.setProperty('--font-ui', FONT_OPTIONS[f].value);
-    set({ fontFamily: f });
-  },
   setCardImagePack: (loaded) => {
     localStorage.setItem('cardImagePack', String(loaded));
     set({ cardImagePack: loaded });
@@ -79,8 +57,4 @@ export const useSettingsStore = create<SettingsState>((set) => ({
     localStorage.setItem('autoPlay', String(next));
     return { autoPlay: next };
   }),
-  setUiTheme: (t) => {
-    localStorage.setItem('uiTheme', t);
-    set({ uiTheme: t });
-  },
 }));


### PR DESCRIPTION
## Summary
- 删除字体选择器（大厅 + 首页）和圆角/科技风格切换按钮及全部相关代码
- 精简 settings-store，移除 `FontOption`、`FONT_OPTIONS`、`UiTheme`、`.theme-tech` CSS
- 大厅右下角新增 BGM 开关按钮（音量图标一键切换）

## Test plan
- [ ] 大厅右下角无字体选择下拉框和圆角/直角切换按钮
- [ ] 大厅右下角有 BGM 开关按钮，点击可切换背景音乐
- [ ] 首页右下角无字体选择下拉框
- [ ] 全局字体和圆角样式保持默认值正常显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)