### PR TITLE
feat: 大厅房间列表改为 Socket.IO 实时推送

### DIFF
--- a/packages/client/src/features/lobby/pages/LobbyPage.tsx
+++ b/packages/client/src/features/lobby/pages/LobbyPage.tsx
@@ -24,7 +24,7 @@ export default function LobbyPage() {
   const [joinCode, setJoinCode] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
-  const { activeRooms, fetchActiveRooms } = useLobbyStore();
+  const activeRooms = useLobbyStore((s) => s.activeRooms);
   const songName = useBgm('lobby');
   const [musicHall, setMusicHall] = useState(false);
   const [showTutorial, setShowTutorial] = useState(false);
@@ -52,12 +52,6 @@ export default function LobbyPage() {
       cancelled = true;
       socket.off('connect', checkRoom);
     };
-  }, []);
-
-  useEffect(() => {
-    fetchActiveRooms();
-    const interval = setInterval(fetchActiveRooms, 30_000);
-    return () => clearInterval(interval);
   }, []);
 
   const handleCreate = () => {
@@ -277,7 +271,6 @@ export default function LobbyPage() {
                     if (res.success) navigate(`/game/${room.roomCode}?spectate=true`);
                     else {
                       setError(res.error || '无法观战');
-                      fetchActiveRooms();
                     }
                   });
                 }}

--- a/packages/client/src/features/lobby/stores/lobby-store.ts
+++ b/packages/client/src/features/lobby/stores/lobby-store.ts
@@ -1,33 +1,12 @@
 import { create } from 'zustand';
-import { apiGet } from '@/shared/api';
-
-interface ActiveRoom {
-  roomCode: string;
-  players: { nickname: string; avatarUrl?: string | null }[];
-  playerCount: number;
-  startedAt: string;
-  spectatorCount: number;
-  spectatorMode: 'full' | 'hidden';
-}
+import type { ActiveRoomInfo } from '@uno-online/shared';
 
 interface LobbyState {
-  activeRooms: ActiveRoom[];
-  loadingRooms: boolean;
-  fetchActiveRooms: () => Promise<void>;
+  activeRooms: ActiveRoomInfo[];
+  setActiveRooms: (rooms: ActiveRoomInfo[]) => void;
 }
 
 export const useLobbyStore = create<LobbyState>((set) => ({
   activeRooms: [],
-  loadingRooms: false,
-  fetchActiveRooms: async () => {
-    set({ loadingRooms: true });
-    try {
-      const rooms = await apiGet<ActiveRoom[]>('/rooms/active');
-      set({ activeRooms: rooms });
-    } catch {
-      set({ activeRooms: [] });
-    } finally {
-      set({ loadingRooms: false });
-    }
-  },
+  setActiveRooms: (rooms) => set({ activeRooms: rooms }),
 }));

--- a/packages/client/src/shared/socket.ts
+++ b/packages/client/src/shared/socket.ts
@@ -11,6 +11,7 @@ import { useServerVersionStore } from './stores/server-version-store';
 import { useServerStore } from './stores/server-store';
 import { setServerTimeOffset } from './server-time';
 import { useSpectatorStore } from '@/features/game/stores/spectator-store';
+import { useLobbyStore } from '@/features/lobby/stores/lobby-store';
 import { resetClientRoomState } from './stores/reset-room';
 
 type TypedSocket = SocketType<ServerToClientEvents, ClientToServerEvents>;
