### PR TITLE
fix: 延迟测量改为自定义 ping/ack 往返

### DIFF
--- a/packages/client/src/shared/socket.ts
+++ b/packages/client/src/shared/socket.ts
@@ -196,8 +196,11 @@ export function getSocket(): TypedSocket {
 
     socket.on('connect', () => {
       connectionStatusCallback?.('connected');
-      (socket!.io.engine as any)?.on('pong', (latency: number) => {
-        useServerStore.getState().setSocketLatency(latency);
+      (socket!.io.engine as any)?.on('ping', () => {
+        const start = performance.now();
+        socket!.volatile.emit('ping:latency', () => {
+          useServerStore.getState().setSocketLatency(Math.round(performance.now() - start));
+        });
       });
     });
 

--- a/packages/server/src/ws/socket-handler.ts
+++ b/packages/server/src/ws/socket-handler.ts
@@ -163,6 +163,8 @@ export function setupSocketHandlers(
 
     socket.emit('server:version', { version: serverStartTime, serverTime: Date.now() });
 
+    socket.on('ping:latency', (callback) => callback());
+
     if (!socket.data.roomCode) {
       getActiveRooms(redis, io).then(rooms => socket.emit('lobby:rooms', rooms));
     }

--- a/packages/shared/src/types/socket-events.ts
+++ b/packages/shared/src/types/socket-events.ts
@@ -100,4 +100,5 @@ export interface ClientToServerEvents {
   'game:leave_to_spectate': (callback?: (res: SocketCallbackResult) => void) => void;
   'game:autopilot_once': (callback?: (res: SocketCallbackResult) => void) => void;
   'user:current_room': (callback: (res: { roomCode: string | null }) => void) => void;
+  'ping:latency': (callback: () => void) => void;
 }


### PR DESCRIPTION
## Summary

- Engine.IO v6 的 `pong` 事件不带 latency 参数，之前的方案测不到延迟
- 改为每次收到 Engine.IO `ping` 时发送 `ping:latency` 事件，服务端立即回调
- 用 `performance.now()` 测量真实 Socket.IO 往返延迟
- 使用 `volatile` 发送，网络抖动时不堆积

🤖 Generated with [Claude Code](https://claude.com/claude-code)