### PR TITLE
fix: 玩家与观战席分列、MAX_PLAYERS 不再算观战席

### DIFF
--- a/packages/client/src/features/game/pages/RoomPage.tsx
+++ b/packages/client/src/features/game/pages/RoomPage.tsx
@@ -12,7 +12,7 @@ import PlayerVoiceStatus from '@/shared/voice/PlayerVoiceStatus';
 import { useToastStore } from '@/shared/stores/toast-store';
 import PlayerActionMenu from '../components/PlayerActionMenu';
 import { useLeaveRoom } from '../hooks/useLeaveRoom';
-import { DEFAULT_HOUSE_RULES, HOUSE_RULES_PRESETS, HOUSE_RULE_DEFINITIONS } from '@uno-online/shared';
+import { DEFAULT_HOUSE_RULES, HOUSE_RULES_PRESETS, HOUSE_RULE_DEFINITIONS, MAX_PLAYERS } from '@uno-online/shared';
 import type { HouseRules, HouseRuleDefinition } from '@uno-online/shared';
 import { Button } from '@/shared/components/ui/Button';
 import { useBgm } from '@/shared/sound/useBgm';
@@ -84,6 +84,7 @@ export default function RoomPage() {
   const isOwner = room?.ownerId === user?.id;
   const myPlayer = players.find((p) => p.userId === user?.id);
   const activePlayers = players.filter((p) => !p.spectator);
+  const spectatorPlayers = players.filter((p) => p.spectator);
   const allReady = activePlayers.length >= 2 && activePlayers.every((p) => p.ready);
   const [houseRules, setHouseRules] = useState<HouseRules>(DEFAULT_HOUSE_RULES);
   const [menuTarget, setMenuTarget] = useState<{ player: RoomPlayer; position: { x: number; y: number } } | null>(null);
@@ -171,40 +172,80 @@ export default function RoomPage() {
 
         {/* Two-column layout */}
         <div className="flex flex-col md:flex-row gap-6 w-full max-w-[900px] flex-1 min-h-0">
-          {/* Left: Player list */}
-          <div className="flex-1 glass-panel p-6">
-            <h3 className="mb-4 text-sm text-muted-foreground font-game">
-              玩家 ({players.length}/10)
-            </h3>
-            <div className="flex flex-col gap-1">
-              {players.map((p) => {
-                const roleColor = getRoleColor(p.role);
-                const isMe = p.userId === user?.id;
-                return (
-                  <div
-                    key={p.userId}
-                    className={cn(
-                      'flex items-center justify-between py-3 px-3 rounded-lg border-b border-white/5 last:border-b-0',
-                      !isMe && 'cursor-pointer hover:bg-white/5'
-                    )}
-                    onClick={(e) => {
-                      if (isMe) return;
-                      setMenuTarget({ player: p, position: { x: e.clientX, y: e.clientY } });
-                    }}
-                  >
-                    <span className="flex min-w-0 flex-1 items-center gap-2" style={roleColor ? { color: roleColor } : undefined}>
-                      <span className="truncate text-base font-medium">{p.nickname}</span>
-                      {p.isBot && <AiBadge />}
-                      {room?.ownerId === p.userId && <Crown size={16} className="shrink-0 text-primary" />}
-                      <PlayerVoiceStatus playerId={p.userId} playerName={p.nickname} isSelf={isMe} className="shrink-0" />
-                    </span>
-                    <span className={cn('text-xs font-medium', p.spectator ? 'text-blue-400' : p.ready ? 'text-uno-green' : 'text-muted-foreground')}>
-                      {p.spectator ? <><Eye size={14} className="inline-block align-middle" /> 观战</> : p.ready ? <><Check size={14} className="inline-block align-middle" /> 已准备</> : '未准备'}
-                    </span>
-                  </div>
-                );
-              })}
-            </div>
+          {/* Left: Player + spectator lists */}
+          <div className="flex-1 glass-panel p-6 flex flex-col gap-4 min-h-0">
+            <section>
+              <h3 className="mb-4 text-sm text-muted-foreground font-game">
+                玩家 ({activePlayers.length}/{MAX_PLAYERS})
+              </h3>
+              <div className="flex flex-col gap-1">
+                {activePlayers.map((p) => {
+                  const roleColor = getRoleColor(p.role);
+                  const isMe = p.userId === user?.id;
+                  return (
+                    <div
+                      key={p.userId}
+                      className={cn(
+                        'flex items-center justify-between py-3 px-3 rounded-lg border-b border-white/5 last:border-b-0',
+                        !isMe && 'cursor-pointer hover:bg-white/5'
+                      )}
+                      onClick={(e) => {
+                        if (isMe) return;
+                        setMenuTarget({ player: p, position: { x: e.clientX, y: e.clientY } });
+                      }}
+                    >
+                      <span className="flex min-w-0 flex-1 items-center gap-2" style={roleColor ? { color: roleColor } : undefined}>
+                        <span className="truncate text-base font-medium">{p.nickname}</span>
+                        {p.isBot && <AiBadge />}
+                        {room?.ownerId === p.userId && <Crown size={16} className="shrink-0 text-primary" />}
+                        <PlayerVoiceStatus playerId={p.userId} playerName={p.nickname} isSelf={isMe} className="shrink-0" />
+                      </span>
+                      <span className={cn('text-xs font-medium', p.ready ? 'text-uno-green' : 'text-muted-foreground')}>
+                        {p.ready ? <><Check size={14} className="inline-block align-middle" /> 已准备</> : '未准备'}
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+            </section>
+
+            {spectatorPlayers.length > 0 && (
+              <section>
+                <h3 className="mb-4 text-sm text-muted-foreground font-game flex items-center gap-1.5">
+                  <Eye size={14} className="text-blue-400" />
+                  观战 ({spectatorPlayers.length})
+                </h3>
+                <div className="flex flex-col gap-1">
+                  {spectatorPlayers.map((p) => {
+                    const roleColor = getRoleColor(p.role);
+                    const isMe = p.userId === user?.id;
+                    return (
+                      <div
+                        key={p.userId}
+                        className={cn(
+                          'flex items-center justify-between py-3 px-3 rounded-lg border-b border-white/5 last:border-b-0 opacity-70',
+                          !isMe && 'cursor-pointer hover:bg-white/5 hover:opacity-100'
+                        )}
+                        onClick={(e) => {
+                          if (isMe) return;
+                          setMenuTarget({ player: p, position: { x: e.clientX, y: e.clientY } });
+                        }}
+                      >
+                        <span className="flex min-w-0 flex-1 items-center gap-2" style={roleColor ? { color: roleColor } : undefined}>
+                          <span className="truncate text-base font-medium">{p.nickname}</span>
+                          {p.isBot && <AiBadge />}
+                          {room?.ownerId === p.userId && <Crown size={16} className="shrink-0 text-primary" />}
+                          <PlayerVoiceStatus playerId={p.userId} playerName={p.nickname} isSelf={isMe} className="shrink-0" />
+                        </span>
+                        <span className="text-xs font-medium text-blue-400">
+                          <Eye size={14} className="inline-block align-middle" /> 观战
+                        </span>
+                      </div>
+                    );
+                  })}
+                </div>
+              </section>
+            )}
           </div>
 
           {/* Right: Settings (spectator + house rules in one panel) */}

--- a/packages/server/src/plugins/core/room/manager.ts
+++ b/packages/server/src/plugins/core/room/manager.ts
@@ -36,7 +36,11 @@ export class RoomManager {
     if (room.status !== 'waiting') throw new Error('Game already in progress');
     const players = await getRoomPlayers(this.redis, roomCode);
     if (players.some((p) => p.userId === userId)) throw new Error('Already in room');
-    if (players.length >= MAX_PLAYERS) throw new Error('Room is full');
+    // MAX_PLAYERS gates the active roster, not the spectator bench — joining
+    // as a player should still succeed when the only thing filling the room
+    // is in-room spectators.
+    const activePlayers = players.filter((p) => !p.spectator);
+    if (activePlayers.length >= MAX_PLAYERS) throw new Error('Room is full');
     await addPlayerToRoom(this.redis, roomCode, { userId, nickname, avatarUrl, role, isBot });
   }
 

--- a/packages/server/src/ws/room-events.ts
+++ b/packages/server/src/ws/room-events.ts
@@ -1,7 +1,7 @@
 import type { Socket, Server as SocketIOServer } from 'socket.io';
 import type { KvStore } from '../kv/types.js';
 import type { GameAction, GameState, RoomSettings } from '@uno-online/shared';
-import { MIN_PLAYERS, DEFAULT_HOUSE_RULES, chooseAutopilotAction, chooseJumpInAction } from '@uno-online/shared';
+import { MIN_PLAYERS, MAX_PLAYERS, DEFAULT_HOUSE_RULES, chooseAutopilotAction, chooseJumpInAction } from '@uno-online/shared';
 import { RoomManager } from '../plugins/core/room/manager.js';
 import { getRoom, getRoomPlayers, setRoomSettings, setRoomStatus, setRoomOwner, touchRoomActivity, ensureNotInRoom } from '../plugins/core/room/store.js';
 import { joinRoomSocket, leaveRoomSocket } from './socket-room.js';
@@ -234,6 +234,19 @@ export function registerRoomEvents(
     if (!roomCode) return callback?.({ success: false });
     const room = await getRoom(redis, roomCode);
     if (!room || room.status !== 'waiting') return callback?.({ success: false });
+
+    // When switching back from the spectator bench to a player seat, make
+    // sure we don't blow past the active-roster cap (e.g. 10 active + 1
+    // bench, where toggling back would yield 11 active).
+    if (!spectator) {
+      const players = await getRoomPlayers(redis, roomCode);
+      const me = players.find((p) => p.userId === data.user.userId);
+      const activeCount = players.filter((p) => !p.spectator).length;
+      if (me?.spectator && activeCount >= MAX_PLAYERS) {
+        return callback?.({ success: false, error: '玩家席位已满' });
+      }
+    }
+
     await roomManager.setSpectator(roomCode, data.user.userId, spectator);
     await touchRoomActivity(redis, roomCode);
     const players = await getRoomPlayers(redis, roomCode);


### PR DESCRIPTION
## 背景

用户反馈："为啥观战玩家会占用玩家席位数量，而不是单独的观战席，而且观战玩家应该不和玩家在一个列表里，观战应该单独在一个列表里"

排查：PR #99 引入"房间内观战席"后，spectator 与 active player 共享同一份 \`players\` 列表，但许多地方仍把它当作"参与游戏的玩家总数"处理：

- RoomPage 显示 \`玩家 (players.length/10)\` —— 把观战席算进玩家计数
- \`roomManager.joinRoom\` 检查 \`players.length >= MAX_PLAYERS\` —— 8 player + 2 spectator 时第 9 个 active join 会被拒
- \`room:toggle_spectator\` 反向（spectator 切回 player）没有上限检查 —— 可在边角突破 MAX_PLAYERS

## 服务端

- \`roomManager.joinRoom\`: 改为 \`activePlayers.length >= MAX_PLAYERS\`（filter \`!spectator\`）
- \`room:toggle_spectator\`: spectator 切回 player 时检查 active 上限，超限返回 \`玩家席位已满\` 错误

## 客户端

- RoomPage 左栏拆成两个 \`<section>\`：
  - 上半 **玩家 (N/MAX_PLAYERS)** 只列 \`activePlayers\`
  - 下半 **观战 (N)** 只列 \`spectatorPlayers\`，仅在有观战时显示
- 观战席条目轻度降低不透明度（\`opacity-70\`），hover 恢复——视觉与玩家区分

## 验证

- shared build / test ✓ 240/240
- server tsc ✓ / client tsc ✓ / client build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)