### PR TITLE
fix(client): 延迟测量间隔从 10 秒改为 30 秒

### DIFF
--- a/packages/client/src/shared/socket.ts
+++ b/packages/client/src/shared/socket.ts
@@ -205,7 +205,7 @@ export function getSocket(): TypedSocket {
     socket.on('connect', () => {
       connectionStatusCallback?.('connected');
       measureLatency();
-      latencyInterval = setInterval(measureLatency, 10_000);
+      latencyInterval = setInterval(measureLatency, 30_000);
     });
 
     socket.on('disconnect', () => {


### PR DESCRIPTION
## Summary
- 延迟测量间隔从 10 秒改为 30 秒，减少不必要的网络开销

## Test plan
- [ ] 验证连接时立即测量一次延迟
- [ ] 验证之后每 30 秒测量一次

🤖 Generated with [Claude Code](https://claude.com/claude-code)