### PR TITLE
perf(server): 减少 autopilot 重复广播 + 截断弃牌堆传输

### DIFF
--- a/packages/client/src/features/game/components/DiscardPile.tsx
+++ b/packages/client/src/features/game/components/DiscardPile.tsx
@@ -40,6 +40,7 @@ function getPlayOrigin(
 
 function DiscardPile() {
   const discardPile = useGameStore((s) => s.discardPile);
+  const discardPileCount = useGameStore((s) => s.discardPileCount);
   const drawStack = useGameStore((s) => s.drawStack);
   const phase = useGameStore((s) => s.phase);
   const currentColor = useGameStore((s) => s.currentColor);
@@ -159,7 +160,7 @@ function DiscardPile() {
           +{drawStack}
         </motion.div>
       )}
-      <span className="text-xs text-muted-foreground">弃牌堆 ({discardPile.length})</span>
+      <span className="text-xs text-muted-foreground">弃牌堆 ({discardPileCount || discardPile.length})</span>
     </div>
   );
 }

--- a/packages/client/src/features/game/stores/game-store.ts
+++ b/packages/client/src/features/game/stores/game-store.ts
@@ -23,6 +23,7 @@ interface GameState {
   pendingPenaltyDraws: number;
   deckLeftCount: number;
   deckRightCount: number;
+  discardPileCount: number;
   roundNumber: number;
   winnerId: string | null;
   pendingDrawPlayerId: string | null;
@@ -65,6 +66,7 @@ export const useGameStore = create<GameState>((set) => ({
   pendingPenaltyDraws: 0,
   deckLeftCount: 0,
   deckRightCount: 0,
+  discardPileCount: 0,
   roundNumber: 0,
   winnerId: null,
   pendingDrawPlayerId: null,
@@ -118,6 +120,7 @@ export const useGameStore = create<GameState>((set) => ({
         pendingPenaltyDraws: view.pendingPenaltyDraws ?? 0,
         deckLeftCount: view.deckLeftCount,
         deckRightCount: view.deckRightCount,
+        discardPileCount: view.discardPileCount ?? view.discardPile.length,
         roundNumber: view.roundNumber,
         winnerId: view.winnerId,
         pendingDrawPlayerId: view.pendingDrawPlayerId,
@@ -151,6 +154,7 @@ export const useGameStore = create<GameState>((set) => ({
       pendingPenaltyDraws: 0,
       deckLeftCount: 0,
       deckRightCount: 0,
+      discardPileCount: 0,
       roundNumber: 0,
       winnerId: null,
       pendingDrawPlayerId: null,

--- a/packages/server/src/plugins/core/game/session.ts
+++ b/packages/server/src/plugins/core/game/session.ts
@@ -55,8 +55,12 @@ export class GameSession {
     return this.state;
   }
 
+  private static readonly DISCARD_TRUNCATE = 10;
+
   private buildPlayerViews(viewerId: string, shouldReveal: (playerId: string) => boolean): PlayerView {
     const threshold = this.state.settings.houseRules.handRevealThreshold;
+    const fullPile = this.state.discardPile;
+    const truncated = fullPile.length > GameSession.DISCARD_TRUNCATE;
     return {
       viewerId,
       phase: this.state.phase,
@@ -84,7 +88,7 @@ export class GameSession {
       }),
       currentPlayerIndex: this.state.currentPlayerIndex,
       direction: this.state.direction,
-      discardPile: this.state.discardPile,
+      discardPile: truncated ? fullPile.slice(-GameSession.DISCARD_TRUNCATE) : fullPile,
       currentColor: this.state.currentColor,
       drawStack: this.state.drawStack,
       pendingPenaltyDraws: this.state.pendingPenaltyDraws ?? 0,
@@ -95,6 +99,7 @@ export class GameSession {
       settings: this.state.settings,
       pendingDrawPlayerId: this.state.pendingDrawPlayerId,
       lastAction: this.state.lastAction,
+      ...(truncated ? { discardPileCount: fullPile.length } : {}),
     };
   }
 

--- a/packages/server/src/ws/room-events.ts
+++ b/packages/server/src/ws/room-events.ts
@@ -504,7 +504,6 @@ export function startTurnTimer(
       }
       await executeAutopilot(s, pid, async () => {
         persister.markDirty(code, s.getFullState());
-        await emitGameUpdate(io, code, s, redis);
       }, (action) => notifyAutopilotAction(code, s, action));
       persister.markDirty(code, s.getFullState());
       await emitGameUpdate(io, code, s, redis);
@@ -526,7 +525,6 @@ export function startTurnTimer(
       }
       await executeAutopilot(s, pid, async () => {
         persister.markDirty(code, s.getFullState());
-        await emitGameUpdate(io, code, s, redis);
       }, (action) => notifyAutopilotAction(code, s, action));
       persister.markDirty(code, s.getFullState());
       await emitGameUpdate(io, code, s, redis);
@@ -549,7 +547,6 @@ export function startTurnTimer(
       }
       await executeAutopilot(s, pid, async () => {
         persister.markDirty(code, s.getFullState());
-        await emitGameUpdate(io, code, s, redis);
       }, (action) => notifyAutopilotAction(code, s, action));
       persister.markDirty(code, s.getFullState());
       await emitGameUpdate(io, code, s, redis);
@@ -577,7 +574,6 @@ export function startTurnTimer(
     }
     await executeAutopilot(s, pid, async () => {
       persister.markDirty(code, s.getFullState());
-      await emitGameUpdate(io, code, s, redis);
     }, (action) => notifyAutopilotAction(code, s, action));
     persister.markDirty(code, s.getFullState());
     await emitGameUpdate(io, code, s, redis);

--- a/packages/server/src/ws/socket-handler.ts
+++ b/packages/server/src/ws/socket-handler.ts
@@ -101,7 +101,6 @@ export function setupSocketHandlers(
 
       const acted = await executeAutopilot(session, userId, async () => {
         persister.markDirty(roomCode, session.getFullState());
-        await emitGameUpdate(io, roomCode, session, redis);
       }, (action) => notifyAutopilotAction(roomCode, session, action));
 
       if (acted) {
@@ -323,7 +322,6 @@ export function setupSocketHandlers(
 
       const acted = await executeAutopilot(session, userId, async () => {
         persister.markDirty(roomCode, session.getFullState());
-        await emitGameUpdate(io, roomCode, session, redis);
       }, (action) => notifyAutopilotAction(roomCode, session, action));
 
       if (acted) {

--- a/packages/shared/src/types/player-view.ts
+++ b/packages/shared/src/types/player-view.ts
@@ -37,4 +37,5 @@ export interface PlayerView {
   pendingDrawPlayerId: string | null;
   lastAction: GameState['lastAction'];
   deckHash?: string;
+  discardPileCount?: number;
 }


### PR DESCRIPTION
## Summary

- 移除 `executeAutopilot` 回调内的 `emitGameUpdate` 调用，每次 bot/autopilot 操作从 2-6 次全量广播降至 1 次
- `game:update` 事件的 `discardPile` 截断为最近 10 张（客户端仅渲染顶部 8 张），通过新增 `discardPileCount` 字段传递完整数量
- `game:state`（加入/重连时的全量同步）仍发送完整弃牌堆，不受影响

## Test plan

- [x] shared/server/client 类型检查通过
- [x] 全部 298 个测试通过
- [ ] 与 bot 对局验证响应速度提升
- [ ] 打 20+ 张牌后验证弃牌堆计数标签正确
- [ ] 中途重连验证完整状态恢复

🤖 Generated with [Claude Code](https://claude.com/claude-code)