### PR TITLE
refactor: 清理 Bot UI 重复代码及冗余调用

### DIFF
--- a/packages/client/src/features/game/components/PlayerListPanel.tsx
+++ b/packages/client/src/features/game/components/PlayerListPanel.tsx
@@ -38,43 +38,49 @@ export default function PlayerListPanel() {
                   p.eliminated && 'opacity-40',
                 )}
               >
-                <div
-                  className="relative w-6 h-6 rounded-full flex items-center justify-center text-xs shrink-0 overflow-hidden"
-                  style={{
-                    background: p.isBot && p.botConfig
-                      ? DIFFICULTY_DISPLAY[p.botConfig.difficulty].avatarBg
-                      : AVATAR_COLORS[i % AVATAR_COLORS.length],
-                  }}
-                >
-                  {p.isBot && p.botConfig ? (
-                    <Bot size={13} className="text-white drop-shadow-sm" />
-                  ) : (
-                    <>
-                      <span>{AVATAR_EMOJIS[i % AVATAR_EMOJIS.length]}</span>
-                      {p.avatarUrl && (
-                        <img
-                          src={p.avatarUrl}
-                          alt={p.name}
-                          className="absolute inset-0 w-full h-full object-cover"
-                          referrerPolicy="no-referrer"
-                          onError={(e) => {
-                            e.currentTarget.style.display = 'none';
+                {(() => {
+                  const isConfiguredBot = p.isBot && !!p.botConfig;
+                  const botDisplay = isConfiguredBot ? DIFFICULTY_DISPLAY[p.botConfig!.difficulty] : undefined;
+                  return (
+                    <div
+                      className="relative w-6 h-6 rounded-full flex items-center justify-center text-xs shrink-0 overflow-hidden"
+                      style={{
+                        background: botDisplay
+                          ? botDisplay.avatarBg
+                          : AVATAR_COLORS[i % AVATAR_COLORS.length],
+                      }}
+                    >
+                      {isConfiguredBot ? (
+                        <Bot size={13} className="text-white drop-shadow-sm" />
+                      ) : (
+                        <>
+                          <span>{AVATAR_EMOJIS[i % AVATAR_EMOJIS.length]}</span>
+                          {p.avatarUrl && (
+                            <img
+                              src={p.avatarUrl}
+                              alt={p.name}
+                              className="absolute inset-0 w-full h-full object-cover"
+                              referrerPolicy="no-referrer"
+                              onError={(e) => {
+                                e.currentTarget.style.display = 'none';
+                              }}
+                            />
+                          )}
+                        </>
+                      )}
+                      {botDisplay ? (
+                        <div
+                          className="absolute inset-0 rounded-full pointer-events-none"
+                          style={{
+                            border: `1.5px solid ${botDisplay.ringColor}`,
                           }}
                         />
+                      ) : (
+                        <GoogleRing size={0} className="w-full h-full" />
                       )}
-                    </>
-                  )}
-                  {p.isBot && p.botConfig ? (
-                    <div
-                      className="absolute inset-0 rounded-full pointer-events-none"
-                      style={{
-                        border: `1.5px solid ${DIFFICULTY_DISPLAY[p.botConfig.difficulty].ringColor}`,
-                      }}
-                    />
-                  ) : (
-                    <GoogleRing size={0} className="w-full h-full" />
-                  )}
-                </div>
+                    </div>
+                  );
+                })()}
                 <div className="flex-1 min-w-0">
                   <div className={cn(
                     'text-xs truncate',

--- a/packages/client/src/features/game/constants/bot-difficulty.ts
+++ b/packages/client/src/features/game/constants/bot-difficulty.ts
@@ -17,7 +17,6 @@ export const DIFFICULTY_DISPLAY: Record<BotDifficulty, DifficultyDisplay> = {
   hard: { value: 'hard', label: '困难', color: 'text-red-400', border: 'border-red-400', avatarBg: '#ef4444', ringColor: '#f87171', description: '高级策略' },
 };
 
-
 export const DIFFICULTY_LIST: DifficultyDisplay[] = [
   DIFFICULTY_DISPLAY.novice,
   DIFFICULTY_DISPLAY.easy,

--- a/packages/client/src/features/game/pages/RoomPage.tsx
+++ b/packages/client/src/features/game/pages/RoomPage.tsx
@@ -42,6 +42,18 @@ const RULES: RuleDef[] = HOUSE_RULE_DEFINITIONS.map((def) => ({
   ...RULE_EXTRAS[def.key],
 }));
 
+function BotDifficultyBadge({ difficulty }: { difficulty: import('@uno-online/shared').BotDifficulty }) {
+  const d = DIFFICULTY_DISPLAY[difficulty];
+  return (
+    <span
+      className="inline-flex items-center shrink-0 rounded px-1.5 py-0.5 text-[10px] font-bold leading-none"
+      style={{ color: d.ringColor, backgroundColor: `${d.avatarBg}20` }}
+    >
+      AI · {d.label}
+    </span>
+  );
+}
+
 /* ── Component ── */
 
 export default function RoomPage() {
@@ -218,19 +230,9 @@ export default function RoomPage() {
                       <span className="flex min-w-0 flex-1 items-center gap-2" style={roleColor ? { color: roleColor } : undefined}>
                         <span className="truncate text-base font-medium">{p.nickname}</span>
                         {p.isBot && (
-                          p.botConfig ? (
-                            <span
-                              className="inline-flex items-center shrink-0 rounded px-1.5 py-0.5 text-[10px] font-bold leading-none"
-                              style={{
-                                color: DIFFICULTY_DISPLAY[p.botConfig.difficulty].ringColor,
-                                backgroundColor: `${DIFFICULTY_DISPLAY[p.botConfig.difficulty].avatarBg}20`,
-                              }}
-                            >
-                              AI · {DIFFICULTY_DISPLAY[p.botConfig.difficulty].label}
-                            </span>
-                          ) : (
-                            <AiBadge />
-                          )
+                          p.botConfig
+                            ? <BotDifficultyBadge difficulty={p.botConfig.difficulty} />
+                            : <AiBadge />
                         )}
                         {room?.ownerId === p.userId && <Crown size={16} className="shrink-0 text-primary" />}
                         <PlayerVoiceStatus playerId={p.userId} playerName={p.nickname} isSelf={isMe} className="shrink-0" />

--- a/packages/client/src/shared/socket.ts
+++ b/packages/client/src/shared/socket.ts
@@ -37,7 +37,9 @@ export function getSocket(): TypedSocket {
 
     socket.on('room:updated', (data) => {
       useRoomStore.getState().updateRoom(data as unknown as { players?: RoomPlayer[]; room?: RoomData });
-      useGameStore.getState().setOwnerTransferAt(null);
+      if (useGameStore.getState().ownerTransferAt !== null) {
+        useGameStore.getState().setOwnerTransferAt(null);
+      }
     });
 
     socket.on('voice:presence', (presence) => {

--- a/packages/server/src/ws/socket-handler.ts
+++ b/packages/server/src/ws/socket-handler.ts
@@ -255,8 +255,7 @@ export function setupSocketHandlers(
         await joinRoomSocket(redis, socket, roomCode);
         cancelDissolutionTimer(roomCode);
         if (ownerTransferTimers.has(roomCode)) {
-          const r = await getRoom(redis, roomCode);
-          if (r && r.ownerId === userId) {
+          if (room.ownerId === userId) {
             cancelOwnerTransferTimer(roomCode);
             io.to(roomCode).emit('room:owner_transfer_cancelled');
           }


### PR DESCRIPTION
## Summary
- 提取 RoomPage 中重复的 Bot 难度标签为 `BotDifficultyBadge` 组件
- PlayerListPanel 中 `isBot && botConfig` 条件提升为变量避免重复判断
- `socket.ts` 中 `setOwnerTransferAt(null)` 加判空守卫，避免每次 `room:updated` 都触发无意义的 Zustand 状态更新
- `socket-handler.ts` 重连时复用已有 `room` 变量，减少一次 Redis 请求

## Test plan
- [x] `pnpm --filter shared build` 通过
- [x] `pnpm --filter server exec tsc --noEmit` 通过
- [x] `pnpm --filter client exec tsc --noEmit` 通过
- [x] `pnpm test` 全部 58 个测试通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)