@@ -187,6 +188,10 @@ export function getSocket(): TypedSocket {
     socket.on('server:version', (data) => {
       useServerVersionStore.getState().setVersion(data.version);
       if (data.serverTime) setServerTimeOffset(data.serverTime);
+    });
+
+    socket.on('lobby:rooms', (rooms) => {
+      useLobbyStore.getState().setActiveRooms(rooms);
     });
 
     socket.on('connect', () => {

--- a/packages/server/src/plugins/core/spectate/routes.ts
+++ b/packages/server/src/plugins/core/spectate/routes.ts
@@ -1,40 +1,58 @@
 import type { FastifyInstance } from 'fastify';
+import type { Server as SocketIOServer } from 'socket.io';
+import type { ActiveRoomInfo } from '@uno-online/shared';
 import type { PluginContext } from '../../../plugin-context.js';
+import type { KvStore } from '../../../kv/types.js';
 import { authPreHandler } from '../auth/service.js';
 import { getRoom, getRoomPlayers } from '../room/store.js';
+
+export async function getActiveRooms(kv: KvStore, io: SocketIOServer): Promise<ActiveRoomInfo[]> {
+  const allKeys = await kv.keys('room:*');
+  const roomKeys = allKeys.filter(k => !k.includes(':players') && !k.includes(':state'));
+
+  const activeRooms: ActiveRoomInfo[] = [];
+  for (const key of roomKeys) {
+    const roomCode = key.replace('room:', '');
+    const room = await getRoom(kv, roomCode);
+    if (!room || room.status !== 'playing') continue;
+
+    const settings = room.settings;
+    if (!settings.allowSpectators) continue;
+
+    const players = await getRoomPlayers(kv, roomCode);
+    if (players.length === 0) continue;
+
+    const spectatorSockets = await io.in(roomCode).fetchSockets();
+    const spectatorCount = spectatorSockets.filter(s => (s.data as { isSpectator?: boolean }).isSpectator).length;
+
+    activeRooms.push({
+      roomCode,
+      players: players.map(p => ({ nickname: p.nickname, avatarUrl: p.avatarUrl })),
+      playerCount: players.length,
+      startedAt: room.createdAt,
+      spectatorCount,
+      spectatorMode: settings.spectatorMode,
+    });
+  }
+
+  return activeRooms;
+}
+
+export async function broadcastLobbyRooms(kv: KvStore, io: SocketIOServer): Promise<void> {
+  const rooms = await getActiveRooms(kv, io);
+  const sockets = await io.fetchSockets();
+  for (const s of sockets) {
+    const data = s.data as { roomCode?: string };
+    if (!data.roomCode) {
+      s.emit('lobby:rooms', rooms);
+    }
+  }
+}
 
 export async function registerRoutes(fastify: FastifyInstance, ctx: PluginContext) {
   const preHandler = authPreHandler(ctx.config.jwtSecret);
 
   fastify.get('/rooms/active', { preHandler }, async () => {
-    const allKeys = await ctx.kv.keys('room:*');
-    const roomKeys = allKeys.filter(k => !k.includes(':players') && !k.includes(':state'));
-
-    const activeRooms = [];
-    for (const key of roomKeys) {
-      const roomCode = key.replace('room:', '');
-      const room = await getRoom(ctx.kv, roomCode);
-      if (!room || room.status !== 'playing') continue;
-
-      const settings = room.settings;
-      if (!settings.allowSpectators) continue;
-
-      const players = await getRoomPlayers(ctx.kv, roomCode);
-      if (players.length === 0) continue;
-
-      const spectatorSockets = await ctx.io.in(roomCode).fetchSockets();
-      const spectatorCount = spectatorSockets.filter(s => (s.data as { isSpectator?: boolean }).isSpectator).length;
-
-      activeRooms.push({
-        roomCode,
-        players: players.map(p => ({ nickname: p.nickname, avatarUrl: p.avatarUrl })),
-        playerCount: players.length,
-        startedAt: room.createdAt,
-        spectatorCount,
-        spectatorMode: settings.spectatorMode,
-      });
-    }
-
-    return activeRooms;
+    return getActiveRooms(ctx.kv, ctx.io);
   });
 }

--- a/packages/server/src/ws/game-events.ts
+++ b/packages/server/src/ws/game-events.ts
@@ -9,6 +9,7 @@ import type { TurnTimer } from '../plugins/core/game/turn-timer.js';
 import { getRoom, getRoomPlayers, setRoomStatus, touchRoomActivity, removePlayerFromRoom, addPlayerToRoom, resetAllPlayersReady, setUserRoom, setPlayerSpectator } from '../plugins/core/room/store.js';
 import { MAX_PLAYERS } from '@uno-online/shared';
 import { addSpectator, removeSpectator, clearRoomSpectators, broadcastSpectatorList } from '../plugins/core/spectate/ws.js';
+import { broadcastLobbyRooms } from '../plugins/core/spectate/routes.js';
 import type { SocketData } from './types.js';
 
 function getSession(socket: Socket, sessions: Map<string, GameSession>): { session: GameSession; roomCode: string } | null {
@@ -820,6 +821,7 @@ export function registerGameEvents(
     io.to(roomCode).emit('game:back_to_room', { players, room: updatedRoom });
     io.to(roomCode).emit('chat:cleared');
     broadcastSpectatorList(io, roomCode);
+    broadcastLobbyRooms(redis, io);
     callback?.({ success: true });
   });
 }

--- a/packages/server/src/ws/room-events.ts
+++ b/packages/server/src/ws/room-events.ts
@@ -13,6 +13,7 @@ import { removePlayerVote } from './game-events.js';
 import type { SocketData } from './types.js';
 import { dissolveRoom } from './room-lifecycle.js';
 import { removeVoicePresence, setForceMuted } from './voice-presence.js';
+import { broadcastLobbyRooms } from '../plugins/core/spectate/routes.js';
 import { getAutopilotActionPlayerId } from './autopilot-action-player.js';
 import { addSpectator, broadcastSpectatorLeft } from '../plugins/core/spectate/ws.js';
 
@@ -430,6 +431,7 @@ export function registerRoomEvents(
     }
 
     callback?.({ success: true, gameState: session.getPlayerView(data.user.userId) });
+    broadcastLobbyRooms(redis, io);
   });
 }
 

