### PR TITLE
fix(scoreboard): 冷却倒计时改为独立进度条 + 修复客户端时钟偏差

### DIFF
--- a/packages/client/src/features/game/components/ScoreBoard.tsx
+++ b/packages/client/src/features/game/components/ScoreBoard.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/shared/components/ui/Button';
 import { AiBadge } from '@/shared/components/ui/AiBadge';
 import { getSocket } from '@/shared/socket';
 import { useToastStore } from '@/shared/stores/toast-store';
+import { serverNow } from '@/shared/server-time';
 
 const KICK_DELAY_S = 30;
 const START_COOLDOWN_S = 10;
@@ -56,12 +57,12 @@ export default function ScoreBoard({ isSpectator = false, onPlayAgain, onBackToR
   const pendingJoinQueue = useSpectatorStore((s) => s.pendingJoinQueue);
   const [kickCountdown, setKickCountdown] = useState(() => {
     if (!roundEndAt) return KICK_DELAY_S;
-    return Math.max(0, KICK_DELAY_S - Math.floor((Date.now() - roundEndAt) / 1000));
+    return Math.max(0, KICK_DELAY_S - Math.floor((serverNow() - roundEndAt) / 1000));
   });
   const [leaveCountdown, setLeaveCountdown] = useState(5);
   const [startCooldown, setStartCooldown] = useState(() => {
     const endAt = roundEndAt ?? gameOverAt;
-    if (endAt) return Math.max(0, START_COOLDOWN_S - Math.floor((Date.now() - endAt) / 1000));
+    if (endAt) return Math.max(0, START_COOLDOWN_S - Math.floor((serverNow() - endAt) / 1000));
     return START_COOLDOWN_S;
   });
   const [spectatorQueued, setSpectatorQueued] = useState(() => {
@@ -72,7 +73,7 @@ export default function ScoreBoard({ isSpectator = false, onPlayAgain, onBackToR
 
   useEffect(() => {
     if (phase !== 'round_end' || !roundEndAt) { setKickCountdown(KICK_DELAY_S); return; }
-    const calc = () => Math.max(0, KICK_DELAY_S - Math.floor((Date.now() - roundEndAt) / 1000));
+    const calc = () => Math.max(0, KICK_DELAY_S - Math.floor((serverNow() - roundEndAt) / 1000));
     setKickCountdown(calc());
     kickTimerRef.current = setInterval(() => {
       const v = calc();
@@ -93,7 +94,7 @@ export default function ScoreBoard({ isSpectator = false, onPlayAgain, onBackToR
   useEffect(() => {
     const endAt = roundEndAt ?? gameOverAt;
     const initial = endAt
-      ? Math.max(0, START_COOLDOWN_S - Math.floor((Date.now() - endAt) / 1000))
+      ? Math.max(0, START_COOLDOWN_S - Math.floor((serverNow() - endAt) / 1000))
       : START_COOLDOWN_S;
     setStartCooldown(initial);
     if (initial <= 0) return;
@@ -146,22 +147,20 @@ export default function ScoreBoard({ isSpectator = false, onPlayAgain, onBackToR
   const allAgreed = votes >= required;
   const canKick = kickCountdown === 0;
   const cooldownActive = startCooldown > 0;
-  const nextRoundButtonText = cooldownActive
-    ? `${startCooldown}s`
-    : isHost
+  const nextRoundButtonText = isHost
+    ? hasVoted
       ? allAgreed
         ? '开始下一轮'
-        : hasVoted
-          ? `等待同意 (${votes}/${required})`
-          : `同意继续 (${votes}/${required})`
-      : hasVoted
-        ? allAgreed
-          ? '等待房主开始'
-          : `已同意 (${votes}/${required})`
-        : `同意继续 (${votes}/${required})`;
-  const isNextRoundDisabled = cooldownActive || (!isGameOver && (
-    isHost ? hasVoted && !allAgreed : hasVoted
-  ));
+        : `等待同意 (${votes}/${required})`
+      : `同意继续 (${votes}/${required})`
+    : hasVoted
+      ? allAgreed
+        ? '等待房主开始'
+        : `已同意 (${votes}/${required})`
+      : `同意继续 (${votes}/${required})`;
+  const isNextRoundDisabled = !isGameOver && (
+    isHost ? hasVoted && (!allAgreed || cooldownActive) : hasVoted
+  );
 
   return (
     <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-modal">
@@ -223,6 +222,22 @@ export default function ScoreBoard({ isSpectator = false, onPlayAgain, onBackToR
             {allAgreed ? '所有玩家已同意，等待房主开始下一轮' : `已有 ${votes}/${required} 人同意继续下一轮`}
           </p>
         )}
+        {cooldownActive && (
+          <div className="mb-3 mx-auto max-w-xs">
+            <p className="text-xs text-muted-foreground mb-1">
+              {isGameOver ? `${startCooldown}s 后可返回房间` : `${startCooldown}s 后可开始下一轮`}
+            </p>
+            <div className="h-1 rounded-full bg-muted-foreground/20 overflow-hidden">
+              <div
+                className="h-full rounded-full bg-accent"
+                style={{
+                  width: `${(startCooldown / START_COOLDOWN_S) * 100}%`,
+                  transition: 'width 1s linear',
+                }}
+              />
+            </div>
+          </div>
+        )}
         {isSpectator ? (
           <div className="flex gap-3 justify-center flex-wrap">
             {spectatorQueued ? (
@@ -239,8 +254,8 @@ export default function ScoreBoard({ isSpectator = false, onPlayAgain, onBackToR
         ) : (
           <div className="flex gap-3 justify-center flex-wrap">
             {!isGameOver && <Button variant="primary" onClick={onPlayAgain} disabled={isNextRoundDisabled} sound="ready">{nextRoundButtonText}</Button>}
-            {isGameOver && isHost && <Button variant="primary" onClick={onBackToRoom} disabled={cooldownActive} sound="ready">{cooldownActive ? `返回房间 (${startCooldown}s)` : '返回房间'}</Button>}
-            {isGameOver && !isHost && <Button variant="primary" disabled>{cooldownActive ? `${startCooldown}s` : '等待房主返回房间…'}</Button>}
+            {isGameOver && isHost && <Button variant="primary" onClick={onBackToRoom} disabled={cooldownActive} sound="ready">返回房间</Button>}
+            {isGameOver && !isHost && <Button variant="primary" disabled>等待房主返回房间…</Button>}
             <Button variant="secondary" onClick={onLeaveToSpectate} sound="click"><Eye size={14} className="inline align-middle mr-1" />进入观战席</Button>
             <Button variant="secondary" onClick={onBackToLobby} sound="click" disabled={leaveCountdown > 0}>{leaveCountdown > 0 ? `返回大厅 (${leaveCountdown}s)` : '返回大厅'}</Button>
           </div>

--- a/packages/client/src/shared/server-time.ts
+++ b/packages/client/src/shared/server-time.ts
@@ -1,0 +1,9 @@
+let offset = 0;
+
+export function setServerTimeOffset(serverTimestamp: number): void {
+  offset = serverTimestamp - Date.now();
+}
+
+export function serverNow(): number {
+  return Date.now() + offset;
+}

--- a/packages/client/src/shared/socket.ts
+++ b/packages/client/src/shared/socket.ts
@@ -8,6 +8,7 @@ import { playSound } from './sound/sound-manager';
 import { useGatewayStore, type PlayerVoicePresence } from './voice/gateway-store';
 import { sendNotification } from './utils/notification';
 import { useServerVersionStore } from './stores/server-version-store';
+import { setServerTimeOffset } from './server-time';
 import { useSpectatorStore } from '@/features/game/stores/spectator-store';
 import { resetClientRoomState } from './stores/reset-room';
 
@@ -184,6 +185,7 @@ export function getSocket(): TypedSocket {
 
     socket.on('server:version', (data) => {
       useServerVersionStore.getState().setVersion(data.version);
+      if (data.serverTime) setServerTimeOffset(data.serverTime);
     });
 
     socket.on('connect', () => {

--- a/packages/server/src/ws/socket-handler.ts
+++ b/packages/server/src/ws/socket-handler.ts
@@ -161,7 +161,7 @@ export function setupSocketHandlers(
   io.on('connection', async (socket) => {
     const userId = socket.data.user.userId;
 
-    socket.emit('server:version', { version: serverStartTime });
+    socket.emit('server:version', { version: serverStartTime, serverTime: Date.now() });
 
     // Multi-tab: kick existing connection for same user
     const existingSocketId = userSocketMap.get(userId);

--- a/packages/shared/src/types/socket-events.ts
+++ b/packages/shared/src/types/socket-events.ts
@@ -51,7 +51,7 @@ export interface ServerToClientEvents {
   'game:spectator_queue': (data: { queue: string[]; nickname: string; joined: boolean }) => void;
   'game:cheat_detected': () => void;
   'voice:presence': (presence: Record<string, unknown>) => void;
-  'server:version': (data: { version: string }) => void;
+  'server:version': (data: { version: string; serverTime: number }) => void;
 }
 
 export interface ClientToServerEvents {


### PR DESCRIPTION
## Summary
- 开始冷却（10s）仅限制房主开游戏，不再阻止玩家投票/准备
- 倒计时从按钮文字移至独立进度条组件，所有人可见
- 新增 `server-time` 模块，连接时通过 `server:version` 校准服务器时间偏移量，修复客户端时钟偏差导致倒计时异常的问题
- ScoreBoard 所有倒计时改用 `serverNow()` 替代 `Date.now()`

## Test plan
- [ ] 回合结束后，非房主玩家可立即投票，不受冷却影响
- [ ] 房主投票后，需等冷却结束才能点"开始下一轮"
- [ ] 进度条在冷却期间正确显示并平滑缩减
- [ ] 调整客户端系统时间偏差几分钟后，倒计时仍然准确
- [ ] 重连后倒计时正确恢复

🤖 Generated with [Claude Code](https://claude.com/claude-code)