### PR TITLE
perf(client): 减少不必要的 re-render + 方向指示器改用 CSS 动画

### DIFF
--- a/packages/client/src/features/game/components/GameTable.tsx
+++ b/packages/client/src/features/game/components/GameTable.tsx
@@ -288,25 +288,16 @@ export default function GameTable({ onDraw }: GameTableProps) {
           }}
         >
           {/* Direction indicator */}
-          <motion.div
+          <div
             key={direction}
-            className="absolute w-32 h-32 md:w-40 md:h-40 border-2 border-dashed border-primary/30 rounded-full flex items-center justify-center pointer-events-none"
-            animate={{ rotate: isClockwise ? 360 : -360 }}
-            transition={{ duration: 3, repeat: Infinity, ease: 'linear' }}
+            className={`absolute w-32 h-32 md:w-40 md:h-40 border-2 border-dashed border-primary/30 rounded-full flex items-center justify-center pointer-events-none ${isClockwise ? 'animate-spin-cw' : 'animate-spin-ccw'}`}
           >
-            <motion.span
-              className="text-direction text-primary/50"
-              initial={{ scale: 1.6, opacity: 0 }}
-              animate={{ scale: 1, opacity: 1, rotate: isClockwise ? -360 : 360 }}
-              transition={{
-                scale: { type: 'spring', stiffness: 300, damping: 15 },
-                opacity: { duration: 0.2 },
-                rotate: { duration: 3, repeat: Infinity, ease: 'linear' },
-              }}
+            <span
+              className={`text-direction text-primary/50 animate-fade-in ${isClockwise ? 'animate-spin-ccw' : 'animate-spin-cw'}`}
             >
               {isClockwise ? '↻' : '↺'}
-            </motion.span>
-          </motion.div>
+            </span>
+          </div>
 
           <DrawPile
             side="left"

