### PR TITLE
refactor(spectate): 折叠待入队清理路径 + 修复重连解散时的注册表泄漏

### DIFF
--- a/packages/client/src/features/game/stores/spectator-store.ts
+++ b/packages/client/src/features/game/stores/spectator-store.ts
@@ -13,15 +13,7 @@ interface SpectatorState {
 export const useSpectatorStore = create<SpectatorState>((set) => ({
   spectators: [],
   pendingJoinQueue: [],
-  setSpectators: (list) =>
-    set((s) => {
-      // Skip the update when the server snapshot matches what we already
-      // have — startNextRound rebroadcasts the list every round as a
-      // defense-in-depth resync, and we don't want consumers to re-render
-      // when nothing actually changed.
-      if (s.spectators.length === list.length && s.spectators.every((n, i) => n === list[i])) return s;
-      return { spectators: list };
-    }),
+  setSpectators: (list) => set({ spectators: list }),
   setPendingJoinQueue: (list) => set({ pendingJoinQueue: list }),
   clearSpectators: () => set({ spectators: [], pendingJoinQueue: [] }),
 }));

--- a/packages/client/src/features/game/stores/spectator-store.ts
+++ b/packages/client/src/features/game/stores/spectator-store.ts
@@ -1,7 +1,6 @@
 import { create } from 'zustand';
 
-// Populated only via full snapshots from the server's spectator events.
-// No incremental add/remove — those would drift from the authoritative state.
+// Snapshot-only — incremental updates would drift from the server's list.
 interface SpectatorState {
   spectators: string[];
   pendingJoinQueue: string[];

--- a/packages/client/src/features/game/stores/spectator-store.ts
+++ b/packages/client/src/features/game/stores/spectator-store.ts
@@ -13,7 +13,15 @@ interface SpectatorState {
 export const useSpectatorStore = create<SpectatorState>((set) => ({
   spectators: [],
   pendingJoinQueue: [],
-  setSpectators: (list) => set({ spectators: list }),
+  setSpectators: (list) =>
+    set((s) => {
+      // Skip the update when the server snapshot matches what we already
+      // have — startNextRound rebroadcasts the list every round as a
+      // defense-in-depth resync, and we don't want consumers to re-render
+      // when nothing actually changed.
+      if (s.spectators.length === list.length && s.spectators.every((n, i) => n === list[i])) return s;
+      return { spectators: list };
+    }),
   setPendingJoinQueue: (list) => set({ pendingJoinQueue: list }),
   clearSpectators: () => set({ spectators: [], pendingJoinQueue: [] }),
 }));

--- a/packages/server/src/plugins/core/spectate/ws.ts
+++ b/packages/server/src/plugins/core/spectate/ws.ts
@@ -35,10 +35,11 @@ export function addSpectator(roomCode: string, userId: string, nickname: string)
 /** Returns the removed nickname, or `null` if the user wasn't tracked. */
 export function removeSpectator(roomCode: string, userId: string): string | null {
   const room = roomSpectators.get(roomCode);
-  const nickname = room?.get(userId);
+  if (!room) return null;
+  const nickname = room.get(userId);
   if (nickname == null) return null;
-  room!.delete(userId);
-  if (room!.size === 0) roomSpectators.delete(roomCode);
+  room.delete(userId);
+  if (room.size === 0) roomSpectators.delete(roomCode);
   return nickname;
 }
 
@@ -48,30 +49,36 @@ export function broadcastSpectatorList(io: SocketIOServer, roomCode: string): vo
 }
 
 /**
- * Single entry point for every "a spectator left" path (disconnect,
- * room:leave, future flows). Removes the user from the registry and emits
- * the resulting authoritative state to the rest of the room.
+ * Single entry point for every "a spectator left" path. Drains the user
+ * from both the pending-join queue and the spectator registry, then emits
+ * the resulting authoritative state.
  *
- * When the user isn't tracked we *don't* broadcast (nothing changed), but
- * we do warn — every caller's precondition (`data.isSpectator === true` or
- * "user is in the pending-join queue") implies the user must be in the
- * registry, so a null here is the exact kind of state drift this refactor
- * was written to prevent. Logging gives operators a breadcrumb instead of
- * silently swallowing it the way the previous code did.
+ * Warns instead of silently no-op'ing when the user wasn't in the registry
+ * — every caller's precondition (`data.isSpectator === true`) implies the
+ * user must be tracked, so a null is exactly the kind of drift this
+ * refactor exists to surface.
  */
 export function broadcastSpectatorLeft(
   io: SocketIOServer,
   roomCode: string,
   userId: string,
+  nickname: string,
 ): void {
-  const nickname = removeSpectator(roomCode, userId);
-  if (nickname == null) {
+  if (removePendingSpectatorJoin(roomCode, userId)) {
+    io.to(roomCode).emit('game:spectator_queue', {
+      queue: getPendingSpectatorQueue(roomCode),
+      nickname,
+      joined: false,
+    });
+  }
+  const removed = removeSpectator(roomCode, userId);
+  if (removed == null) {
     console.warn('[spectate] broadcastSpectatorLeft called for untracked user', { roomCode, userId });
     return;
   }
   const spectators = getSpectatorNames(roomCode);
   io.to(roomCode).emit('room:spectator_list', { spectators });
-  io.to(roomCode).emit('room:spectator_left', { nickname, spectators });
+  io.to(roomCode).emit('room:spectator_left', { nickname: removed, spectators });
 }
 
 export function setupSpectateHandlers(
@@ -139,19 +146,9 @@ export function setupSpectateHandlers(
 
     socket.on('disconnect', () => {
       const data = socket.data as SocketData;
-      if (!data.isSpectator || !data.roomCode) return;
-      const roomCode = data.roomCode;
-      const userId = data.user?.userId;
-      if (!userId) return;
-
-      if (removePendingSpectatorJoin(roomCode, userId)) {
-        io.to(roomCode).emit('game:spectator_queue', {
-          queue: getPendingSpectatorQueue(roomCode),
-          nickname: data.user.nickname ?? '',
-          joined: false,
-        });
-      }
-      broadcastSpectatorLeft(io, roomCode, userId);
+      if (!data.isSpectator || !data.roomCode || !data.user) return;
+      const { userId, nickname } = data.user;
+      broadcastSpectatorLeft(io, data.roomCode, userId, nickname);
       clearUserRoom(kv, userId).catch((err) => {
         console.warn('[spectate] clearUserRoom on disconnect failed:', err);
       });

--- a/packages/server/src/plugins/core/spectate/ws.ts
+++ b/packages/server/src/plugins/core/spectate/ws.ts
@@ -7,11 +7,8 @@ import { loadGameState } from '../game/state-store.js';
 import { removePendingSpectatorJoin, getPendingSpectatorQueue } from '../../../ws/game-events.js';
 import { joinRoomSocket } from '../../../ws/socket-room.js';
 
-// Authoritative in-memory spectator registry. Keyed by userId (nicknames can
-// change and aren't unique on the wire). Single socket per user is enforced
-// at the connection layer (socket-handler.ts kicks the prior socket on
-// reconnect), so no per-socket ref-counting is needed — mirrors the
-// voice-presence registry next door.
+// Keyed by userId — nicknames aren't enforced unique at signup. Single
+// socket per user is enforced at connection time, so no ref-counting.
 const roomSpectators = new Map<string, Map<string, string>>();
 
 export function getSpectatorNames(roomCode: string): string[] {
@@ -43,20 +40,14 @@ export function removeSpectator(roomCode: string, userId: string): string | null
   return nickname;
 }
 
-/** Broadcasts the room's current spectator list. */
 export function broadcastSpectatorList(io: SocketIOServer, roomCode: string): void {
   io.to(roomCode).emit('room:spectator_list', { spectators: getSpectatorNames(roomCode) });
 }
 
 /**
- * Single entry point for every "a spectator left" path. Drains the user
- * from both the pending-join queue and the spectator registry, then emits
- * the resulting authoritative state.
- *
- * Warns instead of silently no-op'ing when the user wasn't in the registry
- * — every caller's precondition (`data.isSpectator === true`) implies the
- * user must be tracked, so a null is exactly the kind of drift this
- * refactor exists to surface.
+ * Drains the user from both the pending-join queue and the registry, then
+ * broadcasts. Warns on untracked users — every caller's precondition
+ * (`data.isSpectator === true`) implies they must be tracked.
  */
 export function broadcastSpectatorLeft(
   io: SocketIOServer,

--- a/packages/server/src/ws/game-events.ts
+++ b/packages/server/src/ws/game-events.ts
@@ -255,9 +255,8 @@ async function processPendingSpectatorJoins(
     });
   }
 
-  // 升级后 roomSpectators 已经少了 joined.length 人，但 removeSpectator
-  // 是 silent 的，客户端的观战席列表此刻还停留在旧快照——必须广播一次
-  // 才会刷新。无人升级时不广播。
+  // removeSpectator above is silent; without this broadcast the client's
+  // spectator panel would keep showing the just-promoted users.
   if (joined.length > 0) {
     broadcastSpectatorList(io, roomCode);
   }
@@ -789,9 +788,8 @@ export function registerGameEvents(
     persister.cleanup(roomCode);
     turnTimer.stop(roomCode);
     clearRoomTimeouts(roomCode);
-    // Drop any spectator→player opt-ins left over from the previous game's
-    // queue. Without this, the next game's startNextRound would re-apply
-    // them using stale socket ids and could resurrect ghost players.
+    // Leftover opt-ins from the previous game would otherwise be re-applied
+    // with stale socket ids → ghost players.
     clearPendingSpectatorJoins(roomCode);
 
     await setRoomStatus(redis, roomCode, 'waiting');
@@ -820,8 +818,6 @@ export function registerGameEvents(
     const updatedRoom = await getRoom(redis, roomCode);
     io.to(roomCode).emit('game:back_to_room', { players, room: updatedRoom });
     io.to(roomCode).emit('chat:cleared');
-    // Mirror the just-cleared server registry to every client so their
-    // spectator panel doesn't show last round's list.
     broadcastSpectatorList(io, roomCode);
     callback?.({ success: true });
   });

--- a/packages/server/src/ws/game-events.ts
+++ b/packages/server/src/ws/game-events.ts
@@ -256,8 +256,6 @@ async function processPendingSpectatorJoins(
       joined: true,
     });
   }
-  // No room:spectator_list emit here — startNextRound broadcasts it once
-  // after this function returns.
 }
 
 async function startNextRound(

--- a/packages/server/src/ws/game-events.ts
+++ b/packages/server/src/ws/game-events.ts
@@ -223,8 +223,6 @@ async function processPendingSpectatorJoins(
     const sock = io.sockets.sockets.get(info.socketId);
     if (sock) (sock.data as SocketData).isSpectator = false;
 
-    // Role transition (spectator → player): no broadcast here — startNextRound
-    // ships a fresh room:spectator_list immediately after this returns.
     removeSpectator(roomCode, userId);
     session.addPlayer({
       id: userId,
@@ -255,6 +253,13 @@ async function processPendingSpectatorJoins(
       nickname: '',
       joined: true,
     });
+  }
+
+  // 升级后 roomSpectators 已经少了 joined.length 人，但 removeSpectator
+  // 是 silent 的，客户端的观战席列表此刻还停留在旧快照——必须广播一次
+  // 才会刷新。无人升级时不广播。
+  if (joined.length > 0) {
+    broadcastSpectatorList(io, roomCode);
   }
 }
 

--- a/packages/server/src/ws/game-events.ts
+++ b/packages/server/src/ws/game-events.ts
@@ -788,6 +788,10 @@ export function registerGameEvents(
     persister.cleanup(roomCode);
     turnTimer.stop(roomCode);
     clearRoomTimeouts(roomCode);
+    // Drop any spectator→player opt-ins left over from the previous game's
+    // queue. Without this, the next game's startNextRound would re-apply
+    // them using stale socket ids and could resurrect ghost players.
+    clearPendingSpectatorJoins(roomCode);
 
     await setRoomStatus(redis, roomCode, 'waiting');
     await resetAllPlayersReady(redis, roomCode);

--- a/packages/server/src/ws/game-events.ts
+++ b/packages/server/src/ws/game-events.ts
@@ -277,10 +277,6 @@ async function startNextRound(
     persister.flushNow(roomCode),
   ]);
   io.to(roomCode).emit('game:next_round_vote', { votes: 0, required: session.getFullState().players.length, voters: [] });
-  // Defense in depth: round transitions are natural state-sync checkpoints,
-  // so re-broadcast the authoritative spectator list every round in case
-  // some other path failed to.
-  broadcastSpectatorList(io, roomCode);
   const room = await getRoom(redis, roomCode);
   const spectatorMode = (room?.settings?.spectatorMode as 'full' | 'hidden') ?? 'hidden';
   const sockets = await io.in(roomCode).fetchSockets();

--- a/packages/server/src/ws/room-events.ts
+++ b/packages/server/src/ws/room-events.ts
@@ -149,9 +149,7 @@ export function registerRoomEvents(
           const updatedRoom = await getRoom(redis, roomCode);
           io.to(roomCode).emit('room:updated', { players, room: updatedRoom });
         } else {
-          // No player left to inherit — fully dissolve the room. The
-          // imminent room:dissolved broadcast subsumes any spectator_left
-          // signal, so skip the dedicated cleanup here.
+          // dissolveRoom's room:dissolved broadcast subsumes spectator_left.
           await leaveRoomSocket(redis, socket, roomCode);
           await dissolveRoom(io, redis, roomCode, sessions, turnTimer, persister, 'empty', voiceChannels);
           return callback?.({ success: true, dissolved: true });

--- a/packages/server/src/ws/room-events.ts
+++ b/packages/server/src/ws/room-events.ts
@@ -9,7 +9,7 @@ import { GameSession } from '../plugins/core/game/session.js';
 import type { GameStatePersister } from '../plugins/core/game/state-store.js';
 import type { TurnTimer } from '../plugins/core/game/turn-timer.js';
 import type { VoiceChannelManager } from '../voice/channel-manager.js';
-import { removePlayerVote, removePendingSpectatorJoin, getPendingSpectatorQueue } from './game-events.js';
+import { removePlayerVote } from './game-events.js';
 import type { SocketData } from './types.js';
 import { dissolveRoom } from './room-lifecycle.js';
 import { removeVoicePresence, setForceMuted } from './voice-presence.js';
@@ -135,16 +135,7 @@ export function registerRoomEvents(
     const roomCode = data.roomCode;
     if (!roomCode) return callback?.({ success: false, error: 'Not in a room' });
     if (data.isSpectator) {
-      const userId = data.user.userId;
-      const nickname = data.user.nickname;
-
-      if (removePendingSpectatorJoin(roomCode, userId)) {
-        io.to(roomCode).emit('game:spectator_queue', {
-          queue: getPendingSpectatorQueue(roomCode),
-          nickname,
-          joined: false,
-        });
-      }
+      const { userId, nickname } = data.user;
 
       // If the owner is leaving while on the spectator bench (e.g. after
       // game:leave_to_spectate), transfer ownership before clearing socket
@@ -170,7 +161,7 @@ export function registerRoomEvents(
       // leaveRoomSocket first so the broadcast doesn't echo back to the
       // leaver themselves.
       await leaveRoomSocket(redis, socket, roomCode);
-      broadcastSpectatorLeft(io, roomCode, userId);
+      broadcastSpectatorLeft(io, roomCode, userId, nickname);
       return callback?.({ success: true });
     }
     const room = await getRoom(redis, roomCode);

--- a/packages/server/src/ws/socket-handler.ts
+++ b/packages/server/src/ws/socket-handler.ts
@@ -417,12 +417,9 @@ export function setupSocketHandlers(
             ]);
             io.to(roomCode).emit('room:updated', { players, room });
           } else {
-            // Last player gone — route through dissolveRoom so every
-            // in-memory registry (spectators, pending joins, voice presence,
-            // room timeouts, persister) gets torn down, the Mumble channel
-            // is actually removed (not just unmapped), and any straggler
-            // sockets in the room get notified + ejected. The cached
-            // inline cleanup here used to forget all of that.
+            // Route through dissolveRoom to stay in sync with the other
+            // dissolve sites — chiefly so the Mumble channel actually gets
+            // removed (the inline form only unmapped the kv key).
             await dissolveRoom(io, redis, roomCode, sessions, turnTimer, persister, 'empty', voiceChannels);
           }
         }, RECONNECT_TIMEOUT_MS);

--- a/packages/server/src/ws/socket-handler.ts
+++ b/packages/server/src/ws/socket-handler.ts
@@ -417,9 +417,13 @@ export function setupSocketHandlers(
             ]);
             io.to(roomCode).emit('room:updated', { players, room });
           } else {
-            sessions.delete(roomCode);
-            turnTimer.stop(roomCode);
-            await voiceChannels.clearRoomChannelMapping(roomCode);
+            // Last player gone — route through dissolveRoom so every
+            // in-memory registry (spectators, pending joins, voice presence,
+            // room timeouts, persister) gets torn down, the Mumble channel
+            // is actually removed (not just unmapped), and any straggler
+            // sockets in the room get notified + ejected. The cached
+            // inline cleanup here used to forget all of that.
+            await dissolveRoom(io, redis, roomCode, sessions, turnTimer, persister, 'empty', voiceChannels);
           }
         }, RECONNECT_TIMEOUT_MS);
         disconnectTimers.set(userId, timer);

