### PR TITLE
feat: 房主可观战、主动解散用作弊动画、退出改为转让

### DIFF
--- a/packages/client/src/app/router.tsx
+++ b/packages/client/src/app/router.tsx
@@ -5,6 +5,7 @@ import { authRoutes, authProtectedRoutes } from '@/features/auth/routes';
 import { gameProtectedRoutes } from '@/features/game/routes';
 import { lobbyProtectedRoutes } from '@/features/lobby/routes';
 import { profileProtectedRoutes } from '@/features/profile/routes';
+import CheatOverlayMount from '@/features/game/components/CheatOverlayMount';
 const allPublicRoutes = [...authRoutes];
 const allProtectedRoutes = [
   ...authProtectedRoutes,
@@ -34,6 +35,7 @@ export default function AppRouter() {
           </Route>
         </Routes>
       </Suspense>
+      <CheatOverlayMount />
     </BrowserRouter>
   );
 }

--- a/packages/client/src/features/game/components/CheatOverlayMount.tsx
+++ b/packages/client/src/features/game/components/CheatOverlayMount.tsx
@@ -1,0 +1,14 @@
+import { useGameStore } from '../stores/game-store';
+import CheatOverlay from './CheatOverlay';
+
+/**
+ * Top-level mount point for `CheatOverlay`. Lives inside the router so any
+ * page (RoomPage waiting lobby, GamePage in-game) can surface the glitch
+ * overlay when triggered — either by genuine cheat detection or by the host
+ * dissolving the room (`game:cheat_detected` emit covers both).
+ */
+export default function CheatOverlayMount() {
+  const cheatDetected = useGameStore((s) => s.cheatDetected);
+  if (!cheatDetected) return null;
+  return <CheatOverlay />;
+}

--- a/packages/client/src/features/game/components/ScoreBoard.tsx
+++ b/packages/client/src/features/game/components/ScoreBoard.tsx
@@ -241,7 +241,7 @@ export default function ScoreBoard({ isSpectator = false, onPlayAgain, onBackToR
             {!isGameOver && <Button variant="primary" onClick={onPlayAgain} disabled={isNextRoundDisabled} sound="ready">{nextRoundButtonText}</Button>}
             {isGameOver && isHost && <Button variant="primary" onClick={onBackToRoom} disabled={cooldownActive} sound="ready">{cooldownActive ? `返回房间 (${startCooldown}s)` : '返回房间'}</Button>}
             {isGameOver && !isHost && <Button variant="primary" disabled>{cooldownActive ? `${startCooldown}s` : '等待房主返回房间…'}</Button>}
-            {!isHost && <Button variant="secondary" onClick={onLeaveToSpectate} sound="click"><Eye size={14} className="inline align-middle mr-1" />进入观战席</Button>}
+            <Button variant="secondary" onClick={onLeaveToSpectate} sound="click"><Eye size={14} className="inline align-middle mr-1" />进入观战席</Button>
             <Button variant="secondary" onClick={onBackToLobby} sound="click" disabled={leaveCountdown > 0}>{leaveCountdown > 0 ? `返回大厅 (${leaveCountdown}s)` : '返回大厅'}</Button>
           </div>
         )}

--- a/packages/client/src/features/game/components/TopBar.tsx
+++ b/packages/client/src/features/game/components/TopBar.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Eye, Volume2, VolumeX, Music, Spade, DoorOpen, LogOut, Bot, HelpCircle, Keyboard } from 'lucide-react';
+import { Eye, Volume2, VolumeX, Music, Spade, DoorOpen, LogOut, Bot, HelpCircle, Keyboard, Trash2 } from 'lucide-react';
 import type { Card, Color } from '@uno-online/shared';
 import TurnTimer from './TurnTimer';
 import { useSettingsStore } from '@/shared/stores/settings-store';
