### PR TITLE
feat: 替换浏览器原生 confirm/alert 为页面内 modal

### DIFF
--- a/packages/client/src/app/App.tsx
+++ b/packages/client/src/app/App.tsx
@@ -4,6 +4,7 @@ import ChangelogModal from '@/shared/components/ChangelogModal';
 import NotificationPermissionDialog from '@/shared/components/NotificationPermissionDialog';
 import ServerUpdateDialog from '@/shared/components/ServerUpdateDialog';
 import ProfileModal from '@/shared/components/ProfileModal';
+import ConfirmDialog from '@/shared/components/ConfirmDialog';
 
 export default function App() {
 
@@ -15,6 +16,7 @@ export default function App() {
       <NotificationPermissionDialog />
       <ServerUpdateDialog />
       <ProfileModal />
+      <ConfirmDialog />
     </div>
   );
 }

--- a/packages/client/src/features/game/components/PlayerActionMenu.tsx
+++ b/packages/client/src/features/game/components/PlayerActionMenu.tsx
@@ -4,6 +4,7 @@ import { cn } from '@/shared/lib/utils';
 import { getSocket } from '@/shared/socket';
 import { useGatewayStore } from '@/shared/voice/gateway-store';
 import { useToastStore } from '@/shared/stores/toast-store';