--- a/packages/server/tests/ws/spectate-registry.test.ts
+++ b/packages/server/tests/ws/spectate-registry.test.ts
@@ -12,7 +12,6 @@ import {
 const ROOM_A = 'TESTAA';
 const ROOM_B = 'TESTBB';
 
-/** Reset every room the suite touches so tests can't leak state into each other. */
 function resetRegistry(): void {
   for (const code of [ROOM_A, ROOM_B]) clearRoomSpectators(code);
 }
@@ -89,9 +88,8 @@ describe('spectator registry', () => {
       ]);
     });
 
-    // The room:spectator_left payload's `nickname` should come from the
-    // authoritative registry, not the caller — guards against a stale
-    // caller-supplied nickname after rename.
+    // Authoritative nickname comes from the registry, not the caller — the
+    // caller's copy could be stale.
     it('broadcastSpectatorLeft uses the registry nickname for room:spectator_left', () => {
       const { io, emits } = makeIoStub();
       addSpectator(ROOM_A, 'u1', 'RegistryName');
@@ -100,9 +98,8 @@ describe('spectator registry', () => {
       expect((left!.payload as { nickname: string }).nickname).toBe('RegistryName');
     });
 
-    // The bug this whole refactor exists to fix: the server used to emit
-    // { nickname } without `spectators`. Lock the contract in a test so any
-    // future path that bypasses broadcastSpectatorLeft will get caught.
+    // Any future path that emits room:spectator_left without going through
+    // broadcastSpectatorLeft will fail this — that's the point.
     it('broadcastSpectatorLeft always populates spectators on room:spectator_left (contract guard)', () => {
       const { io, emits } = makeIoStub();
       addSpectator(ROOM_A, 'u1', 'Alice');

--- a/packages/server/tests/ws/spectate-registry.test.ts
+++ b/packages/server/tests/ws/spectate-registry.test.ts
@@ -82,11 +82,22 @@ describe('spectator registry', () => {
       const { io, emits } = makeIoStub();
       addSpectator(ROOM_A, 'u1', 'Alice');
       addSpectator(ROOM_A, 'u2', 'Bob');
-      broadcastSpectatorLeft(io, ROOM_A, 'u1');
+      broadcastSpectatorLeft(io, ROOM_A, 'u1', 'Alice');
       expect(emits).toEqual([
         { event: 'room:spectator_list', payload: { spectators: ['Bob'] } },
         { event: 'room:spectator_left', payload: { nickname: 'Alice', spectators: ['Bob'] } },
       ]);
+    });
+
+    // The room:spectator_left payload's `nickname` should come from the
+    // authoritative registry, not the caller — guards against a stale
+    // caller-supplied nickname after rename.
+    it('broadcastSpectatorLeft uses the registry nickname for room:spectator_left', () => {
+      const { io, emits } = makeIoStub();
+      addSpectator(ROOM_A, 'u1', 'RegistryName');
+      broadcastSpectatorLeft(io, ROOM_A, 'u1', 'StaleCallerName');
+      const left = emits.find((e) => e.event === 'room:spectator_left');
+      expect((left!.payload as { nickname: string }).nickname).toBe('RegistryName');
     });
 
     // The bug this whole refactor exists to fix: the server used to emit
@@ -95,7 +106,7 @@ describe('spectator registry', () => {
     it('broadcastSpectatorLeft always populates spectators on room:spectator_left (contract guard)', () => {
       const { io, emits } = makeIoStub();
       addSpectator(ROOM_A, 'u1', 'Alice');
-      broadcastSpectatorLeft(io, ROOM_A, 'u1');
+      broadcastSpectatorLeft(io, ROOM_A, 'u1', 'Alice');
       const left = emits.find((e) => e.event === 'room:spectator_left');
       expect(left).toBeDefined();
       expect((left!.payload as { spectators: unknown }).spectators).toEqual([]);
@@ -112,7 +123,7 @@ describe('spectator registry', () => {
 
       it('broadcastSpectatorLeft warns and does not emit when the user is untracked', () => {
         const { io, emits } = makeIoStub();
-        broadcastSpectatorLeft(io, ROOM_A, 'ghost');
+        broadcastSpectatorLeft(io, ROOM_A, 'ghost', 'Ghost');
         expect(emits).toEqual([]);
         expect(warnSpy).toHaveBeenCalledOnce();
         expect(warnSpy.mock.calls[0][0]).toMatch(/untracked user/);


### PR DESCRIPTION
承接 #108 的 `/simplify` 复盘 + 独立审计的修正，对 spectator 相关清理路径做一轮收尾，并撤回 #108 里引入的一段无效防御代码。

## 改动

### 一、合并/简化重复路径

| 项 | 文件 | 说明 |
|---|---|---|
| **Q4** | `spectate/ws.ts` / `room-events.ts` | 把 pending-spectator-queue 清理折进 `broadcastSpectatorLeft`，让它真正成为"观众离场"的唯一入口。两条调用点（disconnect / room:leave）从各自内联 14 行变成一行。 |
| **Q5** | `spectate/ws.ts` | 去掉 `removeSpectator` 里两个不必要的 `!` 非空断言。 |
| **Q7** | `spectate/ws.ts` / `game-events.ts` | 精简 `broadcastSpectatorLeft` JSDoc；删掉 `processPendingSpectatorJoins` 末尾与上文重复的注释。 |

副作用：`disconnect` 处理函数从 12 行缩到 5 行。

### 二、F10 路径收口

`socket-handler.ts:407-426` 重连超时后最后一名玩家未回来的清理路径，过去内联了一段 `dissolveRoom` 的真子集：`sessions.delete + turnTimer.stop + clearRoomChannelMapping`。改成直接走 `dissolveRoom`。

实际堵的漏窄——这条分支只在"无 session + 60s 无人回来"触发（等待房没开局，或 back_to_room 后立刻全员断），大部分清理项在该路径上都是空集。**真正的收益**：

- `clearRoomChannelMapping` → `deleteRoomChannel`：让 Mumble 服务端真去删虚拟频道，避免孤儿频道堆积（之前只解 KV 映射）
- 消灭一份 `dissolveRoom` 阉割副本——避免将来给 `dissolveRoom` 加项时这里默默脱节

### 三、`back_to_room` 漏调 `clearPendingSpectatorJoins`

`game-events.ts:794` 一行修复。`back_to_room` 已清 sessions / persister / turnTimer / roomTimeouts / roomSpectators，唯独漏 pendingSpectatorJoins。上局结束时还在排队"下局加入"的条目残留到下一局 `startNextRound` 的 `processPendingSpectatorJoins`，可能拿过期 socketId 复活幽灵玩家。

### 四、撤回 #108 里的 speculative defense（最后一个 commit）

独立审计指出 #108 在 `startNextRound` 里加的"defense in depth" `broadcastSpectatorList(io, roomCode)` 是没有文档化失败案例的纯防御代码。这条无条件重播自己制造了"每回合都通知客户端列表，即使列表没变"的副作用，PR 早期版本为了消化它又给客户端 `setSpectators` 加了同内容守卫。两者构成 self-canceling pair——一起删。

剩下几个合法的 `broadcastSpectatorList` 调用点（kick→spectator、leave→spectator、back_to_room 清空后）依旧在，状态有真变化时仍会广播。

## 测试

### 单元测试

`spectate-registry.test.ts` 同步新签名，并新增一条："`room:spectator_left` 的 `nickname` 必须来自注册表而非调用方传入"——锁住权威性。

```
✓ tests/ws/spectate-registry.test.ts (10 tests)
```

### 端到端验证

写了独立 e2e 脚本，临时把 `RECONNECT_TIMEOUT_MS` 调成 2s 跑完整链路，验证完已还原：

```
[1] 观众主动 room:leave   → ✓ list + left 都带完整 spectators 快照
[2] 观众断线               → ✓ broadcastSpectatorLeft 同一路径
[3] 多观众下 1 人离开      → ✓ 剩余列表精确
[4] 等待房单玩家断线       → ✓ 房间从 KV 消失，dissolveRoom 跑通
[5] 对局房 2s 防回归        → ✓ 不会被 2s 计时器误解散
[6] 服务端日志             → ✓ 无 untracked-user 告警 / dissolve 失败
```

### 验证流程

- `pnpm --filter shared build` ✅
- `pnpm --filter server exec tsc --noEmit` ✅
- `pnpm --filter client build` ✅（含 tsc）
- 单元测试：shared 240/240 ✅ ｜ server（剔除 Redis 集成）36/36 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
