### PR TITLE
fix: modal 关闭时缺少淡出动画 + 音乐厅与 BGM 状态不一致

### DIFF
--- a/packages/client/src/features/game/components/HotkeySettingsModal.tsx
+++ b/packages/client/src/features/game/components/HotkeySettingsModal.tsx
@@ -49,11 +49,10 @@ export default function HotkeySettingsModal({ open, onClose }: Props) {
     if (!open) setListening(null);
   }, [open]);
 
-  if (!open) return null;
-
   return (
     <AnimatePresence>
-      <motion.div
+      {open && (
+        <motion.div
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
@@ -117,6 +116,7 @@ export default function HotkeySettingsModal({ open, onClose }: Props) {
           </div>
         </motion.div>
       </motion.div>
+      )}
     </AnimatePresence>
   );
 }

--- a/packages/client/src/shared/components/ChangelogModal.tsx
+++ b/packages/client/src/shared/components/ChangelogModal.tsx
@@ -21,8 +21,6 @@ export default function ChangelogModal() {
     localStorage.setItem(STORAGE_KEY, import.meta.env.BUILD_VERSION as string);
   };
 
-  if (!open) return null;
-
   return (
     <AnimatePresence>
       {open && (

--- a/packages/client/src/shared/components/MusicHallModal.tsx
+++ b/packages/client/src/shared/components/MusicHallModal.tsx
@@ -37,13 +37,23 @@ export default function MusicHallModal({ open, onClose, currentScene }: Props) {
   const [playing, setPlaying] = useState<string | null>(null);
   const bgmVolume = useSettingsStore((s) => s.bgmVolume);
   const setBgmVolume = useSettingsStore((s) => s.setBgmVolume);
+  const bgmEnabled = useSettingsStore((s) => s.bgmEnabled);
 
   const songs = PLAYLISTS[tab] ?? [];
+
+  // When the user previews a song with BGM off, resuming/stopping on close
+  // must honor their BGM preference instead of unconditionally starting the
+  // scene playlist (which would surprise-play even though the BGM button is
+  // still showing 关闭).
+  const resumeOrStop = () => {
+    if (bgmEnabled) bgm.start(currentScene);
+    else bgm.stop();
+  };
 
   const play = (scene: string, index: number) => {
     const key = `${scene}:${index}`;
     if (playing === key) {
-      bgm.start(currentScene);
+      resumeOrStop();
       setPlaying(null);
     } else {
       bgm.playSingle(scene, index);
@@ -52,7 +62,7 @@ export default function MusicHallModal({ open, onClose, currentScene }: Props) {
   };
 
   const close = () => {
-    if (playing) bgm.start(currentScene);
+    if (playing) resumeOrStop();
     setPlaying(null);
     onClose();
   };
@@ -62,8 +72,6 @@ export default function MusicHallModal({ open, onClose, currentScene }: Props) {
     setBgmVolume(v);
     bgm.setVolume(v);
   };
-
-  if (!open) return null;
 
   return (
     <AnimatePresence>

--- a/packages/client/src/shared/components/NotificationPermissionDialog.tsx
+++ b/packages/client/src/shared/components/NotificationPermissionDialog.tsx
@@ -26,7 +26,7 @@ export default function NotificationPermissionDialog() {
 
   const close = () => setOpen(false);
 
-  if (!open || permission === 'unsupported') return null;
+  if (permission === 'unsupported') return null;
 
   const isDenied = permission === 'denied';
 

--- a/packages/client/src/shared/components/ProfileModal.tsx
+++ b/packages/client/src/shared/components/ProfileModal.tsx
@@ -129,8 +129,6 @@ export default function ProfileModal() {
 
   const profileRoleColor = getRoleColor(profile?.user.role);
 
-  if (!isOpen) return null;
-
   return (
     <AnimatePresence>
       {isOpen && (

--- a/packages/client/src/shared/components/ServerSelectModal.tsx
+++ b/packages/client/src/shared/components/ServerSelectModal.tsx
@@ -160,8 +160,6 @@ export function ServerSelectModal() {
     }
   };
 
-  if (!isModalOpen) return null;
-
   return (
     <AnimatePresence>
       {isModalOpen && (

--- a/packages/client/src/shared/components/ServerUpdateDialog.tsx
+++ b/packages/client/src/shared/components/ServerUpdateDialog.tsx
@@ -5,8 +5,6 @@ import { useServerVersionStore } from '../stores/server-version-store';
 export default function ServerUpdateDialog() {
   const needsRefresh = useServerVersionStore((s) => s.needsRefresh);
 
-  if (!needsRefresh) return null;
-
   const handleRefresh = () => window.location.reload();
 
   return (

--- a/packages/client/src/shared/components/TutorialModal.tsx
+++ b/packages/client/src/shared/components/TutorialModal.tsx
@@ -164,16 +164,17 @@ export default function TutorialModal({ open, onClose }: { open: boolean; onClos
   const [page, setPage] = useState(0);
   const [dir, setDir] = useState(1);
 
-  const close = () => { setPage(0); onClose(); };
+  // Reset to page 0 only *after* the exit animation finishes — otherwise the
+  // user sees page 0 fade out instead of whatever page they were on when they
+  // closed it.
+  const close = () => onClose();
   const go = (next: number) => { setDir(next > page ? 1 : -1); setPage(next); };
-
-  if (!open) return null;
 
   const current = PAGES[page]!;
   const isLast = page === PAGES.length - 1;
 
   return (
-    <AnimatePresence>
+    <AnimatePresence onExitComplete={() => setPage(0)}>
       {open && (
         <motion.div
           initial={{ opacity: 0 }}


### PR DESCRIPTION
## 1. modal 关闭时没有淡出动画

用户反馈：音乐厅和个人信息弹窗关闭时只有淡入没有淡出。

### 根因

这些 modal 写法都是：

\`\`\`tsx
if (!open) return null;        // ← 在 AnimatePresence 之外

return (
  <AnimatePresence>
    {open && (
      <motion.div initial=... animate=... exit=... />
    )}
  </AnimatePresence>
);
\`\`\`

当 \`open\` 从 true 变 false 时，整个组件直接 \`return null\` 卸载，\`AnimatePresence\` 根本看不到子节点被移除（它都已经不存在了），exit 动画无从播放。

### 修复

去掉 \`AnimatePresence\` **外面**的 early return，交给内部 \`{open && ...}\` 条件渲染处理。8 个文件中招：

- MusicHallModal / ProfileModal / ServerSelectModal / HotkeySettingsModal（顺便补 \`{open && ...}\`）
- ServerUpdateDialog / ChangelogModal
- TutorialModal：用 \`onExitComplete={() => setPage(0)}\` 取代 \`close\` 时 \`setPage(0)\`，否则 exit 动画期间会闪现 page 0
- NotificationPermissionDialog：保留 \`permission === 'unsupported'\` 的 early return，只去掉 \`!open\` 部分

## 2. 音乐厅与 BGM 按钮状态不一致

用户反馈：BGM 关闭状态下，在音乐厅试听音乐后关闭音乐厅，**音乐继续播放但 BGM 按钮还是显示关闭**。

### 根因

\`MusicHallModal.close()\` 在 \`playing\` 非空时无条件调 \`bgm.start(currentScene)\` 切回场景 playlist——完全忽略 \`bgmEnabled\` 偏好。BGM 引擎被强制启动，但 \`bgmEnabled\` 还是 false，UI 按钮显示关闭——状态分叉。

### 修复

新增 \`resumeOrStop()\` 内联 helper，\`close()\` 与 \`play()\` 的"停止预览"分支都改走它：

- \`bgmEnabled === true\` → \`bgm.start(currentScene)\` 切回场景 playlist（原行为）
- \`bgmEnabled === false\` → \`bgm.stop()\` 真停下，与按钮状态一致

预览功能（\`bgm.playSingle\`）本身仍然保持"无视 bgmEnabled 直接放"——音乐厅就是要让用户能试听。只在关闭/切歌时尊重用户的 BGM 偏好。

## 验证

- shared build ✓ / shared test ✓ 240/240
- client tsc ✓ / client build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)