### PR TITLE
refactor(caddy): 抽取 SPA snippet + 加默认安全头与健康检查

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,37 +1,73 @@
-{$CADDY_SITE_ADDRESS}
+# ---- Reusable snippets ----
 
-encode gzip
-
-handle /api/* {
-	reverse_proxy server:3001
-}
-
-handle /socket.io/* {
-	reverse_proxy server:3001
-}
-
-handle /mumble-ws* {
-	uri strip_prefix /mumble-ws
-	reverse_proxy mumble-gateway:64737
-}
-
-@admin_exact path /admin
-redir @admin_exact /admin/ permanent
-
-handle /admin/* {
-	root * /srv
-	try_files {path} /admin/index.html
+# SPA file serving with sensible cache headers.
+#   {args[0]} = web root directory
+#   {args[1]} = SPA fallback (e.g. /index.html)
+(spa) {
+	root * {args[0]}
+	try_files {path} {args[1]}
 	file_server
 
 	@static path *.js *.css *.png *.jpg *.jpeg *.gif *.ico *.svg *.woff *.woff2
 	header @static Cache-Control "public, max-age=2592000, immutable"
+
+	# Anything else served here is the SPA shell (try_files rewrites unknown
+	# paths to {args[1]}). Must not be long-cached or clients miss new releases.
+	@shell not path *.js *.css *.png *.jpg *.jpeg *.gif *.ico *.svg *.woff *.woff2
+	header @shell Cache-Control "no-cache"
 }
 
-handle {
-	root * /srv
-	try_files {path} /index.html
-	file_server
+# Default response headers applied to every response.
+(common_headers) {
+	header {
+		X-Content-Type-Options "nosniff"
+		Referrer-Policy "strict-origin-when-cross-origin"
+		-Server
+	}
+}
 
-	@static path *.js *.css *.png *.jpg *.jpeg *.gif *.ico *.svg *.woff *.woff2
-	header @static Cache-Control "public, max-age=2592000, immutable"
+# Upstream headers for reverse proxies. Caddy already sets X-Forwarded-*
+# and transparently upgrades WebSockets, so we only add X-Real-IP for
+# upstreams that look at it directly.
+(proxy_headers) {
+	header_up X-Real-IP {remote_host}
+}
+
+# ---- Site ----
+
+{$CADDY_SITE_ADDRESS} {
+	encode gzip
+	import common_headers
+
+	respond /healthz 200
+
+	handle /api/* {
+		reverse_proxy server:3001 {
+			import proxy_headers
+		}
+	}
+
+	handle /socket.io/* {
+		reverse_proxy server:3001 {
+			import proxy_headers
+		}
+	}
+
+	handle /mumble-ws* {
+		uri strip_prefix /mumble-ws
+		reverse_proxy mumble-gateway:64737 {
+			import proxy_headers
+		}
+	}
+
+	@admin_exact path /admin
+	redir @admin_exact /admin/ permanent
+
+	handle /admin/* {
+		import spa /srv /admin/index.html
+	}
+
+	handle {
+		import spa /srv /index.html
+	}
 }


### PR DESCRIPTION
## 动机

Caddyfile 里 `/admin/*` 和兜底 SPA handler 之间有大段重复（`root * /srv` / `try_files` / `file_server` / 静态资源缓存头都写了两遍），改缓存策略要改两处。顺手补了两个常被踩的坑：SPA 入口没设 `no-cache` 导致发版后用户拿不到新版；反代上游缺 `X-Real-IP`。

## 改动

- **结构去重**：新增 `(spa)` snippet，接 web root 和 SPA fallback 两个参数，两个 SPA handler 各 `import` 一次。
- **SPA shell 加 `Cache-Control: no-cache`**：用 `@shell not path *.js *.css …` 反向匹配（`try_files` 重写后的 path 不进入请求阶段的 path 匹配器，所以走反向更稳）。哈希过的 js/css/字体/图片仍保留一个月 immutable 长缓存。
- **全局默认响应头**（新 `(common_headers)` snippet）：`X-Content-Type-Options: nosniff`、`Referrer-Policy: strict-origin-when-cross-origin`、剥离 `Server`。
- **`(proxy_headers)` snippet**：给三个 `reverse_proxy` 补 `X-Real-IP`（`X-Forwarded-*` 和 WebSocket 升级 Caddy 已自动处理，不需要重复声明）。
- **`/healthz` 路由**：`respond /healthz 200`，给容器/编排做存活探测。
- **格式调整**：从隐式单站点改为显式 `{ ... }` 包裹（snippet 必须定义在站点块外）。对外行为等价。

## 故意没做

- 不加 CSP——需要根据前端实际加载的第三方资源调，留单独 PR。
- 不加 `trusted_proxies`——容器内网，目前不需要。

## 验证

- `caddy validate --adapter caddyfile` 通过，无 warning。
- 用 `caddy:2-alpine` + stub `/srv` 起容器跑端到端 smoke test：

  | 路由 | 期望 | 实测 |
  |---|---|---|
  | `/healthz` | 200 | ✅ 200 |
  | `/` | 200, `Cache-Control: no-cache` | ✅ |
  | `/some/spa/route` (未知路径) | 200, `no-cache`, 落回 `index.html` | ✅ |
  | `/app.abc123.js` | 200, `public, max-age=2592000, immutable` | ✅ |
  | `/admin` | 301 → `/admin/` | ✅ |
  | `/admin/` | 200, `no-cache` | ✅ |
  | `/admin/deep/route` | 200, `no-cache` | ✅ |
  | `/api/foo` (上游不存在) | 502（不崩） | ✅ 502 |
  | 任意响应 | 含 `X-Content-Type-Options`、`Referrer-Policy`，无 `Server` | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)