### PR TITLE
refactor(server): 移除 /api/rooms/active HTTP 接口

### DIFF
--- a/packages/server/src/plugins/core/spectate/routes.ts
+++ b/packages/server/src/plugins/core/spectate/routes.ts
@@ -3,7 +3,6 @@ import type { Server as SocketIOServer } from 'socket.io';
 import type { ActiveRoomInfo } from '@uno-online/shared';
 import type { PluginContext } from '../../../plugin-context.js';
 import type { KvStore } from '../../../kv/types.js';
-import { authPreHandler } from '../auth/service.js';
 import { getRoom, getRoomPlayers } from '../room/store.js';
 
 export async function getActiveRooms(kv: KvStore, io: SocketIOServer): Promise<ActiveRoomInfo[]> {
@@ -49,10 +48,5 @@ export async function broadcastLobbyRooms(kv: KvStore, io: SocketIOServer): Prom
   }
 }
 
-export async function registerRoutes(fastify: FastifyInstance, ctx: PluginContext) {
-  const preHandler = authPreHandler(ctx.config.jwtSecret);
-
-  fastify.get('/rooms/active', { preHandler }, async () => {
-    return getActiveRooms(ctx.kv, ctx.io);
-  });
+export async function registerRoutes(_fastify: FastifyInstance, _ctx: PluginContext) {
 }


### PR DESCRIPTION
## Summary

- 移除 `/api/rooms/active` HTTP 接口，大厅房间列表完全由 `lobby:rooms` socket 事件推送
- `getActiveRooms` / `broadcastLobbyRooms` 公共函数保留

🤖 Generated with [Claude Code](https://claude.com/claude-code)