### PR TITLE
fix: 大厅音乐开关按钮补充文字标签

### DIFF
--- a/packages/client/src/features/lobby/pages/LobbyPage.tsx
+++ b/packages/client/src/features/lobby/pages/LobbyPage.tsx
@@ -206,7 +206,7 @@ export default function LobbyPage() {
           className="bg-card text-foreground border border-white/20 rounded-lg px-2.5 py-1.5 text-sm cursor-pointer flex items-center gap-1"
           title={bgmEnabled ? '关闭背景音乐' : '开启背景音乐'}
         >
-          {bgmEnabled ? <Volume2 size={14} /> : <VolumeX size={14} />}
+          {bgmEnabled ? <Volume2 size={14} /> : <VolumeX size={14} />} {bgmEnabled ? '音乐' : '静音'}
         </button>
         <button
           onClick={() => setMusicHall(true)}


### PR DESCRIPTION
## Summary
- 音乐开关按钮补充文字（音乐/静音），与其他按钮风格统一

🤖 Generated with [Claude Code](https://claude.com/claude-code)