### PR TITLE
feat(client): 服务器延迟改用 Socket.IO pong 实时获取

### DIFF
--- a/packages/client/src/app/App.tsx
+++ b/packages/client/src/app/App.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import AppRouter from './router';
 import ToastContainer from '@/shared/components/Toast';
 import ChangelogModal from '@/shared/components/ChangelogModal';
@@ -6,8 +7,14 @@ import ServerUpdateDialog from '@/shared/components/ServerUpdateDialog';
 import ProfileModal from '@/shared/components/ProfileModal';
 import ConfirmDialog from '@/shared/components/ConfirmDialog';
 import StartScreenOverlay from '@/shared/components/StartScreenOverlay';
+import { connectSocket } from '@/shared/socket';
 
 export default function App() {
+  useEffect(() => {
+    if (localStorage.getItem('token')) {
+      connectSocket();
+    }
+  }, []);
 
   return (
     <div className="flex min-h-svh flex-col font-game bg-background text-foreground">

--- a/packages/client/src/shared/components/ServerStatusBar.tsx
+++ b/packages/client/src/shared/components/ServerStatusBar.tsx
@@ -19,8 +19,6 @@ export default function ServerStatusBar() {
 
   useEffect(() => {
     refreshServerInfo(currentServerId);
-    const id = setInterval(() => refreshServerInfo(currentServerId), 30_000);
-    return () => clearInterval(id);
   }, [currentServerId, refreshServerInfo]);
 
   return (

--- a/packages/client/src/shared/socket.ts
+++ b/packages/client/src/shared/socket.ts
@@ -8,6 +8,7 @@ import { playSound } from './sound/sound-manager';
 import { useGatewayStore, type PlayerVoicePresence } from './voice/gateway-store';
 import { sendNotification } from './utils/notification';
 import { useServerVersionStore } from './stores/server-version-store';
+import { useServerStore } from './stores/server-store';
 import { setServerTimeOffset } from './server-time';
 import { useSpectatorStore } from '@/features/game/stores/spectator-store';
 import { resetClientRoomState } from './stores/reset-room';
@@ -190,10 +191,14 @@ export function getSocket(): TypedSocket {
 
     socket.on('connect', () => {
       connectionStatusCallback?.('connected');
+      (socket!.io.engine as any)?.on('pong', (latency: number) => {
+        useServerStore.getState().setSocketLatency(latency);
+      });
     });
 
     socket.on('disconnect', () => {
       connectionStatusCallback?.('disconnected');
+      useServerStore.getState().setSocketLatency(null);
     });
 
     socket.io.on('reconnect_attempt', () => {

--- a/packages/client/src/shared/stores/server-store.ts
+++ b/packages/client/src/shared/stores/server-store.ts
@@ -57,18 +57,14 @@ async function fetchServerInfo(address: string): Promise<ServerInfo | null> {
 
 async function measureLatency(address: string): Promise<number | null> {
   const base = buildServerUrl(address);
-  const times: number[] = [];
-  for (let i = 0; i < 3; i++) {
-    const start = performance.now();
-    try {
-      const res = await fetch(`${base}/api/server/info`, { cache: 'no-store' });
-      if (!res.ok) return null;
-      times.push(performance.now() - start);
-    } catch {
-      return null;
-    }
+  const start = performance.now();
+  try {
+    const res = await fetch(`${base}/api/server/info`, { cache: 'no-store' });
+    if (!res.ok) return null;
+    return Math.round(performance.now() - start);
+  } catch {
+    return null;
   }
-  return Math.round(times.reduce((a, b) => a + b, 0) / times.length);
 }
 
 interface ServerState {
@@ -81,6 +77,7 @@ interface ServerState {
   addServer: (address: string) => Promise<ServerInfo | null>;
   removeServer: (id: string) => void;
   selectServer: (id: string) => void;
+  setSocketLatency: (latency: number | null) => void;
   refreshServerInfo: (id: string) => Promise<void>;
   refreshAll: () => Promise<void>;
   openModal: () => void;
@@ -133,20 +130,24 @@ export const useServerStore = create<ServerState>((set, get) => ({
     saveCurrentServerId(id);
   },
 
+  setSocketLatency: (latency: number | null) => {
+    const { currentServerId } = get();
+    set({ latencyMap: { ...get().latencyMap, [currentServerId]: latency } });
+  },
+
   refreshServerInfo: async (id: string) => {
     const { servers } = get();
     const server = servers.find(s => s.id === id);
     if (!server) return;
 
-    const [info, latency] = await Promise.all([
-      fetchServerInfo(server.address),
-      measureLatency(server.address),
-    ]);
-
-    set({
+    const info = await fetchServerInfo(server.address);
+    const update: Partial<ServerState> = {
       serverInfoMap: { ...get().serverInfoMap, [id]: info },
-      latencyMap: { ...get().latencyMap, [id]: latency },
-    });
+    };
+    if (!server.isDefault) {
+      update.latencyMap = { ...get().latencyMap, [id]: await measureLatency(server.address) };
+    }
+    set(update);
   },
 
   refreshAll: async () => {


### PR DESCRIPTION
## Summary

- 服务器延迟从 HTTP 轮询（每 30s 发 4 个请求取平均）改为 Socket.IO Engine `pong` 事件，跟随心跳自动更新
- App 挂载时已登录用户自动连接 socket，延迟立即可用
- 断连时延迟显示 `--`，重连后自动恢复
- 服务端重启时 socket 自动重连，`server:version` 事件可检测服务器更新
- 非当前连接的自定义服务器仍用 HTTP 测量

## Test plan

- [x] 类型检查通过
- [x] 298 个测试通过
- [ ] 进入首页验证延迟数值自动显示和更新
- [ ] 断网恢复后验证延迟自动恢复

🤖 Generated with [Claude Code](https://claude.com/claude-code)