@@ -100,9 +100,14 @@ export default function TopBar({ roomCode, onOpenHotkeys }: TopBarProps) {
   };
 
   const handleLeave = () => {
-    const msg = isHost ? '你是房主，离开将解散房间，确定吗？' : '确定要退出对局吗？';
+    const msg = isHost ? '你是房主，离开后房主权将转让给其他玩家，确定吗？' : '确定要退出对局吗？';
     if (!window.confirm(msg)) return;
     leaveRoom();
+  };
+
+  const handleDissolve = () => {
+    if (!window.confirm('确定要解散房间吗？所有玩家将被踢出。')) return;
+    getSocket().emit('room:dissolve', () => {});
   };
 
   return (
@@ -173,10 +178,19 @@ export default function TopBar({ roomCode, onOpenHotkeys }: TopBarProps) {
         <button
           onClick={handleLeave}
           className="bg-transparent border-none text-sm cursor-pointer text-destructive hover:text-destructive/80 transition-colors"
-          title={isHost ? '离开并解散房间' : '退出对局'}
+          title={isHost ? '离开并转让房主' : '退出对局'}
         >
           {isHost ? <DoorOpen size={16} /> : <LogOut size={16} />}
         </button>
+        {isHost && (
+          <button
+            onClick={handleDissolve}
+            className="bg-transparent border-none text-sm cursor-pointer text-destructive hover:text-destructive/80 transition-colors"
+            title="解散房间"
+          >
+            <Trash2 size={16} />
+          </button>
+        )}
       </div>
     </div>
   );

--- a/packages/client/src/features/game/pages/GamePage.tsx
+++ b/packages/client/src/features/game/pages/GamePage.tsx
@@ -32,7 +32,6 @@ import PlayerListPanel from '../components/PlayerListPanel';
 import DanmakuLayer from '../components/DanmakuLayer';
 import SpectatorActions from '../components/SpectatorActions';
 import AntiCheatToast from '../components/AntiCheatToast';
-import CheatOverlay from '../components/CheatOverlay';
 import { useSpectatorStore } from '../stores/spectator-store';
 import { useAuthStore } from '@/features/auth/stores/auth-store';
 import GameStartRulesModal from '../components/GameStartRulesModal';
@@ -49,7 +48,6 @@ export default function GamePage() {
   const openInfoDrawer = useGameStore((s) => s.openInfoDrawer);
   const backToLobby = useLeaveRoom();
   const clearSpectators = useSpectatorStore((s) => s.clearSpectators);
-  const cheatDetected = useGameStore((s) => s.cheatDetected);
 
   const isSpectator = useGameStore((s) => s.isSpectator);
   const setSpectator = useGameStore((s) => s.setSpectator);
@@ -255,7 +253,6 @@ export default function GamePage() {
           onJoinedFromSpectator={() => { setSpectator(false); clearSpectators(); }}
         />
       )}
-      {cheatDetected && <CheatOverlay />}
       <BgmToast song={bgmSongName} />
       <HotkeySettingsModal open={showHotkeys} onClose={() => setShowHotkeys(false)} />
     </div>

--- a/packages/client/src/features/game/pages/RoomPage.tsx
+++ b/packages/client/src/features/game/pages/RoomPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { Crown, Check, Copy, Eye } from 'lucide-react';
+import { Crown, Check, Copy, Eye, Trash2 } from 'lucide-react';
 import { cn, getRoleColor } from '@/shared/lib/utils';
 import { AiBadge } from '@/shared/components/ui/AiBadge';
 import { useAuthStore } from '@/features/auth/stores/auth-store';
@@ -118,8 +118,14 @@ export default function RoomPage() {
   };
 
   const leaveRoom = () => {
-    if (!window.confirm('确定要离开房间吗？')) return;
+    const msg = isOwner ? '你是房主，离开后房主权将转让给其他玩家，确定吗？' : '确定要离开房间吗？';
+    if (!window.confirm(msg)) return;
     leaveRoomHook();
+  };
+
+  const dissolveRoom = () => {
+    if (!window.confirm('确定要解散房间吗？所有玩家将被踢出。')) return;
+    getSocket().emit('room:dissolve', () => {});
   };
 
   /* House-rules helpers */
@@ -308,7 +314,7 @@ export default function RoomPage() {
               {myPlayer?.ready ? '取消准备' : '准备'}
             </Button>
           )}
