### PR TITLE
fix: Bot 回合结束阶段自动投票并支持直接移除

### DIFF
--- a/packages/client/src/features/game/components/ScoreBoard.tsx
+++ b/packages/client/src/features/game/components/ScoreBoard.tsx
@@ -191,7 +191,12 @@ export default function ScoreBoard({ isSpectator = false, onPlayAgain, onBackToR
                   </td>
                   {!isGameOver && (
                     <td className="px-2 py-1.5 text-center whitespace-nowrap">
-                      {ready
+                      {p.isBot ? (
+                        <span className="inline-flex items-center gap-1">
+                          <Check size={14} className="inline text-green-400" />
+                          {isHost && <button onClick={() => onKickPlayer(p.id)} className="text-destructive hover:text-destructive/80 cursor-pointer bg-transparent border-none" title="移除机器人"><UserX size={14} className="inline" /></button>}
+                        </span>
+                      ) : ready
                         ? <Check size={14} className="inline text-green-400" />
                         : isSpectator
                           ? <span className="text-xs text-muted-foreground">等待中</span>

--- a/packages/server/src/plugins/core/room/manager.ts
+++ b/packages/server/src/plugins/core/room/manager.ts
@@ -47,13 +47,16 @@ export class RoomManager {
   async leaveRoom(roomCode: string, userId: string): Promise<{ deleted: boolean }> {
     await removePlayerFromRoom(this.redis, roomCode, userId);
     const players = await getRoomPlayers(this.redis, roomCode);
-    if (players.length === 0) {
+    if (players.length === 0 || players.every(p => p.isBot)) {
+      for (const bot of players) {
+        await removePlayerFromRoom(this.redis, roomCode, bot.userId);
+      }
       await deleteRoom(this.redis, roomCode);
       return { deleted: true };
     }
     const room = await getRoom(this.redis, roomCode);
     if (room && room.ownerId === userId) {
-      const nextOwner = players.find((p) => !p.isBot) ?? players[0]!;
+      const nextOwner = players.find((p) => !p.isBot)!;
       await setRoomOwner(this.redis, roomCode, nextOwner.userId);
     }
     return { deleted: false };

--- a/packages/server/src/ws/game-events.ts
+++ b/packages/server/src/ws/game-events.ts
@@ -338,10 +338,12 @@ export async function emitTerminalStateIfNeeded(
   if (state.phase === 'round_end') {
     nextRoundVotes.delete(roomCode);
 
-    const connectedAutopilotIds = state.players.filter((p) => p.autopilot && p.connected).map((p) => p.id);
-    if (connectedAutopilotIds.length > 0) {
+    const autoVoteIds = state.players
+      .filter((p) => (p.autopilot && p.connected) || p.isBot)
+      .map((p) => p.id);
+    if (autoVoteIds.length > 0) {
       const votes = nextRoundVotes.get(roomCode) ?? new Set<string>();
-      for (const id of connectedAutopilotIds) votes.add(id);
+      for (const id of autoVoteIds) votes.add(id);
       nextRoundVotes.set(roomCode, votes);
     }
 
@@ -694,28 +696,32 @@ export function registerGameEvents(
       return callback?.({ success: false, error: '不能踢自己' });
     }
 
-    const voters = nextRoundVotes.get(roomCode) ?? new Set<string>();
-    if (voters.has(targetId)) {
-      return callback?.({ success: false, error: '该玩家已准备，无法踢出' });
-    }
-
     const state = session.getFullState();
-    if (!state.players.some((p) => p.id === targetId)) {
+    const targetPlayer = state.players.find((p) => p.id === targetId);
+    if (!targetPlayer) {
       return callback?.({ success: false, error: '玩家不在游戏中' });
     }
 
-    const targetPlayer = state.players.find((p) => p.id === targetId);
+    const voters = nextRoundVotes.get(roomCode) ?? new Set<string>();
+    // Bots can always be removed; human players cannot be kicked after voting
+    if (!targetPlayer.isBot && voters.has(targetId)) {
+      return callback?.({ success: false, error: '该玩家已准备，无法踢出' });
+    }
+
     session.removePlayer(targetId);
     await removePlayerFromRoom(redis, roomCode, targetId);
 
-    const targetSockets = await io.in(roomCode).fetchSockets();
-    for (const s of targetSockets) {
-      if ((s.data as SocketData).user.userId === targetId) {
-        (s.data as SocketData).isSpectator = true;
-        s.emit('game:kicked', { reason: '你已被房主移至观战席', toSpectator: true });
+    // Bots are fully removed; human players become spectators
+    if (!targetPlayer.isBot) {
+      const targetSockets = await io.in(roomCode).fetchSockets();
+      for (const s of targetSockets) {
+        if ((s.data as SocketData).user.userId === targetId) {
+          (s.data as SocketData).isSpectator = true;
+          s.emit('game:kicked', { reason: '你已被房主移至观战席', toSpectator: true });
+        }
       }
+      addSpectator(roomCode, targetId, targetPlayer.name, targetPlayer.avatarUrl);
     }
-    if (targetPlayer) addSpectator(roomCode, targetId, targetPlayer.name, targetPlayer.avatarUrl);
 
     voters.delete(targetId);
     const voteState = getNextRoundVoteState(roomCode, session);

--- a/packages/server/src/ws/room-events.ts
+++ b/packages/server/src/ws/room-events.ts
@@ -156,13 +156,12 @@ export function registerRoomEvents(
       const room = await getRoom(redis, roomCode);
       if (room?.ownerId === userId) {
         const players = await getRoomPlayers(redis, roomCode);
-        const nextOwner = players.find(p => !p.isBot) ?? players[0];
+        const nextOwner = players.find(p => !p.isBot);
         if (nextOwner) {
           await setRoomOwner(redis, roomCode, nextOwner.userId);
           const updatedRoom = await getRoom(redis, roomCode);
           io.to(roomCode).emit('room:updated', { players, room: updatedRoom });
         } else {
-          // dissolveRoom's room:dissolved broadcast subsumes spectator_left.
           await leaveRoomSocket(redis, socket, roomCode);
           await dissolveRoom(io, redis, roomCode, sessions, turnTimer, persister, 'empty', voiceChannels);
           return callback?.({ success: true, dissolved: true });


### PR DESCRIPTION
## Summary

- Bot 在回合结束时自动投票下一轮，不再显示"等待中"
- 房主可在回合结束阶段直接移除 Bot（无需等 30s 倒计时，跳过已投票限制）
- Bot 被移除时直接删除，不转为观众
- 记分板中 Bot 显示已准备勾选 + 房主可见的移除按钮
- 同时适用于 AI Bot 和 MCP Bot（共享 `isBot` 标记）

## Test plan

- [x] 服务端类型检查通过
- [x] 客户端类型检查通过
- [x] 全部测试通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)