+import { showConfirm } from '@/shared/stores/confirm-store';
 import type { RoomPlayer } from '@/shared/stores/room-store';
 
 interface PlayerActionMenuProps {
@@ -43,16 +44,25 @@ export default function PlayerActionMenu({ target, isOwner, roomStatus, position
     return () => document.removeEventListener('mousedown', handleClick);
   }, [onClose]);
 
-  const transferOwner = () => {
-    if (!window.confirm(`确定要将房主移交给 ${target.nickname} 吗？`)) return;
+  const transferOwner = async () => {
+    if (!(await showConfirm({
+      title: '移交房主',
+      message: `确定要将房主移交给 ${target.nickname} 吗？`,
+      confirmText: '移交',
+    }))) return;
     getSocket().emit('room:transfer_owner', { targetId: target.userId }, (res) => {
       if (!res.success) useToastStore.getState().addToast(res.error ?? '移交失败', 'error');
     });
     onClose();
   };
 
-  const kickPlayer = () => {
-    if (!window.confirm(`确定要将 ${target.nickname} 踢出房间吗？`)) return;
+  const kickPlayer = async () => {
+    if (!(await showConfirm({
+      title: '踢出玩家',
+      message: `确定要将 ${target.nickname} 踢出房间吗？`,
+      confirmText: '踢出',
+      variant: 'danger',
+    }))) return;
     getSocket().emit('room:kick', { targetId: target.userId }, (res) => {
       if (!res.success) useToastStore.getState().addToast(res.error ?? '踢出失败', 'error');
     });

--- a/packages/client/src/features/game/components/TopBar.tsx
+++ b/packages/client/src/features/game/components/TopBar.tsx
@@ -8,6 +8,7 @@ import { useGameStore } from '../stores/game-store';
 import { useEffectiveUserId } from '../hooks/useEffectiveUserId';
 import { useLeaveRoom } from '../hooks/useLeaveRoom';
 import { getSocket } from '@/shared/socket';
+import { showConfirm } from '@/shared/stores/confirm-store';
 import { cn } from '@/shared/lib/utils';
 import { BUILD_VERSION } from '@/shared/build-info';
 
@@ -99,14 +100,29 @@ export default function TopBar({ roomCode, onOpenHotkeys }: TopBarProps) {
     setTimeout(() => setAutopilotCooldown(false), AUTOPILOT_COOLDOWN_MS);
   };
 
-  const handleLeave = () => {
-    const msg = isHost ? '你是房主，离开后房主权将转让给其他玩家，确定吗？' : '确定要退出对局吗？';
-    if (!window.confirm(msg)) return;
+  const handleLeave = async () => {
+    const ok = isHost
+      ? await showConfirm({
+          title: '退出对局',
+          message: '你是房主，离开后房主权将转让给其他玩家。',
+          confirmText: '退出',
+        })
+      : await showConfirm({
+          title: '退出对局',
+          message: '确定要退出对局吗？',
+          confirmText: '退出',
+        });
+    if (!ok) return;
     leaveRoom();
   };
 
-  const handleDissolve = () => {
-    if (!window.confirm('确定要解散房间吗？所有玩家将被踢出。')) return;
+  const handleDissolve = async () => {
+    if (!(await showConfirm({
+      title: '解散房间',
+      message: '确定要解散房间吗？所有玩家将被踢出。',
+      confirmText: '解散',
+      variant: 'danger',
+    }))) return;
     getSocket().emit('room:dissolve', () => {});
   };
 

--- a/packages/client/src/features/game/pages/RoomPage.tsx
+++ b/packages/client/src/features/game/pages/RoomPage.tsx
@@ -10,6 +10,7 @@ import { getSocket, connectSocket, refreshVoicePresence } from '@/shared/socket'
 import VoicePanel from '@/shared/voice/VoicePanel';
 import PlayerVoiceStatus from '@/shared/voice/PlayerVoiceStatus';
 import { useToastStore } from '@/shared/stores/toast-store';
+import { showConfirm } from '@/shared/stores/confirm-store';
 import PlayerActionMenu from '../components/PlayerActionMenu';
 import { useLeaveRoom } from '../hooks/useLeaveRoom';
 import { DEFAULT_HOUSE_RULES, HOUSE_RULES_PRESETS, HOUSE_RULE_DEFINITIONS, MAX_PLAYERS } from '@uno-online/shared';
@@ -110,22 +111,40 @@ export default function RoomPage() {
 
   const startGame = () => {
     getSocket().emit('game:start', (res: any) => {
-      if (!res.success) alert(res.error);
-      if (res.success && res.gameState) {
+      if (!res.success) {
+        useToastStore.getState().addToast(res.error ?? '开始失败', 'error');
+        return;
+      }
+      if (res.gameState) {
         setGameState(res.gameState);
         navigate(`/game/${roomCode}`);
       }
     });
   };
 
-  const leaveRoom = () => {
-    const msg = isOwner ? '你是房主，离开后房主权将转让给其他玩家，确定吗？' : '确定要离开房间吗？';
-    if (!window.confirm(msg)) return;
+  const leaveRoom = async () => {
+    const ok = isOwner
+      ? await showConfirm({
+          title: '离开房间',
+          message: '你是房主，离开后房主权将转让给其他玩家。',
+          confirmText: '离开',
+        })
+      : await showConfirm({
+          title: '离开房间',
+          message: '确定要离开房间吗？',
+          confirmText: '离开',
+        });
+    if (!ok) return;
     leaveRoomHook();
   };
 
-  const dissolveRoom = () => {
-    if (!window.confirm('确定要解散房间吗？所有玩家将被踢出。')) return;
+  const dissolveRoom = async () => {
+    if (!(await showConfirm({
+      title: '解散房间',
+      message: '确定要解散房间吗？所有玩家将被踢出。',
+      confirmText: '解散',
+      variant: 'danger',
+    }))) return;
     getSocket().emit('room:dissolve', () => {});
   };
 

--- a/packages/client/src/shared/components/ConfirmDialog.tsx
+++ b/packages/client/src/shared/components/ConfirmDialog.tsx
@@ -1,0 +1,93 @@
+import { useEffect } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { AlertTriangle } from 'lucide-react';
+import { useConfirmStore } from '../stores/confirm-store';
+import { cn } from '../lib/utils';
+
+/**
+ * Top-level mount for in-app confirm/alert dialogs. Reads from `confirm-store`
+ * and renders at most one dialog at a time. Keyboard: Enter confirms, Esc
+ * cancels (alerts treat both as confirm).
+ */
+export default function ConfirmDialog() {
+  const current = useConfirmStore((s) => s.current);
+  const resolve = useConfirmStore((s) => s.resolve);
+
+  useEffect(() => {
+    if (!current) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        resolve(current.type === 'alert');
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        resolve(true);
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [current, resolve]);
+
+  return (
+    <AnimatePresence>
+      {current && (
+        <div className="fixed inset-0 z-modal flex items-center justify-center px-4">
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.18 }}
+            className="absolute inset-0 glass-modal-backdrop"
+            onClick={() => resolve(current.type === 'alert')}
+          />
+
+          <motion.div
+            key={current.id}
+            initial={{ opacity: 0, scale: 0.92, y: 8 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.92, y: 8 }}
+            transition={{ duration: 0.18 }}
+            className="relative w-full max-w-[420px] glass-panel"
+          >
+            <div className="flex items-start gap-3 px-6 pt-5">
+              {current.variant === 'danger' && (
+                <AlertTriangle size={20} className="mt-0.5 shrink-0 text-destructive" />
+              )}
+              <div className="flex-1">
+                <h3 className="text-base font-bold text-foreground">{current.title}</h3>
+                {current.message && (
+                  <p className="mt-2 text-sm text-foreground/80 whitespace-pre-line">
+                    {current.message}
+                  </p>
+                )}
+              </div>
+            </div>
+
+            <div className="mt-5 flex items-center justify-end gap-2 border-t border-white/5 px-5 py-3.5">
+              {current.type === 'confirm' && (
+                <button
+                  onClick={() => resolve(false)}
+                  className="rounded-lg bg-white/[0.06] px-4 py-2 text-sm font-semibold text-foreground/80 transition-colors hover:bg-white/[0.10]"
+                >
+                  {current.cancelText}
+                </button>
+              )}
+              <button
+                onClick={() => resolve(true)}
+                autoFocus
+                className={cn(
+                  'rounded-lg px-4 py-2 text-sm font-bold transition-colors',
+                  current.variant === 'danger'
+                    ? 'bg-destructive/90 text-white hover:bg-destructive'
+                    : 'bg-gradient-to-br from-[#fbbf24] to-[#f59e0b] text-[#1a1a2e] hover:opacity-90',
+                )}
+              >
+                {current.confirmText}
+              </button>
+            </div>
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/packages/client/src/shared/components/ProfileModal.tsx
+++ b/packages/client/src/shared/components/ProfileModal.tsx
@@ -8,6 +8,7 @@ import AvatarUpload from '@/features/auth/components/AvatarUpload';
 import { Button } from '@/shared/components/ui/Button';
 import { useNotificationStore, type NotificationEventType } from '@/shared/stores/notification-store';
 import { useProfileModalStore } from '@/shared/stores/profile-modal-store';
+import { showConfirm } from '@/shared/stores/confirm-store';
 
 interface ProfileData {
   user: { id: string; username: string; nickname: string; avatarUrl: string | null; githubId?: string | null; role?: string };
@@ -112,7 +113,12 @@ export default function ProfileModal() {
   };
 
   const handleDeleteKey = async (id: string) => {
-    if (!confirm('确定要删除这个 API Key 吗？删除后使用该 Key 的 MCP 客户端将无法连接。')) return;
+    if (!(await showConfirm({
+      title: '删除 API Key',
+      message: '删除后使用该 Key 的 MCP 客户端将无法连接，确定吗？',
+      confirmText: '删除',
+      variant: 'danger',
+    }))) return;
     try {
       await apiDelete(`/api-keys/${id}`);
       setApiKeys((prev) => prev.filter((k) => k.id !== id));

--- a/packages/client/src/shared/stores/confirm-store.ts
+++ b/packages/client/src/shared/stores/confirm-store.ts
@@ -1,0 +1,87 @@
+import { create } from 'zustand';
+
+interface ConfirmRequest {
+  id: number;
+  title: string;
+  message?: string;
+  confirmText: string;
+  cancelText: string;
+  variant: 'default' | 'danger';
+  type: 'confirm' | 'alert';
+  resolve: (ok: boolean) => void;
+}
+
+interface ConfirmStore {
+  current: ConfirmRequest | null;
+  push: (req: ConfirmRequest) => void;
+  resolve: (ok: boolean) => void;
+}
+
+let nextId = 1;
+
+export const useConfirmStore = create<ConfirmStore>((set, get) => ({
+  current: null,
+  push: (req) => {
+    // If another dialog is already open, cancel it before showing the new one.
+    const prev = get().current;
+    if (prev) prev.resolve(false);
+    set({ current: req });
+  },
+  resolve: (ok) => {
+    const cur = get().current;
+    if (!cur) return;
+    cur.resolve(ok);
+    set({ current: null });
+  },
+}));
+
+export interface ConfirmOptions {
+  title: string;
+  message?: string;
+  confirmText?: string;
+  cancelText?: string;
+  variant?: 'default' | 'danger';
+}
+
+/**
+ * Imperative replacement for `window.confirm`. Renders an in-app modal and
+ * resolves to `true` if the user confirms, `false` if they cancel or close it.
+ *
+ * ```ts
+ * if (!(await showConfirm({ title: '解散房间', message: '...', variant: 'danger' }))) return;
+ * doDangerousThing();
+ * ```
+ */
+export function showConfirm(opts: ConfirmOptions): Promise<boolean> {
+  return new Promise((resolve) => {
+    useConfirmStore.getState().push({
+      id: nextId++,
+      title: opts.title,
+      message: opts.message,
+      confirmText: opts.confirmText ?? '确定',
+      cancelText: opts.cancelText ?? '取消',
+      variant: opts.variant ?? 'default',
+      type: 'confirm',
+      resolve,
+    });
+  });
+}
+
+/**
+ * Imperative replacement for `window.alert`. Single button, resolves when the
+ * user dismisses it.
+ */
+export function showAlert(opts: Omit<ConfirmOptions, 'cancelText' | 'variant'> & { variant?: 'default' | 'danger' }): Promise<void> {
+  return new Promise((resolve) => {
+    useConfirmStore.getState().push({
+      id: nextId++,
+      title: opts.title,
+      message: opts.message,
+      confirmText: opts.confirmText ?? '确定',
+      cancelText: '',
+      variant: opts.variant ?? 'default',
+      type: 'alert',
+      resolve: () => resolve(),
+    });
+  });
+}


### PR DESCRIPTION
## 背景

\`window.confirm\` / \`window.alert\` 在多平台样式不一、无法定制、阻塞 JS 线程，且与游戏整体的玻璃质感 UI 风格不搭。统一改为复用 \`glass-panel\` 风格的 in-app modal。

## 新增基础设施

### \`shared/stores/confirm-store.ts\`

zustand store + imperative API：

\`\`\`ts
import { showConfirm, showAlert } from '@/shared/stores/confirm-store';

const ok = await showConfirm({
  title: '解散房间',
  message: '所有玩家将被踢出',
  confirmText: '解散',
  variant: 'danger',
});
if (!ok) return;
\`\`\`

- 返回 \`Promise<boolean>\`
- 同时只能显示一个 dialog，新 dialog 来时旧的自动 \`resolve(false)\`

### \`shared/components/ConfirmDialog.tsx\`

顶层挂载组件，挂在 \`App.tsx\`：

- framer-motion 弹入/淡入动画
- \`default\` / \`danger\` 两种 variant（danger 红色按钮 + 警告图标）
- 键盘：**Enter** 确认、**Esc** 取消
- 点击 backdrop 取消（alert 单按钮模式下视为确认）
- 自动 focus 主按钮

## 调用点替换（7 处 confirm + 1 处 alert）

| 调用点 | 旧 | 新 | variant |
|---|---|---|---|
| PlayerActionMenu | 移交房主 | showConfirm | default |
| PlayerActionMenu | 踢出玩家 | showConfirm | danger |
| TopBar | 退出对局 | showConfirm | default |
| TopBar | 解散房间 | showConfirm | danger |
| RoomPage | 离开房间 | showConfirm | default |
| RoomPage | 解散房间 | showConfirm | danger |
| RoomPage | startGame 错误 \`alert\` | useToastStore.addToast | — |
| ProfileModal | 删除 API Key | showConfirm | danger |

\`startGame\` 错误从 \`alert\` 改为 toast，与其它失败反馈一致（更轻量）。

## 验证

- shared build / test ✓ 240/240
- client tsc ✓ / client build ✓
- 全局 grep \`window.confirm\` / \`window.alert\` 已无残留调用，仅 docstring 引用

🤖 Generated with [Claude Code](https://claude.com/claude-code)