### PR TITLE
fix(room): 游戏结束后房主无法踢人 + 观战者被强制拉到玩家席

### DIFF
--- a/packages/server/src/ws/game-events.ts
+++ b/packages/server/src/ws/game-events.ts
@@ -6,9 +6,9 @@ import { GameSession } from '../plugins/core/game/session.js';
 import type { GameStatePersister } from '../plugins/core/game/state-store.js';
 import { emitGameUpdate, setAutopilotActionHandler, startTurnTimer, resetPlayerTimeout, clearRoomTimeouts } from './room-events.js';
 import type { TurnTimer } from '../plugins/core/game/turn-timer.js';
-import { getRoom, getRoomPlayers, setRoomStatus, touchRoomActivity, removePlayerFromRoom, addPlayerToRoom, resetAllPlayersReady, setUserRoom } from '../plugins/core/room/store.js';
+import { getRoom, getRoomPlayers, setRoomStatus, touchRoomActivity, removePlayerFromRoom, addPlayerToRoom, resetAllPlayersReady, setUserRoom, setPlayerSpectator } from '../plugins/core/room/store.js';
 import { MAX_PLAYERS } from '@uno-online/shared';
-import { addSpectator, clearRoomSpectators, removeSpectator, broadcastSpectatorList } from '../plugins/core/spectate/ws.js';
+import { addSpectator, removeSpectator, clearRoomSpectators, broadcastSpectatorList } from '../plugins/core/spectate/ws.js';
 import type { SocketData } from './types.js';
 
 function getSession(socket: Socket, sessions: Map<string, GameSession>): { session: GameSession; roomCode: string } | null {
@@ -808,11 +808,12 @@ export function registerGameEvents(
           role: sData.user.role,
           isBot: sData.user.isBot,
         });
+        await setPlayerSpectator(redis, roomCode, sData.user.userId, true);
       }
       sData.isSpectator = false;
     }
-
     clearRoomSpectators(roomCode);
+
     await touchRoomActivity(redis, roomCode);
     const players = await getRoomPlayers(redis, roomCode);
     const updatedRoom = await getRoom(redis, roomCode);

--- a/packages/server/src/ws/room-events.ts
+++ b/packages/server/src/ws/room-events.ts
@@ -315,7 +315,7 @@ export function registerRoomEvents(
     const room = await getRoom(redis, roomCode);
     if (!room) return callback?.({ success: false, error: '房间不存在' });
     if (room.ownerId !== data.user.userId) return callback?.({ success: false, error: '只有房主可以踢人' });
-    if (room.status !== 'waiting') return callback?.({ success: false, error: '游戏进行中无法踢人' });
+    if (room.status === 'playing') return callback?.({ success: false, error: '游戏进行中无法踢人' });
     if (payload.targetId === data.user.userId) return callback?.({ success: false, error: '不能踢自己' });
     const players = await getRoomPlayers(redis, roomCode);
     if (!players.some(p => p.userId === payload.targetId)) return callback?.({ success: false, error: '目标玩家不在房间中' });


### PR DESCRIPTION
## Summary
- `room:kick` 状态检查从 `!== 'waiting'` 改为 `=== 'playing'`，游戏结束（`finished`）后房主可以踢人
- `game:back_to_room` 中游戏级观战者不再被强制加为活跃玩家，而是加入房间玩家列表并标记 `spectator: true`，回到房间后留在观战席，可自行切换到玩家席

## Test plan
- [ ] 开始游戏 → 游戏结束 → 房主点击返回房间 → 房主踢人，应成功
- [ ] 游戏进行中有人中途加入观战 → 游戏结束返回房间 → 该观战者应在观战席，而非玩家席
- [ ] 房间原始观战席玩家（游戏开始前就在观战席的）→ 游戏结束返回房间 → 仍在观战席
- [ ] 游戏中玩家被踢到观战 / 主动退到观战 → 游戏结束返回房间 → 在观战席
- [ ] 游戏中观战者排队入场成为玩家 → 游戏结束返回房间 → 在玩家席
- [ ] 观战席玩家可以通过 toggle 切换回玩家席

🤖 Generated with [Claude Code](https://claude.com/claude-code)