### PR TITLE
feat: game over 返回房间 + 房间观战席 + 冷却修复

### DIFF
--- a/packages/client/src/features/game/components/ScoreBoard.tsx
+++ b/packages/client/src/features/game/components/ScoreBoard.tsx
@@ -12,6 +12,7 @@ import { getSocket } from '@/shared/socket';
 import { useToastStore } from '@/shared/stores/toast-store';
 
 const KICK_DELAY_S = 30;
+const START_COOLDOWN_S = 10;
 
 function KickCountdownRing({ remaining, total }: { remaining: number; total: number }) {
   const r = 7;
@@ -38,25 +39,31 @@ function KickCountdownRing({ remaining, total }: { remaining: number; total: num
 interface ScoreBoardProps {
   isSpectator?: boolean;
   onPlayAgain: () => void;
-  onRematch: () => void;
+  onBackToRoom: () => void;
   onBackToLobby: () => void;
   onKickPlayer: (targetId: string) => void;
   onLeaveToSpectate: () => void;
   onJoinedFromSpectator?: () => void;
 }
 
-export default function ScoreBoard({ isSpectator = false, onPlayAgain, onRematch, onBackToLobby, onKickPlayer, onLeaveToSpectate, onJoinedFromSpectator }: ScoreBoardProps) {
+export default function ScoreBoard({ isSpectator = false, onPlayAgain, onBackToRoom, onBackToLobby, onKickPlayer, onLeaveToSpectate, onJoinedFromSpectator }: ScoreBoardProps) {
   const players = useGameStore((s) => s.players);
   const winnerId = useGameStore((s) => s.winnerId);
   const phase = useGameStore((s) => s.phase);
   const vote = useGameStore((s) => s.nextRoundVote);
   const roundEndAt = vote?.roundEndAt ?? null;
+  const gameOverAt = useGameStore((s) => s.gameOverAt);
   const pendingJoinQueue = useSpectatorStore((s) => s.pendingJoinQueue);
   const [kickCountdown, setKickCountdown] = useState(() => {
     if (!roundEndAt) return KICK_DELAY_S;
     return Math.max(0, KICK_DELAY_S - Math.floor((Date.now() - roundEndAt) / 1000));
   });
   const [leaveCountdown, setLeaveCountdown] = useState(5);
+  const [startCooldown, setStartCooldown] = useState(() => {
+    const endAt = roundEndAt ?? gameOverAt;
+    if (endAt) return Math.max(0, START_COOLDOWN_S - Math.floor((Date.now() - endAt) / 1000));
+    return START_COOLDOWN_S;
+  });
   const [spectatorQueued, setSpectatorQueued] = useState(() => {
     const nickname = useAuthStore.getState().user?.nickname;
     return !!nickname && pendingJoinQueue.includes(nickname);
@@ -82,6 +89,19 @@ export default function ScoreBoard({ isSpectator = false, onPlayAgain, onRematch
     }, 1000);
     return () => clearInterval(interval);
   }, [phase]);
+
+  useEffect(() => {
+    const endAt = roundEndAt ?? gameOverAt;
+    const initial = endAt
+      ? Math.max(0, START_COOLDOWN_S - Math.floor((Date.now() - endAt) / 1000))
+      : START_COOLDOWN_S;
+    setStartCooldown(initial);
+    if (initial <= 0) return;
+    const interval = setInterval(() => {
+      setStartCooldown((c) => { if (c <= 1) { clearInterval(interval); return 0; } return c - 1; });
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [phase, roundEndAt, gameOverAt]);
 
   useEffect(() => {
     const nickname = useAuthStore.getState().user?.nickname;
@@ -125,20 +145,23 @@ export default function ScoreBoard({ isSpectator = false, onPlayAgain, onRematch
   const required = vote?.required ?? fallbackRequired;
   const allAgreed = votes >= required;
   const canKick = kickCountdown === 0;
-  const nextRoundButtonText = isHost
-    ? allAgreed
-      ? '开始下一轮'
-      : hasVoted
-        ? `等待同意 (${votes}/${required})`
-        : `同意继续 (${votes}/${required})`
-    : hasVoted
+  const cooldownActive = startCooldown > 0;
+  const nextRoundButtonText = cooldownActive
+    ? `${startCooldown}s`
+    : isHost
       ? allAgreed
-        ? '等待房主开始'
-        : `已同意 (${votes}/${required})`
-      : `同意继续 (${votes}/${required})`;
-  const isNextRoundDisabled = !isGameOver && (
+        ? '开始下一轮'
+        : hasVoted
+          ? `等待同意 (${votes}/${required})`
+          : `同意继续 (${votes}/${required})`
+      : hasVoted
+        ? allAgreed
+          ? '等待房主开始'
+          : `已同意 (${votes}/${required})`
+        : `同意继续 (${votes}/${required})`;
+  const isNextRoundDisabled = cooldownActive || (!isGameOver && (
     isHost ? hasVoted && !allAgreed : hasVoted
-  );
+  ));
 
   return (
     <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-modal">
@@ -216,8 +239,8 @@ export default function ScoreBoard({ isSpectator = false, onPlayAgain, onRematch
         ) : (
           <div className="flex gap-3 justify-center flex-wrap">
             {!isGameOver && <Button variant="primary" onClick={onPlayAgain} disabled={isNextRoundDisabled} sound="ready">{nextRoundButtonText}</Button>}
-            {isGameOver && isHost && <Button variant="primary" onClick={onRematch} sound="ready">再来一局</Button>}
-            {isGameOver && !isHost && <Button variant="primary" disabled>等待房主再来一局…</Button>}
+            {isGameOver && isHost && <Button variant="primary" onClick={onBackToRoom} disabled={cooldownActive} sound="ready">{cooldownActive ? `返回房间 (${startCooldown}s)` : '返回房间'}</Button>}
+            {isGameOver && !isHost && <Button variant="primary" disabled>{cooldownActive ? `${startCooldown}s` : '等待房主返回房间…'}</Button>}
             {!isHost && <Button variant="secondary" onClick={onLeaveToSpectate} sound="click"><Eye size={14} className="inline align-middle mr-1" />进入观战席</Button>}
             <Button variant="secondary" onClick={onBackToLobby} sound="click" disabled={leaveCountdown > 0}>{leaveCountdown > 0 ? `返回大厅 (${leaveCountdown}s)` : '返回大厅'}</Button>
           </div>

--- a/packages/client/src/features/game/hooks/useGameActions.ts
+++ b/packages/client/src/features/game/hooks/useGameActions.ts
@@ -58,10 +58,10 @@ export function useGameActions() {
     });
   }, []);
 
-  const rematch = useCallback(() => {
-    getSocket().emit('game:rematch', (res: { success?: boolean; error?: string }) => {
+  const backToRoom = useCallback(() => {
+    getSocket().emit('game:back_to_room', (res: { success?: boolean; error?: string }) => {
       if (res && !res.success) {
-        useToastStore.getState().addToast(res.error || '无法发起再来一局', 'error');
+        useToastStore.getState().addToast(res.error || '操作失败', 'error');
       }
     });
   }, []);
@@ -95,7 +95,7 @@ export function useGameActions() {
     pass,
     swapTarget,
     playAgain,
-    rematch,
+    backToRoom,
     kickPlayer,
     leaveToSpectate,
   };

--- a/packages/client/src/features/game/pages/GamePage.tsx
+++ b/packages/client/src/features/game/pages/GamePage.tsx
@@ -61,6 +61,16 @@ export default function GamePage() {
   const showScoreBoard = phase === 'round_end' || phase === 'game_over';
 
   const connectionStatus = useGameSocket(roomCode);
+
+  useEffect(() => {
+    const socket = getSocket();
+    const handleBackToRoom = () => {
+      navigate(`/room/${roomCode}`);
+    };
+    socket.on('game:back_to_room', handleBackToRoom);
+    return () => { socket.off('game:back_to_room', handleBackToRoom); };
+  }, [roomCode, navigate]);
+
   useGameLogTracker();
   const bgmSongName = useBgm('game');
   const [showStartRules, setShowStartRules] = useState(false);
@@ -104,7 +114,7 @@ export default function GamePage() {
     pass,
     swapTarget,
     playAgain,
-    rematch,
+    backToRoom,
     kickPlayer,
     leaveToSpectate,
   } = useGameActions();
@@ -250,7 +260,7 @@ export default function GamePage() {
         <ScoreBoard
           isSpectator={isSpectator}
           onPlayAgain={playAgain}
-          onRematch={rematch}
+          onBackToRoom={backToRoom}
           onBackToLobby={backToLobby}
           onKickPlayer={kickPlayer}
           onLeaveToSpectate={leaveToSpectate}

--- a/packages/client/src/features/game/pages/RoomPage.tsx
+++ b/packages/client/src/features/game/pages/RoomPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { Crown, Check, Copy } from 'lucide-react';
+import { Crown, Check, Copy, Eye } from 'lucide-react';
 import { cn, getRoleColor } from '@/shared/lib/utils';
 import { AiBadge } from '@/shared/components/ui/AiBadge';
 import { useAuthStore } from '@/features/auth/stores/auth-store';
@@ -82,7 +82,8 @@ export default function RoomPage() {
 
   const isOwner = room?.ownerId === user?.id;
   const myPlayer = players.find((p) => p.userId === user?.id);
-  const allReady = players.length >= 2 && players.every((p) => p.ready);
+  const activePlayers = players.filter((p) => !p.spectator);
+  const allReady = activePlayers.length >= 2 && activePlayers.every((p) => p.ready);
   const [houseRules, setHouseRules] = useState<HouseRules>(DEFAULT_HOUSE_RULES);
   const [menuTarget, setMenuTarget] = useState<{ player: RoomPlayer; position: { x: number; y: number } } | null>(null);
 
@@ -94,6 +95,15 @@ export default function RoomPage() {
 
   const toggleReady = () => {
     getSocket().emit('room:ready', !myPlayer?.ready, () => {});
+  };
+
+  const toggleSpectator = () => {
+    const newVal = !myPlayer?.spectator;
+    getSocket().emit('room:toggle_spectator', newVal, (res: { success?: boolean; error?: string }) => {
+      if (!res?.success && res?.error) {
+        useToastStore.getState().addToast(res.error, 'error');
+      }
+    });
   };
 
   const startGame = () => {
@@ -186,8 +196,8 @@ export default function RoomPage() {
                       {room?.ownerId === p.userId && <Crown size={16} className="shrink-0 text-primary" />}
                       <PlayerVoiceStatus playerId={p.userId} playerName={p.nickname} isSelf={isMe} className="shrink-0" />
                     </span>
-                    <span className={cn('text-xs font-medium', p.ready ? 'text-uno-green' : 'text-muted-foreground')}>
-                      {p.ready ? <><Check size={14} className="inline-block align-middle" /> 已准备</> : '未准备'}
+                    <span className={cn('text-xs font-medium', p.spectator ? 'text-blue-400' : p.ready ? 'text-uno-green' : 'text-muted-foreground')}>
+                      {p.spectator ? <><Eye size={14} className="inline-block align-middle" /> 观战</> : p.ready ? <><Check size={14} className="inline-block align-middle" /> 已准备</> : '未准备'}
                     </span>
                   </div>
                 );
@@ -295,9 +305,18 @@ export default function RoomPage() {
 
         {/* Action buttons */}
         <div className="flex gap-4">
-          <Button variant="game" onClick={toggleReady} sound="ready">
-            {myPlayer?.ready ? '取消准备' : '准备'}
-          </Button>
+          {myPlayer?.spectator ? (
+            <Button variant="game" onClick={toggleSpectator} sound="click">取消观战</Button>
+          ) : (
+            <Button variant="game" onClick={toggleReady} sound="ready">
+              {myPlayer?.ready ? '取消准备' : '准备'}
+            </Button>
+          )}
+          {!isOwner && !myPlayer?.spectator && (
+            <Button variant="secondary" onClick={toggleSpectator} sound="click">
+              <Eye size={14} className="inline align-middle mr-1" />观战
+            </Button>
+          )}
           {isOwner && (
             <Button variant="game" className={cn(!allReady && 'opacity-50')} onClick={startGame} disabled={!allReady} sound="ready">
               开始游戏

--- a/packages/client/src/features/game/stores/game-store.ts
+++ b/packages/client/src/features/game/stores/game-store.ts
@@ -35,6 +35,7 @@ interface GameState {
   isSpectator: boolean;
   deckHash: string | null;
   nextRoundVote: NextRoundVoteState | null;
+  gameOverAt: number | null;
   cheatDetected: boolean;
   setCheatDetected: (value: boolean) => void;
   setSpectator: (value: boolean) => void;
@@ -45,6 +46,7 @@ interface GameState {
   setInfoDrawerTab: (tab: InfoDrawerTab) => void;
   setGameState: (view: PlayerView) => void;
   setNextRoundVote: (vote: NextRoundVoteState | null) => void;
+  setGameOverAt: (t: number | null) => void;
   setDrawnCard: (card: Card | null) => void;
   setTurnEndTime: (t: number | null) => void;
   clearGame: () => void;
@@ -73,6 +75,7 @@ export const useGameStore = create<GameState>((set) => ({
   isSpectator: false,
   deckHash: null,
   nextRoundVote: null,
+  gameOverAt: null,
   cheatDetected: false,
   setCheatDetected: (value) => set({ cheatDetected: value }),
   setSpectator: (value) => set({ isSpectator: value }),
@@ -123,10 +126,12 @@ export const useGameStore = create<GameState>((set) => ({
         lastDrawnCard: hasDrawnThisTurn ? state.lastDrawnCard : null,
         deckHash: view.deckHash ?? state.deckHash,
         nextRoundVote: phase === 'round_end' ? state.nextRoundVote : null,
+        gameOverAt: phase === 'game_over' ? state.gameOverAt : null,
         ...spectatorChange,
       };
     }),
   setNextRoundVote: (vote) => set({ nextRoundVote: vote }),
+  setGameOverAt: (t) => set({ gameOverAt: t }),
   setDrawnCard: (card) => set({ lastDrawnCard: card, hasDrawnThisTurn: true }),
   setTurnEndTime: (t) => set({ turnEndTime: t }),
   clearGame: () =>
@@ -153,6 +158,7 @@ export const useGameStore = create<GameState>((set) => ({
       isSpectator: false,
       deckHash: null,
       nextRoundVote: null,
+      gameOverAt: null,
       cheatDetected: false,
       infoDrawerOpen: false,
       infoDrawerTab: 'rules' as InfoDrawerTab,

--- a/packages/client/src/shared/socket.ts
+++ b/packages/client/src/shared/socket.ts
@@ -105,6 +105,20 @@ export function getSocket(): TypedSocket {
       useGameStore.getState().setNextRoundVote(vote.votes > 0 ? vote : null);
     });
 
+    socket.on('game:over', (data: { gameOverAt?: number }) => {
+      if (data.gameOverAt) {
+        useGameStore.getState().setGameOverAt(data.gameOverAt);
+      }
+    });
+
+    socket.on('game:back_to_room', (data: { players?: unknown[]; room?: unknown }) => {
+      const roomCode = useRoomStore.getState().roomCode;
+      if (data.players && data.room && roomCode) {
+        useRoomStore.getState().setRoom(roomCode, data.players as any, data.room as any);
+      }
+      useGameStore.getState().clearGame();
+    });
+
     socket.on('game:card_drawn', (data) => {
       useGameStore.getState().setDrawnCard(data.card);
     });

--- a/packages/client/src/shared/stores/room-store.ts
+++ b/packages/client/src/shared/stores/room-store.ts
@@ -6,6 +6,7 @@ export interface RoomPlayer {
   nickname: string;
   avatarUrl?: string | null;
   ready: boolean;
+  spectator?: boolean;
   role?: string;
   isBot: boolean;
 }

--- a/packages/server/src/plugins/core/room/manager.ts
+++ b/packages/server/src/plugins/core/room/manager.ts
@@ -4,6 +4,7 @@ import { MAX_PLAYERS, ROOM_CODE_LENGTH, ROOM_CODE_CHARS, DEFAULT_HOUSE_RULES } f
 import {
   createRoom, getRoom, addPlayerToRoom, removePlayerFromRoom,
   getRoomPlayers, setPlayerReady, setRoomOwner, deleteRoom,
+  setPlayerSpectator, resetAllPlayersReady,
 } from './store.js';
 
 function generateRoomCode(): string {
@@ -59,7 +60,16 @@ export class RoomManager {
 
   async areAllReady(roomCode: string): Promise<boolean> {
     const players = await getRoomPlayers(this.redis, roomCode);
-    if (players.length < 2) return false;
-    return players.every((p) => p.ready);
+    const activePlayers = players.filter((p) => !p.spectator);
+    if (activePlayers.length < 2) return false;
+    return activePlayers.every((p) => p.ready);
+  }
+
+  async setSpectator(roomCode: string, userId: string, spectator: boolean): Promise<void> {
+    await setPlayerSpectator(this.redis, roomCode, userId, spectator);
+  }
+
+  async resetReady(roomCode: string): Promise<void> {
+    await resetAllPlayersReady(this.redis, roomCode);
   }
 }

--- a/packages/server/src/plugins/core/room/store.ts
+++ b/packages/server/src/plugins/core/room/store.ts
@@ -14,6 +14,7 @@ export interface RoomPlayer {
   nickname: string;
   avatarUrl?: string | null;
   ready: boolean;
+  spectator: boolean;
   role?: string;
   isBot: boolean;
 }
@@ -93,7 +94,7 @@ export async function addPlayerToRoom(kv: KvStore, roomCode: string, player: { u
   await withRoomPlayerLock(roomCode, async () => {
     const existing = await getRoomPlayers(kv, roomCode);
     if (existing.some(p => p.userId === player.userId)) return;
-    existing.push({ userId: player.userId, nickname: player.nickname, avatarUrl: player.avatarUrl ?? null, ready: false, role: player.role ?? 'normal', isBot: player.isBot ?? false });
+    existing.push({ userId: player.userId, nickname: player.nickname, avatarUrl: player.avatarUrl ?? null, ready: false, spectator: false, role: player.role ?? 'normal', isBot: player.isBot ?? false });
     await setRoomPlayers(kv, roomCode, existing);
   });
 }
@@ -110,6 +111,22 @@ export async function setPlayerReady(kv: KvStore, roomCode: string, userId: stri
   await withRoomPlayerLock(roomCode, async () => {
     const players = await getRoomPlayers(kv, roomCode);
     const updated = players.map((p) => p.userId === userId ? { ...p, ready } : p);
+    await setRoomPlayers(kv, roomCode, updated);
+  });
+}
+
+export async function setPlayerSpectator(kv: KvStore, roomCode: string, userId: string, spectator: boolean): Promise<void> {
+  await withRoomPlayerLock(roomCode, async () => {
+    const players = await getRoomPlayers(kv, roomCode);
+    const updated = players.map((p) => p.userId === userId ? { ...p, spectator, ready: spectator ? false : p.ready } : p);
+    await setRoomPlayers(kv, roomCode, updated);
+  });
+}
+
+export async function resetAllPlayersReady(kv: KvStore, roomCode: string): Promise<void> {
+  await withRoomPlayerLock(roomCode, async () => {
+    const players = await getRoomPlayers(kv, roomCode);
+    const updated = players.map((p) => ({ ...p, ready: false }));
     await setRoomPlayers(kv, roomCode, updated);
   });
 }

--- a/packages/server/src/ws/game-events.ts
+++ b/packages/server/src/ws/game-events.ts
@@ -6,9 +6,9 @@ import { GameSession } from '../plugins/core/game/session.js';
 import type { GameStatePersister } from '../plugins/core/game/state-store.js';
 import { emitGameUpdate, setAutopilotActionHandler, startTurnTimer, resetPlayerTimeout, clearRoomTimeouts } from './room-events.js';
 import type { TurnTimer } from '../plugins/core/game/turn-timer.js';
-import { getRoom, setRoomStatus, touchRoomActivity, removePlayerFromRoom, addPlayerToRoom } from '../plugins/core/room/store.js';
+import { getRoom, getRoomPlayers, setRoomStatus, touchRoomActivity, removePlayerFromRoom, addPlayerToRoom, resetAllPlayersReady } from '../plugins/core/room/store.js';
 import { MAX_PLAYERS } from '@uno-online/shared';
-import { removeSpectator, addSpectator, getSpectatorNames } from '../plugins/core/spectate/ws.js';
+import { removeSpectator, addSpectator, getSpectatorNames, clearRoomSpectators } from '../plugins/core/spectate/ws.js';
 import type { SocketData } from './types.js';
 
 function getSession(socket: Socket, sessions: Map<string, GameSession>): { session: GameSession; roomCode: string } | null {
@@ -53,6 +53,7 @@ function buildChatMessage(user: SocketData['user'], text: string, isSpectator = 
 
 const nextRoundVotes = new Map<string, Set<string>>();
 const roundEndTimestamps = new Map<string, number>();
+const NEXT_ROUND_COOLDOWN_MS = 10_000;
 const pendingSpectatorJoins = new Map<string, Map<string, { userId: string; nickname: string; avatarUrl?: string | null; role?: string; isBot?: boolean; socketId: string }>>();
 const AUTOPILOT_JUMP_IN_DELAY_MS = 2_000;
 const autopilotJumpInTimers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -300,6 +301,7 @@ async function emitTerminalStateIfNeeded(
   io.to(roomCode).emit(state.phase === 'game_over' ? 'game:over' : 'game:round_end', {
     winnerId: state.winnerId,
     scores: Object.fromEntries(state.players.map((p) => [p.id, p.score])),
+    ...(state.phase === 'game_over' ? { gameOverAt: Date.now() } : {}),
   });
 
   if (state.phase === 'round_end') {
@@ -319,6 +321,7 @@ async function emitTerminalStateIfNeeded(
   }
 
   if (state.phase === 'game_over') {
+    roundEndTimestamps.set(roomCode, Date.now());
     await Promise.all([
       setRoomStatus(redis, roomCode, 'finished'),
       touchRoomActivity(redis, roomCode),
@@ -590,6 +593,10 @@ export function registerGameEvents(
     io.to(roomCode).emit('game:next_round_vote', voteState);
 
     if (isOwner && hadAlreadyVoted && voteState.votes >= voteState.required) {
+      const endedAt = roundEndTimestamps.get(roomCode);
+      if (endedAt && Date.now() - endedAt < NEXT_ROUND_COOLDOWN_MS) {
+        return callback?.({ success: true, started: false, vote: voteState });
+      }
       await startNextRound(io, redis, roomCode, session, turnTimer, sessions, persister);
       return callback?.({ success: true, started: true, vote: voteState });
     }
@@ -738,7 +745,7 @@ export function registerGameEvents(
     callback?.({ success: true });
   });
 
-  socket.on('game:rematch', async (callback) => {
+  socket.on('game:back_to_room', async (callback) => {
     const ctx = getSession(socket, sessions);
     if (!ctx) return callback?.({ success: false, error: 'No active game' });
     const { session, roomCode } = ctx;
@@ -747,33 +754,47 @@ export function registerGameEvents(
     }
     const room = await getRoom(redis, roomCode);
     if (room?.ownerId !== data.user.userId) {
-      return callback?.({ success: false, error: '只有房主可以发起再来一局' });
+      return callback?.({ success: false, error: '只有房主可以返回房间' });
     }
+    const endedAt = roundEndTimestamps.get(roomCode);
+    if (endedAt && Date.now() - endedAt < NEXT_ROUND_COOLDOWN_MS) {
+      const remaining = Math.ceil((NEXT_ROUND_COOLDOWN_MS - (Date.now() - endedAt)) / 1000);
+      return callback?.({ success: false, error: `请等待 ${remaining} 秒后再操作` });
+    }
+
     nextRoundVotes.delete(roomCode);
     roundEndTimestamps.delete(roomCode);
-    await processPendingSpectatorJoins(io, redis, roomCode, session);
-    session.resetForRematch();
-    sessions.set(roomCode, session);
+    sessions.delete(roomCode);
     persister.cleanup(roomCode);
-    persister.markDirty(roomCode, session.getFullState());
-    await Promise.all([
-      setRoomStatus(redis, roomCode, 'playing'),
-      touchRoomActivity(redis, roomCode),
-      persister.flushNow(roomCode),
-    ]);
-    io.to(roomCode).emit('chat:cleared');
-    const room2 = await getRoom(redis, roomCode);
-    const spectatorMode2 = (room2?.settings?.spectatorMode as 'full' | 'hidden') ?? 'hidden';
+    turnTimer.stop(roomCode);
+    clearRoomTimeouts(roomCode);
+
+    await setRoomStatus(redis, roomCode, 'waiting');
+    await resetAllPlayersReady(redis, roomCode);
+
+    const currentRoomPlayers = await getRoomPlayers(redis, roomCode);
+    const currentIds = new Set(currentRoomPlayers.map((p) => p.userId));
     const sockets = await io.in(roomCode).fetchSockets();
     for (const s of sockets) {
       const sData = s.data as SocketData;
-      if (sData.isSpectator) {
-        s.emit('game:state', session.getSpectatorView(spectatorMode2));
-      } else {
-        s.emit('game:state', session.getPlayerView(sData.user.userId));
+      if (sData.isSpectator && !currentIds.has(sData.user.userId)) {
+        await addPlayerToRoom(redis, roomCode, {
+          userId: sData.user.userId,
+          nickname: sData.user.nickname,
+          avatarUrl: sData.user.avatarUrl,
+          role: sData.user.role,
+          isBot: sData.user.isBot,
+        });
       }
+      sData.isSpectator = false;
     }
-    startTurnTimer(io, redis, roomCode, session, turnTimer, sessions, persister);
+
+    clearRoomSpectators(roomCode);
+    await touchRoomActivity(redis, roomCode);
+    const players = await getRoomPlayers(redis, roomCode);
+    const updatedRoom = await getRoom(redis, roomCode);
+    io.to(roomCode).emit('game:back_to_room', { players, room: updatedRoom });
+    io.to(roomCode).emit('chat:cleared');
     callback?.({ success: true });
   });
 }

--- a/packages/server/src/ws/room-events.ts
+++ b/packages/server/src/ws/room-events.ts
@@ -13,6 +13,7 @@ import type { SocketData } from './types.js';
 import { dissolveRoom } from './room-lifecycle.js';
 import { removeVoicePresence, setForceMuted } from './voice-presence.js';
 import { getAutopilotActionPlayerId } from './autopilot-action-player.js';
+import { addSpectator } from '../plugins/core/spectate/ws.js';
 
 const AUTOPILOT_MIN_ACTION_INTERVAL_MS = 500;
 const AUTO_AUTOPILOT_THRESHOLD = 2;
@@ -162,6 +163,7 @@ export function registerRoomEvents(
           io.to(roomCode).emit('game:over', {
             winnerId: lastPlayer.id,
             scores: Object.fromEntries(st.players.map((p) => [p.id, p.score])),
+            gameOverAt: Date.now(),
           });
         } else {
           turnTimer.stop(roomCode);
@@ -193,6 +195,21 @@ export function registerRoomEvents(
     const roomCode = data.roomCode;
     if (!roomCode) return callback?.({ success: false });
     await roomManager.setReady(roomCode, data.user.userId, ready);
+    await touchRoomActivity(redis, roomCode);
+    const players = await getRoomPlayers(redis, roomCode);
+    io.to(roomCode).emit('room:updated', { players });
+    callback?.({ success: true });
+  });
+
+  socket.on('room:toggle_spectator', async (spectator: boolean, callback) => {
+    const roomCode = data.roomCode;
+    if (!roomCode) return callback?.({ success: false });
+    const room = await getRoom(redis, roomCode);
+    if (!room || room.status !== 'waiting') return callback?.({ success: false });
+    if (room.ownerId === data.user.userId) {
+      return callback?.({ success: false, error: '房主不能观战' });
+    }
+    await roomManager.setSpectator(roomCode, data.user.userId, spectator);
     await touchRoomActivity(redis, roomCode);
     const players = await getRoomPlayers(redis, roomCode);
     io.to(roomCode).emit('room:updated', { players });
@@ -314,7 +331,10 @@ export function registerRoomEvents(
       seen.add(p.userId);
       return true;
     });
-    if (players.length < MIN_PLAYERS) {
+    const activePlayers = players.filter((p) => !p.spectator);
+    const roomSpectatorPlayers = players.filter((p) => p.spectator);
+
+    if (activePlayers.length < MIN_PLAYERS) {
       return callback?.({ success: false, error: 'Not enough players' });
     }
     const allReady = await roomManager.areAllReady(roomCode);
@@ -324,17 +344,25 @@ export function registerRoomEvents(
     await setRoomStatus(redis, roomCode, 'playing');
     await touchRoomActivity(redis, roomCode);
     const session = GameSession.create(
-      players.map((p) => ({ id: p.userId, name: p.nickname, avatarUrl: p.avatarUrl ?? null, role: p.role as import('@uno-online/shared').UserRole | undefined, isBot: p.isBot })),
+      activePlayers.map((p) => ({ id: p.userId, name: p.nickname, avatarUrl: p.avatarUrl ?? null, role: p.role as import('@uno-online/shared').UserRole | undefined, isBot: p.isBot })),
       { turnTimeLimit: room.settings?.turnTimeLimit ?? 30, targetScore: room.settings?.targetScore ?? 1000, houseRules: room.settings?.houseRules ?? DEFAULT_HOUSE_RULES, allowSpectators: room.settings?.allowSpectators ?? true, spectatorMode: room.settings?.spectatorMode ?? 'hidden' } as RoomSettings,
     );
     sessions.set(roomCode, session);
     persister.markDirty(roomCode, session.getFullState());
     await persister.flushNow(roomCode);
 
+    const spectatorMode = (room.settings?.spectatorMode as 'full' | 'hidden') ?? 'hidden';
     const sockets = await io.in(roomCode).fetchSockets();
     for (const s of sockets) {
-      const userId = (s.data as SocketData).user.userId;
-      s.emit('game:state', session.getPlayerView(userId));
+      const sData = s.data as SocketData;
+      const sUserId = sData.user.userId;
+      if (roomSpectatorPlayers.some((p) => p.userId === sUserId)) {
+        sData.isSpectator = true;
+        addSpectator(roomCode, sData.user.nickname);
+        s.emit('game:state', session.getSpectatorView(spectatorMode));
+      } else {
+        s.emit('game:state', session.getPlayerView(sUserId));
+      }
     }
 
     startTurnTimer(io, redis, roomCode, session, turnTimer, sessions, persister);
@@ -359,6 +387,7 @@ export function registerRoomEvents(
             winnerId: winner.id,
             reason: 'blitz_timeout',
             scores: Object.fromEntries(s.getFullState().players.map(p => [p.id, p.score])),
+            gameOverAt: Date.now(),
           });
           turnTimer.stop(roomCode);
         }

--- a/packages/shared/src/types/socket-events.ts
+++ b/packages/shared/src/types/socket-events.ts
@@ -28,7 +28,8 @@ export interface ServerToClientEvents {
   'game:card_drawn': (data: { card: Card }) => void;
   'game:action_rejected': (data: { action?: string; reason: string }) => void;
   'game:next_round_vote': (data: { votes: number; required: number; voters: string[]; roundEndAt: number }) => void;
-  'game:over': (data: { winnerId: string | null; scores: Record<string, number>; reason?: string }) => void;
+  'game:over': (data: { winnerId: string | null; scores: Record<string, number>; reason?: string; gameOverAt?: number }) => void;
+  'game:back_to_room': (data: { players: Record<string, unknown>[]; room: Record<string, unknown> }) => void;
   'game:round_end': (data: { winnerId: string | null; scores: Record<string, number> }) => void;
   'game:kicked': (data: { reason: string; toSpectator?: boolean }) => void;
   'auth:kicked': (data: { reason: string }) => void;
@@ -59,6 +60,7 @@ export interface ClientToServerEvents {
   'room:rejoin': (roomCode: string, callback: (res: SocketCallbackResult & Record<string, unknown>) => void) => void;
   'room:leave': (callback?: (res: SocketCallbackResult) => void) => void;
   'room:ready': (ready: boolean, callback?: (res: SocketCallbackResult) => void) => void;
+  'room:toggle_spectator': (spectator: boolean, callback?: (res: SocketCallbackResult) => void) => void;
   'room:update_settings': (settings: Partial<RoomSettings>, callback?: (res: SocketCallbackResult & { room?: Record<string, unknown> }) => void) => void;
   'room:dissolve': (callback?: (res: SocketCallbackResult) => void) => void;
   'room:transfer_owner': (payload: { targetId: string }, callback?: (res: SocketCallbackResult) => void) => void;
@@ -77,7 +79,7 @@ export interface ClientToServerEvents {
   'game:choose_swap_target': (payload: { targetId: string }, callback?: (res: SocketCallbackResult) => void) => void;
   'game:next_round': (callback?: (res: SocketCallbackResult & { started?: boolean; vote?: { votes: number; required: number; voters: string[] } }) => void) => void;
   'game:kick_player': (payload: { targetId?: string }, callback?: (res: SocketCallbackResult) => void) => void;
-  'game:rematch': (callback?: (res: SocketCallbackResult) => void) => void;
+  'game:back_to_room': (callback?: (res: SocketCallbackResult) => void) => void;
   'chat:message': (data: { text: string }) => void;
   'voice:channel:get': (callback: (res: SocketCallbackResult & { voiceChannelId?: number | null }) => void) => void;
   'voice:presence:get': (callback: (presence: Record<string, unknown>) => void) => void;


### PR DESCRIPTION
## Summary
- **game_over 冷却修复**: `game:over` 事件携带 `gameOverAt` 时间戳，重连后正确计算剩余冷却
- **game_over → 返回房间**: 替换 `game:rematch` 为 `game:back_to_room`，房主点击后所有人回到房间等待页，方便调整设置后再开
- **房间观战席**: 非房主玩家可选择观战模式，观战者不参与准备判定，开始游戏时自动成为游戏观战者

## Test plan
- [ ] 游戏结束后刷新页面，验证冷却倒计时不会重置为 10s
- [ ] 游戏结束后房主点击"返回房间"，验证所有玩家跳转到房间页且 ready 状态重置
- [ ] 房间页非房主点击"观战"按钮，验证状态显示蓝色"观战"标签
- [ ] 观战者不影响"开始游戏"的准备判定（至少 2 名非观战玩家全部准备）
- [ ] 开始游戏后，房间观战者自动进入观战视角
- [ ] 房主无法点击观战按钮

🤖 Generated with [Claude Code](https://claude.com/claude-code)