### PR TITLE
fix(client): 延迟测量改为 10 秒定时器

### DIFF
--- a/packages/client/src/shared/socket.ts
+++ b/packages/client/src/shared/socket.ts
@@ -194,19 +194,24 @@ export function getSocket(): TypedSocket {
       useLobbyStore.getState().setActiveRooms(rooms);
     });
 
+    let latencyInterval: ReturnType<typeof setInterval> | null = null;
+    const measureLatency = () => {
+      const start = performance.now();
+      socket!.volatile.emit('ping:latency', () => {
+        useServerStore.getState().setSocketLatency(Math.round(performance.now() - start));
+      });
+    };
+
     socket.on('connect', () => {
       connectionStatusCallback?.('connected');
-      (socket!.io.engine as any)?.on('ping', () => {
-        const start = performance.now();
-        socket!.volatile.emit('ping:latency', () => {
-          useServerStore.getState().setSocketLatency(Math.round(performance.now() - start));
-        });
-      });
+      measureLatency();
+      latencyInterval = setInterval(measureLatency, 10_000);
     });
 
     socket.on('disconnect', () => {
       connectionStatusCallback?.('disconnected');
       useServerStore.getState().setSocketLatency(null);
+      if (latencyInterval) { clearInterval(latencyInterval); latencyInterval = null; }
     });
 
     socket.io.on('reconnect_attempt', () => {


### PR DESCRIPTION
## Summary

- Engine.IO `ping` 事件在当前版本不触发，改为 `setInterval` 每 10 秒测量一次
- 连接成功时立即测一次，不用等首个周期
- 断连时清除定时器并重置延迟为 `--`
- 使用 `volatile` 发送，不堆积

🤖 Generated with [Claude Code](https://claude.com/claude-code)