-          {!isOwner && !myPlayer?.spectator && (
+          {!myPlayer?.spectator && (
             <Button variant="secondary" onClick={toggleSpectator} sound="click">
               <Eye size={14} className="inline align-middle mr-1" />观战
             </Button>
@@ -319,6 +325,11 @@ export default function RoomPage() {
             </Button>
           )}
           <Button variant="danger" onClick={leaveRoom} sound="danger">离开房间</Button>
+          {isOwner && (
+            <Button variant="danger" onClick={dissolveRoom} sound="danger">
+              <Trash2 size={14} className="inline align-middle mr-1" />解散房间
+            </Button>
+          )}
         </div>
 
         {menuTarget && (

--- a/packages/server/src/ws/game-events.ts
+++ b/packages/server/src/ws/game-events.ts
@@ -584,12 +584,13 @@ export function registerGameEvents(
     }
 
     const playerIds = new Set(session.getFullState().players.map((p) => p.id));
-    if (!playerIds.has(data.user.userId)) {
-      return callback?.({ success: false, error: 'Player not in game' });
-    }
-
     const room = await getRoom(redis, roomCode);
     const isOwner = room?.ownerId === data.user.userId;
+    // Players can always vote. The owner can also vote/trigger the next round
+    // even while sitting on the spectator bench (not in session.players).
+    if (!playerIds.has(data.user.userId) && !isOwner) {
+      return callback?.({ success: false, error: 'Player not in game' });
+    }
     const votes = nextRoundVotes.get(roomCode) ?? new Set<string>();
     const hadAlreadyVoted = votes.has(data.user.userId);
     votes.add(data.user.userId);
@@ -722,11 +723,6 @@ export function registerGameEvents(
     const state = session.getFullState();
     const player = state.players.find((p) => p.id === data.user.userId);
     if (!player) return callback?.({ success: false, error: '玩家不在游戏中' });
-
-    const room = await getRoom(redis, roomCode);
-    if (room?.ownerId === data.user.userId) {
-      return callback?.({ success: false, error: '房主不能离开对局' });
-    }
 
     session.removePlayer(data.user.userId);
     await removePlayerFromRoom(redis, roomCode, data.user.userId);

--- a/packages/server/src/ws/room-events.ts
+++ b/packages/server/src/ws/room-events.ts
@@ -145,20 +145,44 @@ export function registerRoomEvents(
       socket.to(roomCode).emit('room:spectator_left', {
         nickname: data.user.nickname,
       });
+
+      // If the owner is leaving while on the spectator bench (e.g. after
+      // game:leave_to_spectate), transfer ownership before clearing socket
+      // state — otherwise the room is left with an offline owner.
+      const room = await getRoom(redis, roomCode);
+      if (room?.ownerId === data.user.userId) {
+        const players = await getRoomPlayers(redis, roomCode);
+        const nextOwner = players[0];
+        if (nextOwner) {
+          await setRoomOwner(redis, roomCode, nextOwner.userId);
+          const updatedRoom = await getRoom(redis, roomCode);
+          io.to(roomCode).emit('room:updated', { players, room: updatedRoom });
+        } else {
+          // No player left to inherit — fully dissolve the room.
+          await leaveRoomSocket(redis, socket, roomCode);
+          await dissolveRoom(io, redis, roomCode, sessions, turnTimer, persister, 'empty', voiceChannels);
+          return callback?.({ success: true, dissolved: true });
+        }
+      }
+
       await leaveRoomSocket(redis, socket, roomCode);
       return callback?.({ success: true });
     }
     const room = await getRoom(redis, roomCode);
-    if (room?.ownerId === data.user.userId) {
-      await dissolveRoom(io, redis, roomCode, sessions, turnTimer, persister, 'host_closed', voiceChannels);
-      return callback?.({ success: true, dissolved: true });
-    }
+    const wasOwner = room?.ownerId === data.user.userId;
     const { deleted } = await roomManager.leaveRoom(roomCode, data.user.userId);
     removeVoicePresence(io, roomCode, data.user.userId);
     await leaveRoomSocket(redis, socket, roomCode);
 
+    // Room is now empty — do full cleanup (notify any external spectators,
+    // tear down session/timers/voice/chat).
+    if (deleted) {
+      await dissolveRoom(io, redis, roomCode, sessions, turnTimer, persister, 'empty', voiceChannels);
+      return callback?.({ success: true, dissolved: true });
+    }
+
     const session = sessions.get(roomCode);
-    if (session && !deleted) {
+    if (session) {
       const willEndGame = session.getPlayerCount() - 1 < MIN_PLAYERS;
 
       if (willEndGame) {
@@ -187,14 +211,11 @@ export function registerRoomEvents(
       await emitGameUpdate(io, roomCode, session, redis);
     }
 
-    if (!deleted) {
-      const players = await getRoomPlayers(redis, roomCode);
-      io.to(roomCode).emit('room:updated', { players, room });
-    } else {
-      sessions.delete(roomCode);
-      turnTimer.stop(roomCode);
-      await voiceChannels?.clearRoomChannelMapping(roomCode);
-    }
+    // If the leaver was the owner, manager.leaveRoom has just transferred
+    // ownership to players[0]; the cached `room` still has the stale ownerId.
+    const updatedRoom = wasOwner ? await getRoom(redis, roomCode) : room;
+    const players = await getRoomPlayers(redis, roomCode);
+    io.to(roomCode).emit('room:updated', { players, room: updatedRoom });
     callback?.({ success: true });
   });
 
@@ -213,9 +234,6 @@ export function registerRoomEvents(
     if (!roomCode) return callback?.({ success: false });
     const room = await getRoom(redis, roomCode);
     if (!room || room.status !== 'waiting') return callback?.({ success: false });
-    if (room.ownerId === data.user.userId) {
-      return callback?.({ success: false, error: '房主不能观战' });
-    }
     await roomManager.setSpectator(roomCode, data.user.userId, spectator);
     await touchRoomActivity(redis, roomCode);
     const players = await getRoomPlayers(redis, roomCode);

--- a/packages/server/src/ws/room-lifecycle.ts
+++ b/packages/server/src/ws/room-lifecycle.ts
@@ -29,7 +29,16 @@ export async function dissolveRoom(
   sessions.delete(roomCode);
   io.to(roomCode).emit('chat:cleared');
   clearVoicePresence(io, roomCode);
-  io.to(roomCode).emit('room:dissolved', { reason });
+
+  // host_closed = the owner explicitly chose to dissolve. Surface that with
+  // the glitch overlay (reused from cheat detection) instead of the standard
+  // "room dissolved" toast/navigate path, so it feels deliberate and dramatic.
+  // Other reasons (idle_timeout, empty) keep the quieter notification.
+  if (reason === 'host_closed') {
+    io.to(roomCode).emit('game:cheat_detected');
+  } else {
+    io.to(roomCode).emit('room:dissolved', { reason });
+  }
 
   const sockets = await io.in(roomCode).fetchSockets();
   await Promise.all(sockets.map((s) => leaveRoomSocket(kv, s, roomCode)));


### PR DESCRIPTION
## 背景

用户反馈："我刚创建的房间，然后在房间内没法加入观战"。排查发现 PR #99 引入了 \`房主不能观战\` 的硬性限制（\`room:toggle_spectator\` 与 \`game:leave_to_spectate\` 两处拒绝），并且房主\"退出房间\"会直接 \`dissolveRoom\` 把所有人踢回大厅。

## 改动

### 放开房主观战限制

- \`room:toggle_spectator\`: 删 \"房主不能观战\" 拒绝
- \`game:leave_to_spectate\`: 删 \"房主不能离开对局\" 拒绝
- \`game:next_round\`: 房主即使在观战席（不在 \`session.players\`）也能投票/触发下一回合
- 客户端：\`RoomPage\` 与 \`ScoreBoard\` 放开 \`!isOwner\` / \`!isHost\` 限制，房主也能看到观战按钮

### \"退出\"改为转让，\"解散\"独立成按钮

- TopBar 与 RoomPage 各新增一个独立 \"解散房间\" 按钮（Trash2 图标，只对房主可见）
- \"退出\" 按钮提示文案 / 图标改为转让语义
- 服务端 \`room:leave\` 房主分支：从 \`dissolveRoom\` 改为走 \`roomManager.leaveRoom\`，触发所有权转让；只在 \`deleted=true\`（房间真的空了）时走 \`dissolveRoom\` 完整清理；\`wasOwner\` 时重读 \`room\` 拿新 \`ownerId\` 用于 \`room:updated\` 广播
- 服务端 \`room:leave\` 观战分支：补 \"如果离开者是观战席房主则转让所有权\"——否则游戏中房主 \`leave_to_spectate\` 后退出会留下孤儿房间（\`ownerId\` 指向已离开的人）；若已无 player 可继承，\`dissolveRoom\` 收尾

### \"解散房间\"复用 CheatOverlay 动画

- 服务端 \`dissolveRoom\`：\`reason==='host_closed'\` 时改发 \`game:cheat_detected\` 代替 \`room:dissolved\`，让客户端走玻璃碎裂动画；其他 reason（\`idle_timeout\` / \`empty\`）仍发 \`room:dissolved\` 走 toast + navigate
- 客户端：\`CheatOverlayMount\` 提到顶层路由，等待大厅 (RoomPage) 与游戏中 (GamePage) 都能播放动画
- CheatOverlay 文案保持 \"检测到作弊者\"——按需求字面照搬

## 边角覆盖

| 场景 | \`data.isSpectator\` | 在 player 列表 | room:leave 走哪 | 行为 |
|---|---|---|---|---|
| 房主创建、自己一人 → leave | false | true | player 分支 | manager.leaveRoom → players=0 → dissolveRoom |
| 房主有其他玩家 → leave | false | true | player 分支 | manager.leaveRoom 转让 + emit room:updated |
| 房主等待大厅切观战席 → leave | false | true (spectator=true) | player 分支 | 同上 |
| 房主游戏中切观战席 → leave | true | false (removed) | spectator 分支 | 新逻辑：转让 ownerId |
| 纯外部观战者 → leave | true | false | spectator 分支 | wasOwner=false → 跳过转让 |

## 验证

- \`pnpm --filter shared build\` ✓
- \`pnpm --filter shared test\` ✓ 240/240
- \`pnpm --filter server exec tsc --noEmit\` ✓
- \`pnpm --filter client exec tsc --noEmit\` ✓
- \`pnpm --filter client build\` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)