--- a/packages/server/src/ws/room-lifecycle.ts
+++ b/packages/server/src/ws/room-lifecycle.ts
@@ -10,6 +10,7 @@ import { clearPendingSpectatorJoins } from './game-events.js';
 import { leaveRoomSocket } from './socket-room.js';
 import { clearVoicePresence } from './voice-presence.js';
 import { clearRoomSpectators } from '../plugins/core/spectate/ws.js';
+import { broadcastLobbyRooms } from '../plugins/core/spectate/routes.js';
 
 export async function dissolveRoom(
   io: SocketIOServer,
@@ -49,4 +50,6 @@ export async function dissolveRoom(
     voiceChannels?.deleteRoomChannel(roomCode),
     deleteRoom(kv, roomCode),
   ]);
+
+  broadcastLobbyRooms(kv, io);
 }

--- a/packages/server/src/ws/socket-handler.ts
+++ b/packages/server/src/ws/socket-handler.ts
@@ -10,6 +10,7 @@ import { registerGameEvents, addAutopilotVote, clearChatTimestamps, getRoundEndV
 import { getRoom, getRoomPlayers, setRoomOwner, clearUserRoom, getUserRoom } from '../plugins/core/room/store.js';
 import { joinRoomSocket, leaveRoomSocket } from './socket-room.js';
 import { loadGameState, GameStatePersister } from '../plugins/core/game/state-store.js';
+import { getActiveRooms } from '../plugins/core/spectate/routes.js';
 import { checkRateLimit, clearRateLimit } from './rate-limiter.js';
 import { registerInteractionEvents, clearThrowTimestamp } from '../plugins/core/interaction/ws.js';
 import { setupSpectateHandlers, getSpectatorNames, addSpectator, broadcastSpectatorList } from '../plugins/core/spectate/ws.js';
@@ -161,6 +162,10 @@ export function setupSocketHandlers(
     const userId = socket.data.user.userId;
 
     socket.emit('server:version', { version: serverStartTime, serverTime: Date.now() });
+
+    if (!socket.data.roomCode) {
+      getActiveRooms(redis, io).then(rooms => socket.emit('lobby:rooms', rooms));
+    }
 
     // Multi-tab: kick existing connection for same user
     const existingSocketId = userSocketMap.get(userId);

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -6,4 +6,4 @@ export * from './server.js';
 export * from './event.js';
 export * from './chat.js';
 export type { PlayerView, PlayerViewPlayer } from './player-view.js';
-export type { ServerToClientEvents, ClientToServerEvents, SocketCallbackResult } from './socket-events.js';
+export type { ServerToClientEvents, ClientToServerEvents, SocketCallbackResult, ActiveRoomInfo } from './socket-events.js';

--- a/packages/shared/src/types/socket-events.ts
+++ b/packages/shared/src/types/socket-events.ts
@@ -22,7 +22,17 @@ export interface RoomJoinResult extends SocketCallbackResult {
   voiceChannelId?: number | null;
 }
 
+export interface ActiveRoomInfo {
+  roomCode: string;
+  players: { nickname: string; avatarUrl?: string | null }[];
+  playerCount: number;
+  startedAt: string;
+  spectatorCount: number;
+  spectatorMode: 'full' | 'hidden';
+}
+
 export interface ServerToClientEvents {
+  'lobby:rooms': (rooms: ActiveRoomInfo[]) => void;
   'game:state': (view: PlayerView) => void;
   'game:update': (view: PlayerView) => void;
   'game:card_drawn': (data: { card: Card }) => void;


### PR DESCRIPTION
## Summary

- 新增 `lobby:rooms` Socket.IO 事件，服务端在房间状态变更时主动推送活跃房间列表
- 客户端移除 30s HTTP 轮询 `/api/rooms/active`，房间变动实时反映
- 用户连接时立即推送一次当前列表
- 触发时机：游戏开始、游戏结束返回房间、房间解散
- HTTP `/api/rooms/active` 接口保留（复用提取的公共函数）

## Test plan

- [x] 类型检查通过
- [x] 298 个测试通过
- [ ] 大厅页面验证房间列表实时更新
- [ ] 创建/结束游戏后验证其他大厅用户立即看到变化

🤖 Generated with [Claude Code](https://claude.com/claude-code)