### PR TITLE
fix(client): 未登录时延迟回退到 HTTP 测量

### DIFF
--- a/packages/client/src/shared/stores/server-store.ts
+++ b/packages/client/src/shared/stores/server-store.ts
@@ -146,6 +146,8 @@ export const useServerStore = create<ServerState>((set, get) => ({
     };
     if (!server.isDefault) {
       update.latencyMap = { ...get().latencyMap, [id]: await measureLatency(server.address) };
+    } else if (get().latencyMap[id] == null) {
+      update.latencyMap = { ...get().latencyMap, [id]: await measureLatency(server.address) };
     }
     set(update);
   },


### PR DESCRIPTION
## Summary

- 未登录或 socket 未连接时，对当前服务器用一次 HTTP 请求测量延迟
- socket 连接后由 pong 事件自动接管，不再重复 HTTP 测量

🤖 Generated with [Claude Code](https://claude.com/claude-code)