### PR TITLE
fix(server): Bot 摸牌改为快速模式

### DIFF
--- a/packages/server/src/ws/room-events.ts
+++ b/packages/server/src/ws/room-events.ts
@@ -586,7 +586,20 @@ export function startTurnTimer(
     const playableCount = (state.phase === 'playing' && topCard && state.currentColor)
       ? getPlayableCards(actingPlayer.hand, topCard, state.currentColor).length
       : 0;
-    const delayMs = calculateBotDelay(difficulty, playableCount);
+
+    // Fast draw: skip the full thinking delay when the bot has no decision to
+    // make and will just draw a card (penalty draws, draw-until-playable loop,
+    // or no playable cards at all).
+    const hr = state.settings.houseRules;
+    const isPenaltyDraw = (state.pendingPenaltyDraws ?? 0) > 0;
+    const isDrawLoop = state.phase === 'playing'
+      && playableCount === 0
+      && state.lastAction?.type === 'DRAW_CARD'
+      && state.lastAction.playerId === actingPlayerId
+      && (hr.drawUntilPlayable || hr.deathDraw);
+    const delayMs = (isPenaltyDraw || isDrawLoop)
+      ? 250 + Math.random() * 250
+      : calculateBotDelay(difficulty, playableCount);
 
     turnTimer.stop(roomCode);
     clearBotTurnTimer(roomCode);


### PR DESCRIPTION
## Summary

- Bot 罚牌摸牌 (`pendingPenaltyDraws`) 和循环摸牌 (`drawUntilPlayable`/`deathDraw`) 时，从完整思考延迟 (800-3500ms) 改为 250-500ms 快速摸牌
- 仅跳过无决策的摸牌延迟，Bot 出牌决策仍保持正常思考时间

## Test plan

- [x] 服务端类型检查通过
- [x] 服务端 58 测试全部通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)