--- a/packages/client/src/features/game/stores/game-store.ts
+++ b/packages/client/src/features/game/stores/game-store.ts
@@ -3,6 +3,24 @@ import type { Card, Color, GameAction, HouseRules, PlayerView, PlayerViewPlayer 
 
 export type PlayerInfo = PlayerViewPlayer;
 
+function shallowPlayersEqual(a: PlayerViewPlayer[], b: PlayerViewPlayer[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    const pa = a[i], pb = b[i];
+    if (pa.id !== pb.id || pa.handCount !== pb.handCount || pa.score !== pb.score ||
+        pa.connected !== pb.connected || pa.autopilot !== pb.autopilot ||
+        pa.calledUno !== pb.calledUno || pa.hand.length !== pb.hand.length ||
+        pa.eliminated !== pb.eliminated || pa.roundWins !== pb.roundWins) return false;
+  }
+  return true;
+}
+
+function shallowDiscardEqual(a: Card[], b: Card[]): boolean {
+  if (a.length !== b.length) return false;
+  if (a.length === 0) return true;
+  return a[a.length - 1].id === b[b.length - 1].id;
+}
+
 export type InfoDrawerTab = 'rules' | 'house-rules' | 'log' | 'chat';
 
 export interface NextRoundVoteState {
@@ -45,7 +63,7 @@ interface GameState {
   toggleInfoDrawer: () => void;
   openInfoDrawer: (tab?: InfoDrawerTab) => void;
   setInfoDrawerTab: (tab: InfoDrawerTab) => void;
-  setGameState: (view: PlayerView) => void;
+  setGameState: (view: PlayerView, turnEndTime?: number | null) => void;
   setNextRoundVote: (vote: NextRoundVoteState | null) => void;
   setRoundEndAt: (t: number | null) => void;
   setGameOverAt: (t: number | null) => void;
@@ -88,7 +106,7 @@ export const useGameStore = create<GameState>((set) => ({
   toggleInfoDrawer: () => set((state) => ({ infoDrawerOpen: !state.infoDrawerOpen })),
   openInfoDrawer: (tab = 'rules') => set({ infoDrawerOpen: true, infoDrawerTab: tab }),
   setInfoDrawerTab: (tab: InfoDrawerTab) => set({ infoDrawerTab: tab }),
-  setGameState: (view) =>
+  setGameState: (view, turnEndTime) =>
     set((state) => {
       const players = view.players;
       const viewerId = view.viewerId ?? state.viewerId;
@@ -111,10 +129,10 @@ export const useGameStore = create<GameState>((set) => ({
       return {
         phase,
         viewerId,
-        players,
+        players: shallowPlayersEqual(state.players, players) ? state.players : players,
         currentPlayerIndex,
         direction: view.direction,
-        discardPile: view.discardPile,
+        discardPile: shallowDiscardEqual(state.discardPile, view.discardPile) ? state.discardPile : view.discardPile,
         currentColor: view.currentColor,
         drawStack: view.drawStack,
         pendingPenaltyDraws: view.pendingPenaltyDraws ?? 0,
@@ -126,7 +144,7 @@ export const useGameStore = create<GameState>((set) => ({
         pendingDrawPlayerId: view.pendingDrawPlayerId,
         settings: view.settings,
         lastAction,
-        turnEndTime: phase === 'round_end' || phase === 'game_over' ? null : state.turnEndTime,
+        turnEndTime: turnEndTime !== undefined ? turnEndTime : state.turnEndTime,
         hasDrawnThisTurn,
         lastDrawnCard: hasDrawnThisTurn ? state.lastDrawnCard : null,
         deckHash: view.deckHash ?? state.deckHash,

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -714,3 +714,11 @@
   animation: cheat-flash 0.25s steps(1) forwards;
 }
 @keyframes cheat-flash{0%{background:#fff;opacity:1}12%{opacity:0}20%{background:#f0f;opacity:.4}28%{opacity:0}36%{background:#0ff;opacity:.3}44%{background:#fff;opacity:.7}52%{background:#f0f;opacity:.2}60%{opacity:0}100%{background:transparent;opacity:0}}
+
+/* Direction indicator — GPU-composited infinite rotation */
+@keyframes spin-cw { to { transform: rotate(360deg); } }
+@keyframes spin-ccw { to { transform: rotate(-360deg); } }
+@keyframes fade-in { from { opacity: 0; transform: scale(1.6); } to { opacity: 1; transform: scale(1); } }
+.animate-spin-cw { animation: spin-cw 3s linear infinite; }
+.animate-spin-ccw { animation: spin-ccw 3s linear infinite; }
+.animate-fade-in { animation: fade-in 0.3s ease-out; }

--- a/packages/client/src/shared/socket.ts
+++ b/packages/client/src/shared/socket.ts
@@ -62,16 +62,16 @@ export function getSocket(): TypedSocket {
     const handleGameView = (view: PlayerView) => {
       const prevPhase = useGameStore.getState().phase;
       const prevCurrentIndex = useGameStore.getState().currentPlayerIndex;
-      useGameStore.getState().setGameState(view);
+
       const settings = view.settings;
-      if (!settings || view.phase === 'round_end' || view.phase === 'game_over') {
-        useGameStore.getState().setTurnEndTime(null);
-      } else {
+      let turnEndTime: number | null = null;
+      if (settings && view.phase !== 'round_end' && view.phase !== 'game_over') {
         const timeLimit = settings.houseRules?.fastMode
           ? Math.floor(settings.turnTimeLimit / 2)
           : settings.turnTimeLimit;
-        useGameStore.getState().setTurnEndTime(Date.now() + timeLimit * 1000);
+        turnEndTime = Date.now() + timeLimit * 1000;
       }
+      useGameStore.getState().setGameState(view, turnEndTime);
 
       const viewerId = view.viewerId ?? useGameStore.getState().viewerId;
       const currentPlayerId = view.players[view.currentPlayerIndex]?.id;


### PR DESCRIPTION
## Summary

- 合并 `handleGameView` 中 `setGameState` + `setTurnEndTime` 两次独立 store 更新为一次，消除双重 re-render
- 添加 `shallowPlayersEqual` / `shallowDiscardEqual` 浅比较，内容未变时复用旧数组引用
- 方向指示器从 Framer Motion `repeat: Infinity`（主线程 rAF）改为 CSS `@keyframes`（GPU 合成器线程）

## Test plan

- [x] shared/server/client 类型检查通过
- [x] 全部 298 个测试通过
- [ ] 验证方向指示器动画视觉效果与之前一致
- [ ] React DevTools Profiler 验证 render 次数减少

🤖 Generated with [Claude Code](https://claude.com/claude-code)