### PR TITLE
feat: 房间座位系统 — 圆桌选座与换座

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ src/
 ├── socket-client.ts      # Socket.IO 客户端封装
 ├── notifications.ts      # Socket.IO 事件 → MCP 通知
 ├── tools/
-│   ├── room.ts           # 8 个房间管理工具
+│   ├── room.ts           # 10 个房间管理工具
 │   ├── game.ts           # 11 个游戏操作工具
 │   └── query.ts          # 4 个查询工具
 └── types.ts

--- a/docs/backend-development-guide.md
+++ b/docs/backend-development-guide.md
@@ -52,6 +52,7 @@ packages/server/src/
     room-events.ts        # 房间 WS 事件
     room-lifecycle.ts     # 房间生命周期（闲置清理）
     game-events.ts        # 游戏 WS 事件
+    seat-events.ts        # 座位事件处理（入座、离座、换座）
     rate-limiter.ts       # WS 速率限制
     types.ts              # SocketData 等共享类型
   auth/                   # 认证基础设施
@@ -126,7 +127,7 @@ export async function loadPlugins(fastify, ctx) {
 | 函数/变量 | camelCase | `createRoom`, `getRoomPlayers` |
 | 类 | PascalCase | `GameSession`, `RoomManager` |
 | 接口 | PascalCase | `PluginContext`, `SocketData` |
-| 常量 | UPPER_SNAKE_CASE | `MAX_PLAYERS`, `THROW_COOLDOWN_MS` |
+| 常量 | UPPER_SNAKE_CASE | `MAX_PLAYERS`, `THROW_COOLDOWN_MS`, `SEAT_COUNT`, `SWAP_COOLDOWN_MS`, `SWAP_REQUEST_TIMEOUT_MS` |
 | 路由路径 | kebab-case | `/auth/dev-login`, `/admin/users/:id/role` |
 
 ## 类型定义
@@ -173,8 +174,9 @@ export async function loadPlugins(fastify, ctx) {
 
 ### 事件命名
 - 格式: `domain:action`（如 `room:create`, `game:play_card`, `chat:message`）
-- 域: `room`, `game`, `voice`, `chat`, `throw`, `player`
+- 域: `room`, `game`, `voice`, `chat`, `throw`, `player`, `seat`
 - `player` 域事件: `player:disconnected`, `player:reconnected`, `player:timeout`, `player:autopilot`, `player:toggle-autopilot`
+- `seat` 域事件（客户端→服务端）: `seat:take`, `seat:leave`, `seat:swap_request`, `seat:swap_respond`；（服务端→客户端）: `seat:updated`, `seat:swap_requested`, `seat:swap_resolved`
 
 ### 事件处理模式
 ```typescript

--- a/docs/frontend-development-guide.md
+++ b/docs/frontend-development-guide.md
@@ -29,7 +29,10 @@ packages/client/src/
       pages/
       stores/             # game-store, game-log-store, chat-store
       components/         # GameTable, PlayerNode, DrawPile, DiscardPile,
-                          # DirectionIndicator, TurnIndicator, HandSwapAnimation 等
+                          # DirectionIndicator, TurnIndicator, HandSwapAnimation,
+                          # Seat（空位/已入座/Bot/断线状态）, SeatCircle（圆桌座位环形布局）,
+                          # SpectatorBar（观战席横排）, SettingsDrawer（右侧滑出设置面板）,
+                          # SwapRequestDialog（换座请求确认弹窗）等
       hooks/              # usePlayableCardIds, usePlayerLayout, useDrawAnimation,
                           # useChatBubbles 等
       routes.tsx
@@ -39,7 +42,7 @@ packages/client/src/
     components/ui/        # 通用 UI 组件（Button, Input, GoogleRing）
     components/           # 共享布局组件（Toast, ProtectedRoute, ServerButton, ServerSelectModal, ChangelogModal）
     lib/                  # 工具函数（cn, getRoleColor）
-    stores/               # 全局 store（toast, settings, room, server）
+    stores/               # 全局 store（toast, settings, room, server）；room store 包含 `seats: RoomSeats`、`spectators: RoomSpectator[]`（替代原 `players: RoomPlayer[]`）
     utils/                # 工具函数（card-images, playable-cards, image-compress）
     data/                 # 静态数据（changelog）
     sound/                # 音效管理

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -64,7 +64,7 @@ npx -y @uno-online/mcp
 
 | 分类 | 工具 |
 |------|------|
-| 房间管理 | `create_room`, `join_room`, `leave_room`, `ready`, `start_game`, `update_room_settings`, `dissolve_room`, `kick_player` |
+| 房间管理 | `create_room`, `join_room`, `leave_room`, `ready`, `start_game`, `update_room_settings`, `dissolve_room`, `kick_player`, `take_seat`（入座指定座位 0-9，加入房间后默认在观战席）, `leave_seat`（离开座位回到观战席） |
 | 游戏操作 | `play_card`, `draw_card`, `pass`, `call_uno`, `catch_uno`, `challenge`, `accept`, `choose_color`, `choose_swap_target`, `vote_next_round`, `rematch` |
 | 查询 | `get_game_state`, `get_hand`, `get_room_info`, `get_rules` |
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -264,17 +264,20 @@ Array<{ id: string; name: string; keyPreview: string; createdAt: string; lastUse
 | 事件名 | 载荷 | 回调响应 |
 |--------|------|---------|
 | `user:current_room` | 无 | `{ roomCode: string \| null }` |
-| `room:create` | `Partial<RoomSettings>` | `{ success, roomCode?, players?, room?, voiceChannelId?, error? }` |
-| `room:join` | `roomCode: string` | `{ success, players?, room?, rejoin?, voiceChannelId?, error? }` |
-| `room:rejoin` | `roomCode: string` | `{ success, gameState?, players?, room?, isSpectator?, error? }` |
+| `room:create` | `Partial<RoomSettings>` | `{ success, roomCode?, seats?, spectators?, room?, voiceChannelId?, error? }` |
+| `room:join` | `roomCode: string` | `{ success, seats?, spectators?, room?, rejoin?, voiceChannelId?, error? }` |
+| `room:rejoin` | `roomCode: string` | `{ success, gameState?, seats?, spectators?, room?, isSpectator?, error? }` |
 | `room:leave` | 无 | `{ success, dissolved?, error? }` |
 | `room:ready` | `ready: boolean` | `{ success, error? }` |
-| `room:toggle_spectator` | `spectator: boolean` | `{ success, error? }` |
 | `room:update_settings` | `Partial<RoomSettings>` | `{ success, room?, error? }` |
 | `room:dissolve` | 无 | `{ success, error? }` |
 | `room:transfer_owner` | `{ targetId: string }` | `{ success, error? }` |
 | `room:kick` | `{ targetId: string }` | `{ success, error? }` |
 | `room:spectate` | `roomCode: string` | `{ success, error? }`，成功时会额外推送 `game:state` |
+| `seat:take` | `(seatIndex: number, callback)` | `{ success, error? }` — 入座指定座位（0-9） |
+| `seat:leave` | `(callback)` | `{ success, error? }` — 离开座位回到观战席 |
+| `seat:swap_request` | `(targetUserId: string, callback)` | `{ success, error? }` — 请求与目标玩家交换座位（Bot 目标直接交换） |
+| `seat:swap_respond` | `({ requesterId, accept }, callback)` | `{ success, error? }` — 响应换座请求 |
 
 #### 游戏操作
 
@@ -325,7 +328,7 @@ Array<{ id: string; name: string; keyPreview: string; createdAt: string; lastUse
 | `game:over` | `{ winnerId, scores, reason?, gameOverAt }` | 游戏结束；类型见下方 |
 | `game:round_end` | `{ winnerId, scores, roundEndAt }` | 回合结束；类型见下方 |
 | `game:kicked` | `{ reason: string; toSpectator?: boolean }` | 被房主移出或移至观战席 |
-| `game:back_to_room` | `{ players: Record<string, unknown>[]; room: Record<string, unknown> }` | game over 后房主返回房间 |
+| `game:back_to_room` | `{ seats: (RoomSeatPlayer \| null)[]; spectators: RoomSpectator[]; room: RoomData }` | game over 后房主返回房间 |
 | `game:spectator_queue` | `{ queue: string[]; nickname: string; joined: boolean }` | 观众申请加入下一轮队列 |
 | `game:cheat_detected` | 无 | 触发反作弊全屏警告 |
 
@@ -340,7 +343,10 @@ Array<{ id: string; name: string; keyPreview: string; createdAt: string; lastUse
 
 | 事件名 | 载荷 | 说明 |
 |--------|------|------|
-| `room:updated` | `Record<string, unknown>` | 房间状态或玩家列表更新 |
+| `room:updated` | `{ room: RoomData }` | 房间设置变更（不含座位/玩家变化，座位变化通过 `seat:updated` 推送） |
+| `seat:updated` | `{ seats: (RoomSeatPlayer \| null)[], spectators: RoomSpectator[] }` | 座位或观战席变更 |
+| `seat:swap_requested` | `{ requesterId, requesterName, requesterSeatIndex }` | 收到换座请求 |
+| `seat:swap_resolved` | `{ accepted, seat1, seat2 }` | 换座结果 |
 | `room:dissolved` | `{ reason?: string }` | 房间被解散 |
 | `room:rejoin_redirect` | `{ roomCode: string }` | 已在进行中房间，提示客户端跳转 |
 | `room:spectator_joined` | `{ nickname: string; spectators: SpectatorInfo[] }` | 观众加入 |
@@ -392,7 +398,7 @@ interface RoomSettings {
 }
 ```
 
-### 4.3 RoomData / RoomPlayer
+### 4.3 RoomData / RoomSeatPlayer / RoomSpectator
 
 ```typescript
 interface RoomData {
@@ -403,14 +409,24 @@ interface RoomData {
   lastActivityAt: string;
 }
 
-interface RoomPlayer {
+interface RoomSeatPlayer {
   userId: string;
   nickname: string;
   avatarUrl?: string | null;
   ready: boolean;
-  spectator: boolean;
+  connected: boolean;
   role?: string;
   isBot: boolean;
+  botConfig?: BotConfig;
+}
+
+type RoomSeats = (RoomSeatPlayer | null)[];  // 固定长度 10
+
+interface RoomSpectator {
+  userId: string;
+  nickname: string;
+  avatarUrl?: string | null;
+  role?: string;
 }
 ```
 
@@ -516,6 +532,9 @@ interface VoicePresence {
 | `DEFAULT_TARGET_SCORE` | 1000 | `packages/shared/src/constants/scoring.ts` | 默认目标分数 |
 | `DEFAULT_TURN_TIME_LIMIT` | 30 | `packages/shared/src/constants/scoring.ts` | 默认回合时限（秒） |
 | `UNO_PENALTY_CARDS` | 2 | `packages/shared/src/constants/scoring.ts` | UNO 惩罚抽牌数 |
+| `SEAT_COUNT` | 10 | `packages/shared/src/constants/deck.ts` | 座位总数（固定） |
+| `SWAP_COOLDOWN_MS` | 5000 | `packages/server/src/plugins/core/room.ts` | 换座冷却时间 |
+| `SWAP_REQUEST_TIMEOUT_MS` | 15000 | `packages/server/src/plugins/core/room.ts` | 换座请求超时时间 |
 | `RECONNECT_TIMEOUT_MS` | 60000 | `packages/server/src/ws/socket-handler.ts` | 掉线重连窗口 |
 | `AUTOPILOT_THINK_MS` | 2000 | `packages/server/src/ws/socket-handler.ts` | 托管循环间隔 |
 | `MAX_MESSAGES_PER_SECOND` | 20 | `packages/server/src/ws/rate-limiter.ts` | Socket 全局频率限制 |

--- a/packages/client/src/features/game/components/PlayerActionMenu.tsx
+++ b/packages/client/src/features/game/components/PlayerActionMenu.tsx
@@ -15,13 +15,14 @@ interface PlayerActionMenuProps {
   roomStatus: string;
   position: { x: number; y: number };
   onClose: () => void;
+  onSwapRequest?: (targetUserId: string) => void;
 }
 
 function normalizeVoiceName(name: string): string {
   return name.trim().replace(/[^\p{L}\p{N}_ .-]/gu, '').slice(0, 32).toLocaleLowerCase();
 }
 
-export default function PlayerActionMenu({ target, isOwner, roomStatus, position, onClose }: PlayerActionMenuProps) {
+export default function PlayerActionMenu({ target, isOwner, roomStatus, position, onClose, onSwapRequest }: PlayerActionMenuProps) {
   const ref = useRef<HTMLDivElement>(null);
   const { removeBot, setBotDifficulty } = useBotManagement();
   const playerVoicePresence = useGatewayStore((s) => s.playerVoicePresence);
@@ -87,7 +88,8 @@ export default function PlayerActionMenu({ target, isOwner, roomStatus, position
   const hasBotItems = isOwner && target.isBot;
   const hasForceMute = isOwner && isTargetInVoice;
   const hasVolume = voiceConnected && isTargetInVoice;
-  if (!hasOwnerItems && !hasBotItems && !hasForceMute && !hasVolume) return null;
+  const hasSwapRequest = !target.isBot && onSwapRequest;
+  if (!hasOwnerItems && !hasBotItems && !hasForceMute && !hasVolume && !hasSwapRequest) return null;
 
   const clampedX = Math.min(position.x, window.innerWidth - 180);
   const clampedY = Math.min(position.y, window.innerHeight - 200);
@@ -101,6 +103,14 @@ export default function PlayerActionMenu({ target, isOwner, roomStatus, position
       <div className="px-3 py-1.5 text-xs text-muted-foreground border-b border-white/5 truncate">
         {target.nickname}
       </div>
+      {hasSwapRequest && (
+        <button
+          className="w-full text-left px-3 py-2 text-sm hover:bg-white/5 rounded-lg flex items-center gap-2 text-foreground cursor-pointer"
+          onClick={() => { onSwapRequest(target.userId); onClose(); }}
+        >
+          🔄 请求换座
+        </button>
+      )}
       {hasOwnerItems && !target.isBot && (
         <>
           <button onClick={transferOwner} className="w-full flex items-center gap-2 px-3 py-2 text-sm hover:bg-white/10 cursor-pointer transition-colors">

--- a/packages/client/src/features/game/components/Seat.tsx
+++ b/packages/client/src/features/game/components/Seat.tsx
@@ -1,4 +1,4 @@
-import { Crown, WifiOff, Plus, Check } from 'lucide-react';
+import { Bot, Crown, WifiOff, Plus, Check } from 'lucide-react';
 import type { RoomSeatPlayer } from '@uno-online/shared';
 import { cn, getRoleColor } from '@/shared/lib/utils';
 import { AVATAR_COLORS, AVATAR_EMOJIS } from '../constants/avatars';
@@ -64,7 +64,7 @@ export default function Seat({ index, player, isMe, isOwnerSeat, compact = false
           }
         >
           {isBot ? (
-            <span className="text-white" style={{ fontSize: compact ? 14 : 20 }}>🤖</span>
+            <Bot size={compact ? 16 : 22} className="text-white drop-shadow-sm" />
           ) : (
             <>
               <span style={{ fontSize: compact ? 14 : 20 }}>

--- a/packages/client/src/features/game/components/Seat.tsx
+++ b/packages/client/src/features/game/components/Seat.tsx
@@ -11,7 +11,7 @@ interface SeatProps {
   isMe: boolean;
   isOwnerSeat: boolean;
   compact?: boolean;
-  onClick?: () => void;
+  onClick?: (e: React.MouseEvent) => void;
 }
 
 export default function Seat({ index, player, isMe, isOwnerSeat, compact = false, onClick }: SeatProps) {

--- a/packages/client/src/features/game/components/Seat.tsx
+++ b/packages/client/src/features/game/components/Seat.tsx
@@ -1,0 +1,152 @@
+import { Crown, WifiOff, Plus, Check } from 'lucide-react';
+import type { RoomSeatPlayer } from '@uno-online/shared';
+import { cn, getRoleColor } from '@/shared/lib/utils';
+import { AVATAR_COLORS, AVATAR_EMOJIS } from '../constants/avatars';
+import { DIFFICULTY_DISPLAY } from '../constants/bot-difficulty';
+import PlayerVoiceStatus from '@/shared/voice/PlayerVoiceStatus';
+
+interface SeatProps {
+  index: number;
+  player: RoomSeatPlayer | null;
+  isMe: boolean;
+  isOwnerSeat: boolean;
+  compact?: boolean;
+  onClick?: () => void;
+}
+
+export default function Seat({ index, player, isMe, isOwnerSeat, compact = false, onClick }: SeatProps) {
+  const avatarSize = compact ? 36 : 48;
+  const seatLabel = index + 1;
+
+  if (!player) {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        className="flex flex-col items-center gap-1 group cursor-pointer"
+        title={`座位 ${seatLabel}`}
+      >
+        <div
+          className="rounded-full border-2 border-dashed border-white/25 flex items-center justify-center relative transition-colors group-hover:border-white/50 group-hover:bg-white/5"
+          style={{ width: avatarSize, height: avatarSize }}
+        >
+          <Plus size={compact ? 14 : 18} className="text-white/30 group-hover:text-white/60 transition-colors" />
+        </div>
+        <span className="text-xs text-muted-foreground/50">{seatLabel}</span>
+      </button>
+    );
+  }
+
+  const roleColor = getRoleColor(player.role);
+  const isBot = player.isBot;
+  const botDiff = isBot && player.botConfig ? DIFFICULTY_DISPLAY[player.botConfig.difficulty] : undefined;
+  const displayName = player.nickname.length > 7 ? player.nickname.slice(0, 7) + '…' : player.nickname;
+
+  return (
+    <div
+      className={cn('flex flex-col items-center gap-1 select-none', !player.connected && 'opacity-50')}
+      onClick={onClick}
+      role={onClick ? 'button' : undefined}
+      style={onClick ? { cursor: 'pointer' } : undefined}
+    >
+      {/* Avatar */}
+      <div className="relative" style={{ width: avatarSize, height: avatarSize }}>
+        {/* Avatar circle */}
+        <div
+          className={cn(
+            'rounded-full flex items-center justify-center overflow-hidden w-full h-full text-base',
+            isMe && 'ring-2 ring-primary ring-offset-1 ring-offset-background',
+          )}
+          style={
+            botDiff
+              ? { background: botDiff.avatarBg }
+              : { background: AVATAR_COLORS[index % AVATAR_COLORS.length] }
+          }
+        >
+          {isBot ? (
+            <span className="text-white" style={{ fontSize: compact ? 14 : 20 }}>🤖</span>
+          ) : (
+            <>
+              <span style={{ fontSize: compact ? 14 : 20 }}>
+                {AVATAR_EMOJIS[index % AVATAR_EMOJIS.length]}
+              </span>
+              {player.avatarUrl && (
+                <img
+                  src={player.avatarUrl}
+                  alt={player.nickname}
+                  className="absolute inset-0 w-full h-full object-cover rounded-full"
+                  referrerPolicy="no-referrer"
+                  onError={(e) => { e.currentTarget.style.display = 'none'; }}
+                />
+              )}
+            </>
+          )}
+        </div>
+
+        {/* Bot difficulty ring */}
+        {botDiff && (
+          <div
+            className="absolute inset-0 rounded-full pointer-events-none"
+            style={{ border: `2px solid ${botDiff.ringColor}`, boxShadow: `0 0 6px ${botDiff.ringColor}40` }}
+          />
+        )}
+
+        {/* Owner crown */}
+        {isOwnerSeat && (
+          <Crown
+            size={compact ? 10 : 13}
+            className="absolute -top-1.5 -left-1 text-yellow-400 drop-shadow fill-yellow-400"
+          />
+        )}
+
+        {/* Disconnect overlay icon */}
+        {!player.connected && (
+          <div className="absolute inset-0 flex items-center justify-center bg-black/50 rounded-full">
+            <WifiOff size={compact ? 12 : 16} className="text-destructive" />
+          </div>
+        )}
+
+        {/* Ready indicator dot */}
+        {player.ready && (
+          <div className="absolute -bottom-0.5 -right-0.5 w-4 h-4 rounded-full bg-green-500 border-2 border-background flex items-center justify-center">
+            <Check size={9} className="text-white" strokeWidth={3} />
+          </div>
+        )}
+      </div>
+
+      {/* Name row */}
+      <div className="flex items-center gap-0.5 max-w-[64px]">
+        <span
+          className={cn('text-xs truncate leading-none', isMe && 'text-primary font-semibold')}
+          style={!isMe && roleColor ? { color: roleColor } : undefined}
+        >
+          {displayName}
+        </span>
+        {!isBot && player.connected && (
+          <PlayerVoiceStatus
+            playerId={player.userId}
+            playerName={player.nickname}
+            isSelf={isMe}
+          />
+        )}
+      </div>
+
+      {/* Bot difficulty badge */}
+      {botDiff && (
+        <span
+          className="text-[9px] font-bold leading-none rounded px-1 py-0.5"
+          style={{ color: botDiff.ringColor, backgroundColor: `${botDiff.avatarBg}25` }}
+        >
+          AI · {botDiff.label}
+        </span>
+      )}
+
+      {/* Ready / not ready label for non-bot players */}
+      {!isBot && (
+        <span className={cn('text-[9px] leading-none', player.ready ? 'text-green-400' : 'text-muted-foreground/50')}>
+          {player.ready ? '已准备' : '未准备'}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/packages/client/src/features/game/components/SeatCircle.tsx
+++ b/packages/client/src/features/game/components/SeatCircle.tsx
@@ -1,0 +1,70 @@
+import type { RoomSeats } from '@uno-online/shared';
+import { SEAT_COUNT } from '@uno-online/shared';
+import { useAuthStore } from '@/features/auth/stores/auth-store';
+import { useRoomStore } from '@/shared/stores/room-store';
+import Seat from './Seat';
+
+interface SeatCircleProps {
+  seats: RoomSeats;
+  onSeatClick: (seatIndex: number) => void;
+  compact?: boolean;
+}
+
+function getSeatPosition(index: number, total: number, rx: number, ry: number) {
+  const angle = (2 * Math.PI * index) / total - Math.PI / 2;
+  return { x: rx * Math.cos(angle), y: ry * Math.sin(angle) };
+}
+
+export default function SeatCircle({ seats, onSeatClick, compact = false }: SeatCircleProps) {
+  const userId = useAuthStore((s) => s.user?.id);
+  const ownerId = useRoomStore((s) => s.room?.ownerId);
+
+  const rx = compact ? 120 : 190;
+  const ry = compact ? 90 : 140;
+  const seatOffset = compact ? 24 : 36;
+
+  // Container dimensions: center at (rx + seatOffset, ry + seatOffset)
+  const cx = rx + seatOffset;
+  const cy = ry + seatOffset;
+  const containerW = cx * 2;
+  const containerH = cy * 2;
+
+  return (
+    <div className="relative" style={{ width: containerW, height: containerH }}>
+      {/* Table ellipse in the center */}
+      <div
+        className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 flex items-center justify-center rounded-[50%] border-2 border-green-700/60 bg-green-950/40"
+        style={{ width: rx * 1.1, height: ry * 1.1 }}
+      >
+        <span className="text-3xl select-none opacity-60" aria-hidden>🃏</span>
+      </div>
+
+      {/* Seats positioned around the ellipse */}
+      {Array.from({ length: SEAT_COUNT }).map((_, index) => {
+        const { x, y } = getSeatPosition(index, SEAT_COUNT, rx, ry);
+        const player = seats[index] ?? null;
+
+        return (
+          <div
+            key={index}
+            className="absolute"
+            style={{
+              left: cx + x,
+              top: cy + y,
+              transform: 'translate(-50%, -50%)',
+            }}
+          >
+            <Seat
+              index={index}
+              player={player}
+              isMe={!!userId && player?.userId === userId}
+              isOwnerSeat={!!ownerId && player?.userId === ownerId}
+              compact={compact}
+              onClick={() => onSeatClick(index)}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/client/src/features/game/components/SeatCircle.tsx
+++ b/packages/client/src/features/game/components/SeatCircle.tsx
@@ -1,5 +1,6 @@
 import type { RoomSeats } from '@uno-online/shared';
 import { SEAT_COUNT } from '@uno-online/shared';
+import { Layers } from 'lucide-react';
 import { useAuthStore } from '@/features/auth/stores/auth-store';
 import { useRoomStore } from '@/shared/stores/room-store';
 import Seat from './Seat';
@@ -36,7 +37,7 @@ export default function SeatCircle({ seats, onSeatClick, compact = false }: Seat
         className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 flex items-center justify-center rounded-[50%] border-2 border-green-700/60 bg-green-950/40"
         style={{ width: rx * 1.1, height: ry * 1.1 }}
       >
-        <span className="text-3xl select-none opacity-60" aria-hidden>🃏</span>
+        <Layers size={compact ? 24 : 32} className="text-green-500/50" strokeWidth={1.5} />
       </div>
 
       {/* Seats positioned around the ellipse */}

--- a/packages/client/src/features/game/components/SeatCircle.tsx
+++ b/packages/client/src/features/game/components/SeatCircle.tsx
@@ -6,7 +6,7 @@ import Seat from './Seat';
 
 interface SeatCircleProps {
   seats: RoomSeats;
-  onSeatClick: (seatIndex: number) => void;
+  onSeatClick: (seatIndex: number, e?: React.MouseEvent) => void;
   compact?: boolean;
 }
 
@@ -60,7 +60,7 @@ export default function SeatCircle({ seats, onSeatClick, compact = false }: Seat
               isMe={!!userId && player?.userId === userId}
               isOwnerSeat={!!ownerId && player?.userId === ownerId}
               compact={compact}
-              onClick={() => onSeatClick(index)}
+              onClick={(e) => onSeatClick(index, e)}
             />
           </div>
         );

--- a/packages/client/src/features/game/components/SeatContextMenu.tsx
+++ b/packages/client/src/features/game/components/SeatContextMenu.tsx
@@ -11,7 +11,7 @@ interface SeatContextMenuProps {
   position: { x: number; y: number };
   onClose: () => void;
   onTakeSeat: () => void;
-  onAddBot: (difficulty: BotDifficulty) => void;
+  onAddBot: (difficulty: BotDifficulty, seatIndex: number) => void;
   onSwapRequest: (targetUserId: string) => void;
   onSetBotDifficulty: (botId: string, difficulty: BotDifficulty) => void;
   onRemoveBot: (botId: string) => void;
@@ -56,7 +56,7 @@ export function SeatContextMenu({
               <button
                 key={d.value}
                 className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-sm hover:bg-white/8 cursor-pointer"
-                onClick={() => { onAddBot(d.value); onClose(); }}
+                onClick={() => { onAddBot(d.value, seatIndex); onClose(); }}
               >
                 <div className="w-5 h-5 rounded-full flex items-center justify-center shrink-0" style={{ background: d.avatarBg }}>
                   <Bot size={10} className="text-white" />

--- a/packages/client/src/features/game/components/SeatContextMenu.tsx
+++ b/packages/client/src/features/game/components/SeatContextMenu.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useRef } from 'react';
+import { ArrowLeftRight, Bot, Trash2, UserRoundPlus } from 'lucide-react';
+import type { BotDifficulty, RoomSeatPlayer } from '@uno-online/shared';
+import { DIFFICULTY_LIST } from '../constants/bot-difficulty';
+
+interface SeatContextMenuProps {
+  seatIndex: number;
+  player: RoomSeatPlayer | null;
+  isOwner: boolean;
+  isMeSeated: boolean;
+  position: { x: number; y: number };
+  onClose: () => void;
+  onTakeSeat: () => void;
+  onAddBot: (difficulty: BotDifficulty) => void;
+  onSwapRequest: (targetUserId: string) => void;
+  onSetBotDifficulty: (botId: string, difficulty: BotDifficulty) => void;
+  onRemoveBot: (botId: string) => void;
+}
+
+export function SeatContextMenu({
+  seatIndex, player, isOwner, isMeSeated, position, onClose,
+  onTakeSeat, onAddBot, onSwapRequest, onSetBotDifficulty, onRemoveBot,
+}: SeatContextMenuProps) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [onClose]);
+
+  const menuStyle: React.CSSProperties = {
+    position: 'fixed',
+    left: Math.min(position.x, window.innerWidth - 200),
+    top: Math.min(position.y, window.innerHeight - 300),
+    zIndex: 100,
+  };
+
+  if (!player) {
+    return (
+      <div ref={ref} style={menuStyle} className="w-48 rounded-xl bg-card/95 backdrop-blur-sm border border-white/10 p-1.5 shadow-xl animate-in fade-in zoom-in-95 duration-100">
+        <div className="px-3 py-1.5 text-xs text-muted-foreground">{seatIndex + 1}号位</div>
+        <button
+          className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-foreground hover:bg-white/8 cursor-pointer"
+          onClick={() => { onTakeSeat(); onClose(); }}
+        >
+          <UserRoundPlus size={14} /> 入座
+        </button>
+        {isOwner && (
+          <>
+            <div className="border-t border-white/5 my-1" />
+            <div className="px-3 py-1 text-xs text-muted-foreground">添加人机</div>
+            {DIFFICULTY_LIST.map((d) => (
+              <button
+                key={d.value}
+                className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-sm hover:bg-white/8 cursor-pointer"
+                onClick={() => { onAddBot(d.value); onClose(); }}
+              >
+                <div className="w-5 h-5 rounded-full flex items-center justify-center shrink-0" style={{ background: d.avatarBg }}>
+                  <Bot size={10} className="text-white" />
+                </div>
+                <span className="text-foreground">{d.label}</span>
+                <span className="text-xs text-muted-foreground ml-auto">{d.description}</span>
+              </button>
+            ))}
+          </>
+        )}
+      </div>
+    );
+  }
+
+  if (player.isBot) {
+    return (
+      <div ref={ref} style={menuStyle} className="w-48 rounded-xl bg-card/95 backdrop-blur-sm border border-white/10 p-1.5 shadow-xl animate-in fade-in zoom-in-95 duration-100">
+        <div className="px-3 py-1.5 text-xs text-muted-foreground">{seatIndex + 1}号位 · {player.nickname}</div>
+        {isMeSeated && (
+          <button
+            className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-foreground hover:bg-white/8 cursor-pointer"
+            onClick={() => { onSwapRequest(player.userId); onClose(); }}
+          >
+            <ArrowLeftRight size={14} /> 交换座位
+          </button>
+        )}
+        {isOwner && (
+          <>
+            <div className="border-t border-white/5 my-1" />
+            <div className="px-3 py-1 text-xs text-muted-foreground">调整难度</div>
+            {DIFFICULTY_LIST.map((d) => (
+              <button
+                key={d.value}
+                className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-sm hover:bg-white/8 cursor-pointer"
+                onClick={() => { onSetBotDifficulty(player.userId, d.value); onClose(); }}
+              >
+                <div className="w-5 h-5 rounded-full flex items-center justify-center shrink-0" style={{ background: d.avatarBg }}>
+                  <Bot size={10} className="text-white" />
+                </div>
+                <span className="text-foreground">{d.label}</span>
+              </button>
+            ))}
+            <div className="border-t border-white/5 my-1" />
+            <button
+              className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-red-400 hover:bg-white/8 cursor-pointer"
+              onClick={() => { onRemoveBot(player.userId); onClose(); }}
+            >
+              <Trash2 size={14} /> 移除人机
+            </button>
+          </>
+        )}
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/packages/client/src/features/game/components/SettingsDrawer.tsx
+++ b/packages/client/src/features/game/components/SettingsDrawer.tsx
@@ -1,0 +1,211 @@
+import { X } from 'lucide-react';
+import { cn } from '@/shared/lib/utils';
+import { getSocket } from '@/shared/socket';
+import { Button } from '@/shared/components/ui/Button';
+import { DEFAULT_HOUSE_RULES, HOUSE_RULES_PRESETS, HOUSE_RULE_DEFINITIONS } from '@uno-online/shared';
+import type { HouseRules, HouseRuleDefinition } from '@uno-online/shared';
+
+/* ── House-rule rendering helpers ── */
+
+interface RuleDef extends HouseRuleDefinition {
+  type: 'boolean' | 'select';
+  options?: { value: any; label: string }[];
+}
+
+const RULE_EXTRAS: Partial<Record<keyof HouseRules, Pick<RuleDef, 'type' | 'options'>>> = {
+  unoPenaltyCount: { type: 'select', options: [{ value: 2, label: '2张' }, { value: 4, label: '4张' }, { value: 6, label: '6张' }] },
+  handLimit: { type: 'select', options: [{ value: null, label: '无限制' }, { value: 15, label: '15张' }, { value: 20, label: '20张' }, { value: 25, label: '25张' }] },
+  handRevealThreshold: { type: 'select', options: [{ value: null, label: '关闭' }, { value: 3, label: '3张' }, { value: 2, label: '2张' }] },
+  blitzTimeLimit: { type: 'select', options: [{ value: null, label: '关闭' }, { value: 120, label: '2分钟' }, { value: 300, label: '5分钟' }, { value: 600, label: '10分钟' }] },
+};
+
+const RULES: RuleDef[] = HOUSE_RULE_DEFINITIONS.map((def) => ({
+  ...def,
+  type: 'boolean' as const,
+  ...RULE_EXTRAS[def.key],
+}));
+
+/* ── Props ── */
+
+interface SettingsDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  isOwner: boolean;
+  room: { settings?: { allowSpectators?: boolean; spectatorMode?: string; houseRules?: Partial<HouseRules> } } | null;
+  houseRules: HouseRules;
+  onHouseRulesChange: (rules: HouseRules) => void;
+}
+
+/* ── Component ── */
+
+export default function SettingsDrawer({
+  open,
+  onClose,
+  isOwner,
+  room,
+  houseRules,
+  onHouseRulesChange,
+}: SettingsDrawerProps) {
+  const applyPreset = (preset: string) => {
+    const presetRules = HOUSE_RULES_PRESETS[preset];
+    if (presetRules) {
+      const newRules = { ...DEFAULT_HOUSE_RULES, ...presetRules };
+      onHouseRulesChange(newRules);
+      getSocket().emit('room:update_settings', { houseRules: newRules });
+    }
+  };
+
+  const toggleRule = (key: keyof HouseRules) => {
+    const newRules = { ...houseRules, [key]: !houseRules[key] };
+    onHouseRulesChange(newRules);
+    getSocket().emit('room:update_settings', { houseRules: newRules });
+  };
+
+  const setRuleValue = (key: keyof HouseRules, value: any) => {
+    const newRules = { ...houseRules, [key]: value };
+    onHouseRulesChange(newRules);
+    getSocket().emit('room:update_settings', { houseRules: newRules });
+  };
+
+  return (
+    <>
+      {/* Overlay */}
+      {open && (
+        <div
+          className="fixed inset-0 bg-black/50 z-40"
+          onClick={onClose}
+        />
+      )}
+
+      {/* Panel */}
+      <div
+        className={cn(
+          'fixed right-0 top-0 h-full w-[320px] max-w-[75vw] bg-[#0f1729]/98 border-l border-white/10 z-50 flex flex-col',
+          'transition-transform duration-300',
+          open ? 'translate-x-0' : 'translate-x-full',
+        )}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-white/10 shrink-0">
+          <span className="text-sm font-bold font-game text-foreground">房间设置</span>
+          <button
+            onClick={onClose}
+            className="w-7 h-7 rounded-md bg-white/10 flex items-center justify-center text-muted-foreground hover:text-foreground cursor-pointer transition-colors"
+          >
+            <X size={14} />
+          </button>
+        </div>
+
+        {/* Scrollable content */}
+        <div className="flex-1 min-h-0 overflow-y-auto scrollbar-thin p-4 flex flex-col gap-4">
+          {/* Spectator section */}
+          <section>
+            <h3 className="mb-3 text-sm text-muted-foreground font-game">观战设置</h3>
+            <div className="space-y-3">
+              <div className="flex items-center justify-between">
+                <label className="text-sm">允许观战</label>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={room?.settings?.allowSpectators ?? true}
+                  onClick={() => {
+                    if (isOwner) {
+                      getSocket().emit('room:update_settings', { allowSpectators: !(room?.settings?.allowSpectators ?? true) });
+                    }
+                  }}
+                  disabled={!isOwner}
+                  className={cn(
+                    'w-11 h-6 rounded-xl relative transition-colors duration-200',
+                    !isOwner ? 'cursor-default opacity-50' : 'cursor-pointer',
+                    (room?.settings?.allowSpectators ?? true) ? 'bg-accent' : 'bg-white/15',
+                  )}
+                >
+                  <span
+                    className={cn(
+                      'absolute top-0.5 left-0.5 h-5 w-5 rounded-full bg-white transition-transform',
+                      (room?.settings?.allowSpectators ?? true) ? 'translate-x-5' : '',
+                    )}
+                  />
+                </button>
+              </div>
+              {(room?.settings?.allowSpectators ?? true) && (
+                <div className="flex items-center justify-between">
+                  <label className="text-sm">观战模式</label>
+                  <select
+                    value={room?.settings?.spectatorMode ?? 'hidden'}
+                    onChange={(e) => getSocket().emit('room:update_settings', { spectatorMode: e.target.value as 'full' | 'hidden' })}
+                    className={cn(
+                      'bg-white/[0.06] text-foreground border border-white/10 rounded-xl px-3 py-1.5 text-sm outline-none cursor-pointer',
+                      !isOwner && 'opacity-50 cursor-default',
+                    )}
+                    disabled={!isOwner}
+                  >
+                    <option value="hidden">只看出牌</option>
+                    <option value="full">全透视</option>
+                  </select>
+                </div>
+              )}
+            </div>
+          </section>
+
+          {/* Divider */}
+          <div className="border-b border-white/5" />
+
+          {/* House rules section */}
+          <section className="flex flex-col flex-1 min-h-0">
+            <h3 className="mb-3 text-sm text-accent font-game">村规设置</h3>
+            <div className="flex gap-2 mb-3 flex-wrap">
+              {(['classic', 'party', 'crazy'] as const).map((p) => (
+                <Button key={p} variant="outline" size="sm" onClick={() => applyPreset(p)} disabled={!isOwner} sound="click">
+                  {p === 'classic' ? '经典' : p === 'party' ? '派对' : '疯狂'}
+                </Button>
+              ))}
+            </div>
+            <div className="flex-1 min-h-0">
+              {RULES.map((rule) => (
+                <div key={rule.key} className="flex justify-between items-center py-1.5 border-b border-white/5">
+                  <div className="flex-1">
+                    <div className="text-caption">{rule.label}</div>
+                    <div className="text-xs text-muted-foreground">{rule.description}</div>
+                  </div>
+                  {rule.type === 'boolean' ? (
+                    <button
+                      onClick={() => toggleRule(rule.key)}
+                      disabled={!isOwner}
+                      className={cn(
+                        'w-11 h-6 rounded-xl border-none relative transition-colors duration-200',
+                        !isOwner ? 'cursor-default' : 'cursor-pointer',
+                        houseRules[rule.key] ? 'bg-accent' : 'bg-switch-off',
+                      )}
+                    >
+                      <div
+                        className={cn(
+                          'w-toggle-knob h-toggle-knob rounded-full bg-white absolute top-toggle-off transition-[left] duration-200',
+                          houseRules[rule.key] ? 'left-toggle-on' : 'left-toggle-off',
+                        )}
+                      />
+                    </button>
+                  ) : (
+                    <select
+                      value={String(houseRules[rule.key] ?? 'null')}
+                      onChange={(e) => {
+                        const v = e.target.value;
+                        setRuleValue(rule.key, v === 'null' ? null : Number(v));
+                      }}
+                      disabled={!isOwner}
+                      className="bg-white/[0.06] text-foreground border border-white/10 rounded-xl px-3 py-1.5 text-xs outline-none cursor-pointer"
+                    >
+                      {rule.options?.map((opt) => (
+                        <option key={String(opt.value)} value={String(opt.value ?? 'null')}>{opt.label}</option>
+                      ))}
+                    </select>
+                  )}
+                </div>
+              ))}
+            </div>
+          </section>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/packages/client/src/features/game/components/SpectatorBar.tsx
+++ b/packages/client/src/features/game/components/SpectatorBar.tsx
@@ -1,0 +1,65 @@
+import { Eye } from 'lucide-react';
+import type { RoomSpectator } from '@uno-online/shared';
+import { cn } from '@/shared/lib/utils';
+import { getRoleColor } from '@/shared/lib/utils';
+
+interface SpectatorBarProps {
+  spectators: RoomSpectator[];
+  compact?: boolean;
+}
+
+export default function SpectatorBar({ spectators, compact = false }: SpectatorBarProps) {
+  if (spectators.length === 0) return null;
+
+  return (
+    <div className="flex items-center gap-2 bg-white/[0.04] border border-white/[0.08] rounded-xl px-3 py-2">
+      <Eye size={13} className="text-muted-foreground shrink-0" />
+      <span className="text-xs text-muted-foreground shrink-0">{spectators.length}</span>
+
+      <div className="flex items-center gap-1.5 flex-wrap">
+        {spectators.map((spectator) => {
+          const roleColor = getRoleColor(spectator.role);
+          return (
+            <div
+              key={spectator.userId}
+              className={cn(
+                'flex items-center gap-1',
+                compact && 'gap-0',
+              )}
+              title={spectator.nickname}
+            >
+              {/* Avatar */}
+              <div className="w-6 h-6 rounded-full bg-white/10 border border-white/10 flex items-center justify-center text-xs shrink-0 overflow-hidden">
+                {spectator.avatarUrl ? (
+                  <img
+                    src={spectator.avatarUrl}
+                    alt={spectator.nickname}
+                    className="w-full h-full object-cover"
+                    referrerPolicy="no-referrer"
+                    onError={(e) => { e.currentTarget.style.display = 'none'; }}
+                  />
+                ) : (
+                  <span className="text-muted-foreground text-[10px]">
+                    {spectator.nickname.charAt(0).toUpperCase()}
+                  </span>
+                )}
+              </div>
+
+              {/* Name — hidden in compact mode */}
+              {!compact && (
+                <span
+                  className="text-xs text-muted-foreground leading-none"
+                  style={roleColor ? { color: roleColor } : undefined}
+                >
+                  {spectator.nickname.length > 8
+                    ? spectator.nickname.slice(0, 8) + '…'
+                    : spectator.nickname}
+                </span>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/features/game/components/SwapRequestDialog.tsx
+++ b/packages/client/src/features/game/components/SwapRequestDialog.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useState } from 'react';
+import { SWAP_REQUEST_TIMEOUT_MS } from '@uno-online/shared';
+import { Button } from '@/shared/components/ui/Button';
+
+interface SwapRequestDialogProps {
+  requesterId: string;
+  requesterName: string;
+  requesterSeatIndex: number;
+  onRespond: (accept: boolean) => void;
+}
+
+export default function SwapRequestDialog({
+  requesterId: _requesterId,
+  requesterName,
+  requesterSeatIndex,
+  onRespond,
+}: SwapRequestDialogProps) {
+  const totalSeconds = Math.ceil(SWAP_REQUEST_TIMEOUT_MS / 1000);
+  const [remaining, setRemaining] = useState(totalSeconds);
+
+  useEffect(() => {
+    setRemaining(totalSeconds);
+    const interval = setInterval(() => {
+      setRemaining((prev) => {
+        if (prev <= 1) {
+          clearInterval(interval);
+          onRespond(false);
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [totalSeconds, onRespond]);
+
+  return (
+    <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center">
+      <div className="glass-panel p-6 w-[320px] max-w-[90vw] flex flex-col items-center gap-4">
+        {/* Title */}
+        <div className="text-center">
+          <h3 className="text-lg font-bold font-game text-foreground">换座请求</h3>
+          <p className="text-sm text-muted-foreground mt-1">来自 {requesterSeatIndex + 1}号位</p>
+        </div>
+
+        {/* Avatars */}
+        <div className="flex items-center gap-4">
+          {/* Requester */}
+          <div className="flex flex-col items-center gap-1">
+            <div className="w-12 h-12 rounded-full bg-white/10 border border-white/20 flex items-center justify-center text-lg font-bold">
+              {requesterName.charAt(0).toUpperCase()}
+            </div>
+            <span className="text-xs text-muted-foreground max-w-[60px] truncate text-center">{requesterName}</span>
+          </div>
+
+          {/* Swap icon */}
+          <span className="text-xl text-primary">⇄</span>
+
+          {/* Self */}
+          <div className="flex flex-col items-center gap-1">
+            <div className="w-12 h-12 rounded-full bg-primary/20 border border-primary/40 flex items-center justify-center text-lg font-bold text-primary">
+              你
+            </div>
+            <span className="text-xs text-muted-foreground">你</span>
+          </div>
+        </div>
+
+        {/* Countdown */}
+        <p className="text-xs text-muted-foreground">{remaining}秒后自动拒绝</p>
+
+        {/* Buttons */}
+        <div className="flex gap-3 w-full">
+          <Button
+            variant="secondary"
+            className="flex-1"
+            onClick={() => onRespond(false)}
+            sound="click"
+          >
+            拒绝
+          </Button>
+          <Button
+            variant="game"
+            className="flex-1 text-sm px-4 py-2.5 tracking-normal"
+            onClick={() => onRespond(true)}
+            sound="ready"
+          >
+            接受
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/features/game/hooks/useGameSocket.ts
+++ b/packages/client/src/features/game/hooks/useGameSocket.ts
@@ -26,8 +26,8 @@ export function useGameSocket(roomCode: string | undefined) {
     if (!phase && roomCode) {
       socket.emit('room:rejoin', roomCode, (res: any) => {
         if (res.success && res.gameState) {
-          if (roomCode && res.players && res.room) {
-            setRoom(roomCode, res.players, res.room);
+          if (roomCode && res.seats && res.room) {
+            setRoom(roomCode, res.seats, res.spectators ?? [], res.room);
           }
           if (res.isSpectator) {
             useGameStore.getState().setSpectator(true);
@@ -74,8 +74,8 @@ export function useGameSocket(roomCode: string | undefined) {
         const socket = getSocket();
         socket.emit('room:rejoin', roomCode, (res: any) => {
           if (res.success && res.gameState) {
-            if (res.players && res.room) {
-              setRoom(roomCode, res.players, res.room);
+            if (res.seats && res.room) {
+              setRoom(roomCode, res.seats, res.spectators ?? [], res.room);
             }
             if (res.isSpectator) {
               useGameStore.getState().setSpectator(true);

--- a/packages/client/src/features/game/pages/RoomPage.tsx
+++ b/packages/client/src/features/game/pages/RoomPage.tsx
@@ -1,80 +1,72 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { Crown, Check, Copy, Eye, Trash2 } from 'lucide-react';
-import { cn, getRoleColor } from '@/shared/lib/utils';
+import { Copy, Eye, Settings, Trash2 } from 'lucide-react';
+import { cn } from '@/shared/lib/utils';
 import { BotAddButton } from '../components/BotAddButton';
-import { AiBadge } from '@/shared/components/ui/AiBadge';
-import { DIFFICULTY_DISPLAY } from '../constants/bot-difficulty';
 import { useAuthStore } from '@/features/auth/stores/auth-store';
-import { useRoomStore, type RoomPlayer } from '@/shared/stores/room-store';
+import { useRoomStore } from '@/shared/stores/room-store';
+import type { RoomSeatPlayer } from '@/shared/stores/room-store';
 import { useGameStore } from '../stores/game-store';
 import { getSocket, connectSocket, refreshVoicePresence } from '@/shared/socket';
 import VoicePanel from '@/shared/voice/VoicePanel';
-import PlayerVoiceStatus from '@/shared/voice/PlayerVoiceStatus';
 import { useToastStore } from '@/shared/stores/toast-store';
 import { showConfirm } from '@/shared/stores/confirm-store';
 import PlayerActionMenu from '../components/PlayerActionMenu';
 import { useLeaveRoom } from '../hooks/useLeaveRoom';
-import { DEFAULT_HOUSE_RULES, HOUSE_RULES_PRESETS, HOUSE_RULE_DEFINITIONS, MAX_PLAYERS } from '@uno-online/shared';
-import type { HouseRules, HouseRuleDefinition } from '@uno-online/shared';
+import { DEFAULT_HOUSE_RULES } from '@uno-online/shared';
+import type { HouseRules } from '@uno-online/shared';
 import { Button } from '@/shared/components/ui/Button';
 import { useBgm } from '@/shared/sound/useBgm';
 import BgmToast from '@/shared/components/BgmToast';
 import GamePageShell from '@/shared/components/GamePageShell';
-
-/* ── House-rule rendering helpers (inlined from HouseRulesPanel) ── */
-
-interface RuleDef extends HouseRuleDefinition {
-  type: 'boolean' | 'select';
-  options?: { value: any; label: string }[];
-}
-
-const RULE_EXTRAS: Partial<Record<keyof HouseRules, Pick<RuleDef, 'type' | 'options'>>> = {
-  unoPenaltyCount: { type: 'select', options: [{ value: 2, label: '2张' }, { value: 4, label: '4张' }, { value: 6, label: '6张' }] },
-  handLimit: { type: 'select', options: [{ value: null, label: '无限制' }, { value: 15, label: '15张' }, { value: 20, label: '20张' }, { value: 25, label: '25张' }] },
-  handRevealThreshold: { type: 'select', options: [{ value: null, label: '关闭' }, { value: 3, label: '3张' }, { value: 2, label: '2张' }] },
-  blitzTimeLimit: { type: 'select', options: [{ value: null, label: '关闭' }, { value: 120, label: '2分钟' }, { value: 300, label: '5分钟' }, { value: 600, label: '10分钟' }] },
-};
-
-const RULES: RuleDef[] = HOUSE_RULE_DEFINITIONS.map((def) => ({
-  ...def,
-  type: 'boolean' as const,
-  ...RULE_EXTRAS[def.key],
-}));
-
-function BotDifficultyBadge({ difficulty }: { difficulty: import('@uno-online/shared').BotDifficulty }) {
-  const d = DIFFICULTY_DISPLAY[difficulty];
-  return (
-    <span
-      className="inline-flex items-center shrink-0 rounded px-1.5 py-0.5 text-[10px] font-bold leading-none"
-      style={{ color: d.ringColor, backgroundColor: `${d.avatarBg}20` }}
-    >
-      AI · {d.label}
-    </span>
-  );
-}
+import SeatCircle from '../components/SeatCircle';
+import SpectatorBar from '../components/SpectatorBar';
+import SettingsDrawer from '../components/SettingsDrawer';
+import SwapRequestDialog from '../components/SwapRequestDialog';
 
 /* ── Component ── */
 
 export default function RoomPage() {
   const { roomCode } = useParams<{ roomCode: string }>();
   const user = useAuthStore((s) => s.user);
-  const { players, room, setRoom } = useRoomStore();
+  const { seats, spectators, room, setRoom } = useRoomStore();
   const setGameState = useGameStore((s) => s.setGameState);
   const navigate = useNavigate();
   const songName = useBgm('lobby');
   const leaveRoomHook = useLeaveRoom();
 
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [swapRequest, setSwapRequest] = useState<{
+    requesterId: string;
+    requesterName: string;
+    requesterSeatIndex: number;
+  } | null>(null);
+  const [houseRules, setHouseRules] = useState<HouseRules>(DEFAULT_HOUSE_RULES);
+  const [menuTarget, setMenuTarget] = useState<{
+    player: RoomSeatPlayer;
+    seatIndex: number;
+    position: { x: number; y: number };
+  } | null>(null);
+
+  /* Responsive compact detection */
+  const [compact, setCompact] = useState(window.innerWidth < 768);
+  useEffect(() => {
+    const handler = () => setCompact(window.innerWidth < 768);
+    window.addEventListener('resize', handler);
+    return () => window.removeEventListener('resize', handler);
+  }, []);
+
+  /* Rejoin effect */
   useEffect(() => {
     connectSocket();
     const socket = getSocket();
     refreshVoicePresence();
 
-    if (useRoomStore.getState().players.length === 0 && roomCode) {
+    if (useRoomStore.getState().seats.every((s) => s === null) && roomCode) {
       socket.emit('room:rejoin', roomCode, (res: any) => {
         if (res.success) {
-          if (res.players && res.room) {
-            setRoom(roomCode, res.players, res.room);
+          if (res.seats && res.spectators && res.room) {
+            setRoom(roomCode, res.seats, res.spectators, res.room);
             refreshVoicePresence();
           }
           if (res.gameState) {
@@ -93,34 +85,54 @@ export default function RoomPage() {
       navigate(`/game/${roomCode}`);
     };
     socket.on('game:state', onState);
-    return () => { socket.off('game:state', onState); };
+    return () => {
+      socket.off('game:state', onState);
+    };
   }, [roomCode, navigate, setGameState]);
 
-  const isOwner = room?.ownerId === user?.id;
-  const myPlayer = players.find((p) => p.userId === user?.id);
-  const activePlayers = players.filter((p) => !p.spectator);
-  const spectatorPlayers = players.filter((p) => p.spectator);
-  const allReady = activePlayers.length >= 2 && activePlayers.every((p) => p.ready);
-  const [houseRules, setHouseRules] = useState<HouseRules>(DEFAULT_HOUSE_RULES);
-  const [menuTarget, setMenuTarget] = useState<{ player: RoomPlayer; position: { x: number; y: number } } | null>(null);
+  /* Socket listeners for swap requests */
+  useEffect(() => {
+    const socket = getSocket();
+    const onSwapRequested = (data: {
+      requesterId: string;
+      requesterName: string;
+      requesterSeatIndex: number;
+    }) => setSwapRequest(data);
+    const onSwapResolved = () => setSwapRequest(null);
+    socket.on('seat:swap_requested', onSwapRequested);
+    socket.on('seat:swap_resolved', onSwapResolved);
+    return () => {
+      socket.off('seat:swap_requested', onSwapRequested);
+      socket.off('seat:swap_resolved', onSwapResolved);
+    };
+  }, []);
 
+  /* Derived state */
+  const isOwner = room?.ownerId === user?.id;
+  const myPlayer =
+    seats.find((s) => s !== null && s.userId === user?.id) ?? null;
+  const isSpectator =
+    !myPlayer && spectators.some((s) => s.userId === user?.id);
+  const seatedPlayers = seats.filter(
+    (s): s is RoomSeatPlayer => s !== null,
+  );
+  const allReady =
+    seatedPlayers.length >= 2 && seatedPlayers.every((p) => p.ready);
+
+  /* Sync houseRules from room settings */
   useEffect(() => {
     if (room?.settings?.houseRules) {
-      setHouseRules({ ...DEFAULT_HOUSE_RULES, ...room.settings.houseRules });
+      setHouseRules({
+        ...DEFAULT_HOUSE_RULES,
+        ...(room.settings.houseRules as Partial<HouseRules>),
+      });
     }
   }, [room?.settings?.houseRules]);
 
+  /* ── Handlers ── */
+
   const toggleReady = () => {
     getSocket().emit('room:ready', !myPlayer?.ready, () => {});
-  };
-
-  const toggleSpectator = () => {
-    const newVal = !myPlayer?.spectator;
-    getSocket().emit('room:toggle_spectator', newVal, (res: { success?: boolean; error?: string }) => {
-      if (!res?.success && res?.error) {
-        useToastStore.getState().addToast(res.error, 'error');
-      }
-    });
   };
 
   const startGame = () => {
@@ -153,47 +165,79 @@ export default function RoomPage() {
   };
 
   const dissolveRoom = async () => {
-    if (!(await showConfirm({
-      title: '解散房间',
-      message: '确定要解散房间吗？所有玩家将被踢出。',
-      confirmText: '解散',
-      variant: 'danger',
-    }))) return;
+    if (
+      !(await showConfirm({
+        title: '解散房间',
+        message: '确定要解散房间吗？所有玩家将被踢出。',
+        confirmText: '解散',
+        variant: 'danger',
+      }))
+    )
+      return;
     getSocket().emit('room:dissolve', () => {});
   };
 
-  /* House-rules helpers */
-  const applyPreset = (preset: string) => {
-    const presetRules = HOUSE_RULES_PRESETS[preset];
-    if (presetRules) {
-      const newRules = { ...DEFAULT_HOUSE_RULES, ...presetRules };
-      setHouseRules(newRules);
-      getSocket().emit('room:update_settings', { houseRules: newRules });
+  /* Seat click handler */
+  const handleSeatClick = (seatIndex: number) => {
+    const seat = seats[seatIndex];
+    if (!seat) {
+      // Empty seat: take it
+      getSocket().emit(
+        'seat:take',
+        seatIndex,
+        (res: { success?: boolean; error?: string }) => {
+          if (!res?.success && res?.error)
+            useToastStore.getState().addToast(res.error, 'error');
+        },
+      );
+    } else if (seat.userId === user?.id) {
+      // My seat: no action
+    } else if (seat.isBot) {
+      // Bot: swap directly (no confirmation needed)
+      getSocket().emit(
+        'seat:swap_request',
+        seat.userId,
+        (res: { success?: boolean; error?: string }) => {
+          if (!res?.success && res?.error)
+            useToastStore.getState().addToast(res.error, 'error');
+        },
+      );
+    } else {
+      // Other player: show action menu
+      setMenuTarget({
+        player: seat,
+        seatIndex,
+        position: { x: window.innerWidth / 2, y: window.innerHeight / 2 },
+      });
     }
   };
 
-  const toggleRule = (key: keyof HouseRules) => {
-    const newRules = { ...houseRules, [key]: !houseRules[key] };
-    setHouseRules(newRules);
-    getSocket().emit('room:update_settings', { houseRules: newRules });
-  };
-
-  const setRuleValue = (key: keyof HouseRules, value: any) => {
-    const newRules = { ...houseRules, [key]: value };
-    setHouseRules(newRules);
-    getSocket().emit('room:update_settings', { houseRules: newRules });
+  /* Swap respond handler */
+  const handleSwapRespond = (accept: boolean) => {
+    if (!swapRequest) return;
+    getSocket().emit(
+      'seat:swap_respond',
+      { requesterId: swapRequest.requesterId, accept },
+      (res: { success?: boolean; error?: string }) => {
+        if (!res?.success && res?.error)
+          useToastStore.getState().addToast(res.error, 'error');
+      },
+    );
+    setSwapRequest(null);
   };
 
   return (
     <GamePageShell>
-      <div className="relative z-1 flex flex-col items-center gap-4 md:gap-6 w-full h-full overflow-y-auto scrollbar-thin px-4 md:px-8 py-8 md:py-20">
+      <div className="relative z-1 flex flex-col items-center gap-4 md:gap-6 w-full h-full overflow-y-auto scrollbar-thin px-4 md:px-8 py-8 md:py-16">
         {/* Title */}
         <h2 className="font-game text-2xl md:text-[36px] text-primary text-shadow-bold flex items-center gap-2 md:gap-3 shrink-0">
           房间 {roomCode}
           <button
             onClick={() => {
               const url = `${window.location.origin}/room/${roomCode}`;
-              navigator.clipboard.writeText(`来玩 UNO 吧！房间号：${roomCode}\n${url}`);
+              navigator.clipboard.writeText(
+                `来玩 UNO 吧！房间号：${roomCode}\n${url}`,
+              );
               useToastStore.getState().addToast('房间链接已复制', 'success');
             }}
             className="bg-white/10 hover:bg-white/20 rounded-lg p-1.5 cursor-pointer transition-colors"
@@ -203,248 +247,127 @@ export default function RoomPage() {
           </button>
         </h2>
 
-        {/* Two-column layout */}
-        <div className="flex flex-col md:flex-row gap-4 md:gap-6 w-full max-w-[900px] md:flex-1 md:min-h-0">
-          {/* Left: Player + spectator lists */}
-          <div className="flex-1 glass-panel p-4 md:p-6 flex flex-col gap-4 min-h-0 overflow-y-auto scrollbar-thin">
-            <section>
-              <h3 className="mb-4 text-sm text-muted-foreground font-game">
-                玩家 ({activePlayers.length}/{MAX_PLAYERS})
-              </h3>
-              <div className="flex flex-col gap-1">
-                {activePlayers.map((p) => {
-                  const roleColor = getRoleColor(p.role);
-                  const isMe = p.userId === user?.id;
-                  return (
-                    <div
-                      key={p.userId}
-                      className={cn(
-                        'flex items-center justify-between py-3 px-3 rounded-lg border-b border-white/5 last:border-b-0',
-                        !isMe && 'cursor-pointer hover:bg-white/5'
-                      )}
-                      onClick={(e) => {
-                        if (isMe) return;
-                        setMenuTarget({ player: p, position: { x: e.clientX, y: e.clientY } });
-                      }}
-                    >
-                      <span className="flex min-w-0 flex-1 items-center gap-2" style={roleColor ? { color: roleColor } : undefined}>
-                        <span className="truncate text-base font-medium">{p.nickname}</span>
-                        {p.isBot && (
-                          p.botConfig
-                            ? <BotDifficultyBadge difficulty={p.botConfig.difficulty} />
-                            : <AiBadge />
-                        )}
-                        {room?.ownerId === p.userId && <Crown size={16} className="shrink-0 text-primary" />}
-                        <PlayerVoiceStatus playerId={p.userId} playerName={p.nickname} isSelf={isMe} className="shrink-0" />
-                      </span>
-                      <span className={cn('text-xs font-medium', p.ready ? 'text-uno-green' : 'text-muted-foreground')}>
-                        {p.ready ? <><Check size={14} className="inline-block align-middle" /> 已准备</> : '未准备'}
-                      </span>
-                    </div>
-                  );
-                })}
-              </div>
-              {isOwner && activePlayers.length < MAX_PLAYERS && <BotAddButton />}
-            </section>
+        {/* Circular table */}
+        <SeatCircle
+          seats={seats}
+          onSeatClick={handleSeatClick}
+          compact={compact}
+        />
 
-            {spectatorPlayers.length > 0 && (
-              <section>
-                <h3 className="mb-4 text-sm text-muted-foreground font-game flex items-center gap-1.5">
-                  <Eye size={14} className="text-blue-400" />
-                  观战 ({spectatorPlayers.length})
-                </h3>
-                <div className="flex flex-col gap-1">
-                  {spectatorPlayers.map((p) => {
-                    const roleColor = getRoleColor(p.role);
-                    const isMe = p.userId === user?.id;
-                    return (
-                      <div
-                        key={p.userId}
-                        className={cn(
-                          'flex items-center justify-between py-3 px-3 rounded-lg border-b border-white/5 last:border-b-0 opacity-70',
-                          !isMe && 'cursor-pointer hover:bg-white/5 hover:opacity-100'
-                        )}
-                        onClick={(e) => {
-                          if (isMe) return;
-                          setMenuTarget({ player: p, position: { x: e.clientX, y: e.clientY } });
-                        }}
-                      >
-                        <span className="flex min-w-0 flex-1 items-center gap-2" style={roleColor ? { color: roleColor } : undefined}>
-                          <span className="truncate text-base font-medium">{p.nickname}</span>
-                          {p.isBot && (
-                            p.botConfig ? (
-                              <span
-                                className="inline-flex items-center shrink-0 rounded px-1.5 py-0.5 text-[10px] font-bold leading-none"
-                                style={{
-                                  color: DIFFICULTY_DISPLAY[p.botConfig.difficulty].ringColor,
-                                  backgroundColor: `${DIFFICULTY_DISPLAY[p.botConfig.difficulty].avatarBg}20`,
-                                }}
-                              >
-                                AI · {DIFFICULTY_DISPLAY[p.botConfig.difficulty].label}
-                              </span>
-                            ) : (
-                              <AiBadge />
-                            )
-                          )}
-                          {room?.ownerId === p.userId && <Crown size={16} className="shrink-0 text-primary" />}
-                          <PlayerVoiceStatus playerId={p.userId} playerName={p.nickname} isSelf={isMe} className="shrink-0" />
-                        </span>
-                        <span className="text-xs font-medium text-blue-400">
-                          <Eye size={14} className="inline-block align-middle" /> 观战
-                        </span>
-                      </div>
-                    );
-                  })}
-                </div>
-              </section>
-            )}
-          </div>
-
-          {/* Right: Settings (spectator + house rules in one panel) */}
-          <div className="w-full md:w-[320px] md:shrink-0 glass-panel p-4 md:p-5 flex flex-col md:max-h-[calc(100vh-280px)]">
-            {/* Spectator section */}
-            <h3 className="mb-3 text-sm text-muted-foreground font-game">观战设置</h3>
-            <div className="space-y-3">
-              <div className="flex items-center justify-between">
-                <label className="text-sm">允许观战</label>
-                <button
-                  type="button"
-                  role="switch"
-                  aria-checked={room?.settings?.allowSpectators ?? true}
-                  onClick={() => { if (isOwner) getSocket().emit('room:update_settings', { allowSpectators: !(room?.settings?.allowSpectators ?? true) }); }}
-                  disabled={!isOwner}
-                  className={cn(
-                    'w-11 h-6 rounded-xl relative transition-colors duration-200',
-                    !isOwner ? 'cursor-default opacity-50' : 'cursor-pointer',
-                    (room?.settings?.allowSpectators ?? true) ? 'bg-accent' : 'bg-white/15'
-                  )}
-                >
-                  <span className={cn(
-                    'absolute top-0.5 left-0.5 h-5 w-5 rounded-full bg-white transition-transform',
-                    (room?.settings?.allowSpectators ?? true) ? 'translate-x-5' : ''
-                  )} />
-                </button>
-              </div>
-              {(room?.settings?.allowSpectators ?? true) && (
-                <div className="flex items-center justify-between">
-                  <label className="text-sm">观战模式</label>
-                  <select
-                    value={room?.settings?.spectatorMode ?? 'hidden'}
-                    onChange={(e) => getSocket().emit('room:update_settings', { spectatorMode: e.target.value as 'full' | 'hidden' })}
-                    className={cn(
-                      'bg-white/[0.06] text-foreground border border-white/10 rounded-xl px-3 py-1.5 text-sm outline-none cursor-pointer',
-                      !isOwner && 'opacity-50 cursor-default'
-                    )}
-                    disabled={!isOwner}
-                  >
-                    <option value="hidden">只看出牌</option>
-                    <option value="full">全透视</option>
-                  </select>
-                </div>
-              )}
-            </div>
-
-            <div className="border-b border-white/5 my-4" />
-
-            {/* House rules section */}
-            <h3 className="mb-3 text-sm text-accent font-game">村规设置</h3>
-            <div className="flex gap-2 mb-3 flex-wrap">
-              {(['classic', 'party', 'crazy'] as const).map((p) => (
-                <Button key={p} variant="outline" size="sm" onClick={() => applyPreset(p)} disabled={!isOwner} sound="click">
-                  {p === 'classic' ? '经典' : p === 'party' ? '派对' : '疯狂'}
-                </Button>
-              ))}
-            </div>
-            <div className="flex-1 overflow-y-auto scrollbar-thin min-h-0">
-              {RULES.map((rule) => (
-                <div key={rule.key} className="flex justify-between items-center py-1.5 border-b border-white/5">
-                  <div className="flex-1">
-                    <div className="text-caption">{rule.label}</div>
-                    <div className="text-xs text-muted-foreground">{rule.description}</div>
-                  </div>
-                  {rule.type === 'boolean' ? (
-                    <button
-                      onClick={() => toggleRule(rule.key)}
-                      disabled={!isOwner}
-                      className={cn(
-                        'w-11 h-6 rounded-xl border-none relative transition-colors duration-200',
-                        !isOwner ? 'cursor-default' : 'cursor-pointer',
-                        houseRules[rule.key] ? 'bg-accent' : 'bg-switch-off'
-                      )}
-                    >
-                      <div className={cn(
-                        'w-toggle-knob h-toggle-knob rounded-full bg-white absolute top-toggle-off transition-[left] duration-200',
-                        houseRules[rule.key] ? 'left-toggle-on' : 'left-toggle-off'
-                      )} />
-                    </button>
-                  ) : (
-                    <select
-                      value={String(houseRules[rule.key] ?? 'null')}
-                      onChange={(e) => {
-                        const v = e.target.value;
-                        setRuleValue(rule.key, v === 'null' ? null : Number(v));
-                      }}
-                      disabled={!isOwner}
-                      className="bg-white/[0.06] text-foreground border border-white/10 rounded-xl px-3 py-1.5 text-xs outline-none cursor-pointer"
-                    >
-                      {rule.options?.map((opt) => (
-                        <option key={String(opt.value)} value={String(opt.value ?? 'null')}>{opt.label}</option>
-                      ))}
-                    </select>
-                  )}
-                </div>
-              ))}
-            </div>
-          </div>
-        </div>
+        {/* Spectator bar */}
+        <SpectatorBar spectators={spectators} compact={compact} />
 
         {/* Action buttons */}
         <div className="flex flex-col items-center gap-2 shrink-0">
-          <div className="flex flex-wrap justify-center gap-2.5">
-            {myPlayer?.spectator ? (
-              <Button variant="game" onClick={toggleSpectator} sound="click" className="text-sm md:text-base px-5 py-2.5 tracking-normal">
-                取消观战
+          {isSpectator ? (
+            <p className="text-xs text-blue-400/60">点击空座位入座</p>
+          ) : myPlayer ? (
+            <div className="flex flex-wrap justify-center gap-2.5">
+              <Button
+                variant="game"
+                onClick={toggleReady}
+                sound="ready"
+                className="text-sm md:text-base px-5 py-2.5 tracking-normal"
+              >
+                {myPlayer.ready ? '取消准备' : '准备'}
               </Button>
-            ) : (
-              <>
-                <Button variant="game" onClick={toggleReady} sound="ready" className="text-sm md:text-base px-5 py-2.5 tracking-normal">
-                  {myPlayer?.ready ? '取消准备' : '准备'}
+              {isOwner && (
+                <Button
+                  variant="game"
+                  className={cn(
+                    'text-sm md:text-base px-5 py-2.5 tracking-normal',
+                    !allReady && 'opacity-50',
+                  )}
+                  onClick={startGame}
+                  disabled={!allReady}
+                  sound="ready"
+                >
+                  开始游戏
                 </Button>
-                {isOwner && (
-                  <Button variant="game" className={cn('text-sm md:text-base px-5 py-2.5 tracking-normal', !allReady && 'opacity-50')} onClick={startGame} disabled={!allReady} sound="ready">
-                    开始游戏
-                  </Button>
-                )}
-              </>
-            )}
-          </div>
+              )}
+            </div>
+          ) : null}
           <div className="flex flex-wrap justify-center gap-2">
-            {!myPlayer?.spectator && (
-              <Button variant="secondary" onClick={toggleSpectator} sound="click" size="sm" className="text-xs px-3 py-1.5">
-                <Eye size={12} className="inline align-middle mr-1" />观战
+            {myPlayer && (
+              <Button
+                variant="secondary"
+                onClick={() => {
+                  getSocket().emit(
+                    'seat:leave',
+                    (res: { success?: boolean; error?: string }) => {
+                      if (!res?.success && res?.error)
+                        useToastStore.getState().addToast(res.error, 'error');
+                    },
+                  );
+                }}
+                sound="click"
+                size="sm"
+                className="text-xs px-3 py-1.5"
+              >
+                <Eye size={12} className="inline align-middle mr-1" />
+                观战
               </Button>
             )}
-            <Button variant="secondary" onClick={leaveRoom} sound="click" size="sm" className="text-xs px-3 py-1.5">
+            {isOwner && seatedPlayers.length < 10 && <BotAddButton />}
+            <Button
+              variant="secondary"
+              onClick={leaveRoom}
+              sound="click"
+              size="sm"
+              className="text-xs px-3 py-1.5"
+            >
               离开房间
             </Button>
             {isOwner && (
-              <Button variant="danger" onClick={dissolveRoom} sound="danger" size="sm" className="text-xs px-3 py-1.5">
-                <Trash2 size={12} className="inline align-middle mr-1" />解散房间
+              <Button
+                variant="danger"
+                onClick={dissolveRoom}
+                sound="danger"
+                size="sm"
+                className="text-xs px-3 py-1.5"
+              >
+                <Trash2 size={12} className="inline align-middle mr-1" />
+                解散房间
               </Button>
             )}
           </div>
         </div>
 
-        {menuTarget && (
-          <PlayerActionMenu
-            target={menuTarget.player}
-            isOwner={isOwner}
-            roomStatus={room?.status ?? ''}
-            position={menuTarget.position}
-            onClose={() => setMenuTarget(null)}
-          />
-        )}
+        {/* Settings gear (top-right) */}
+        <button
+          className="absolute top-4 right-4 w-9 h-9 bg-white/[0.08] border border-white/15 rounded-lg flex items-center justify-center hover:bg-white/15 cursor-pointer transition-colors"
+          onClick={() => setSettingsOpen(true)}
+          title="房间设置"
+        >
+          <Settings size={16} className="text-muted-foreground" />
+        </button>
       </div>
+
+      <SettingsDrawer
+        open={settingsOpen}
+        onClose={() => setSettingsOpen(false)}
+        isOwner={isOwner}
+        room={room as any}
+        houseRules={houseRules}
+        onHouseRulesChange={setHouseRules}
+      />
+      {swapRequest && (
+        <SwapRequestDialog
+          requesterId={swapRequest.requesterId}
+          requesterName={swapRequest.requesterName}
+          requesterSeatIndex={swapRequest.requesterSeatIndex}
+          onRespond={handleSwapRespond}
+        />
+      )}
+      {menuTarget && (
+        <PlayerActionMenu
+          target={menuTarget.player as any}
+          isOwner={isOwner}
+          roomStatus={room?.status ?? ''}
+          position={menuTarget.position}
+          onClose={() => setMenuTarget(null)}
+        />
+      )}
       <VoicePanel />
       <BgmToast song={songName} />
     </GamePageShell>

--- a/packages/client/src/features/game/pages/RoomPage.tsx
+++ b/packages/client/src/features/game/pages/RoomPage.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { Copy, Eye, Settings, Trash2 } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
-import { BotAddButton } from '../components/BotAddButton';
 import { useAuthStore } from '@/features/auth/stores/auth-store';
 import { useRoomStore } from '@/shared/stores/room-store';
 import type { RoomSeatPlayer } from '@/shared/stores/room-store';
@@ -23,6 +22,8 @@ import SeatCircle from '../components/SeatCircle';
 import SpectatorBar from '../components/SpectatorBar';
 import SettingsDrawer from '../components/SettingsDrawer';
 import SwapRequestDialog from '../components/SwapRequestDialog';
+import { SeatContextMenu } from '../components/SeatContextMenu';
+import type { BotDifficulty } from '@uno-online/shared';
 
 /* ── Component ── */
 
@@ -45,6 +46,11 @@ export default function RoomPage() {
   const [menuTarget, setMenuTarget] = useState<{
     player: RoomSeatPlayer;
     seatIndex: number;
+    position: { x: number; y: number };
+  } | null>(null);
+  const [seatMenu, setSeatMenu] = useState<{
+    seatIndex: number;
+    player: RoomSeatPlayer | null;
     position: { x: number; y: number };
   } | null>(null);
 
@@ -178,38 +184,58 @@ export default function RoomPage() {
   };
 
   /* Seat click handler */
-  const handleSeatClick = (seatIndex: number) => {
+  const handleSeatClick = (seatIndex: number, e?: React.MouseEvent) => {
     const seat = seats[seatIndex];
+    const pos = e ? { x: e.clientX, y: e.clientY } : { x: window.innerWidth / 2, y: window.innerHeight / 2 };
+
     if (!seat) {
-      // Empty seat: take it
-      getSocket().emit(
-        'seat:take',
-        seatIndex,
-        (res: { success?: boolean; error?: string }) => {
-          if (!res?.success && res?.error)
-            useToastStore.getState().addToast(res.error, 'error');
-        },
-      );
+      // Empty seat: if spectator, take directly; if seated/owner, show context menu
+      if (isSpectator) {
+        getSocket().emit('seat:take', seatIndex, (res: { success?: boolean; error?: string }) => {
+          if (!res?.success && res?.error) useToastStore.getState().addToast(res.error, 'error');
+        });
+      } else {
+        setSeatMenu({ seatIndex, player: null, position: pos });
+      }
     } else if (seat.userId === user?.id) {
       // My seat: no action
     } else if (seat.isBot) {
-      // Bot: swap directly (no confirmation needed)
-      getSocket().emit(
-        'seat:swap_request',
-        seat.userId,
-        (res: { success?: boolean; error?: string }) => {
-          if (!res?.success && res?.error)
-            useToastStore.getState().addToast(res.error, 'error');
-        },
-      );
+      // Bot: show context menu (swap, difficulty, remove)
+      setSeatMenu({ seatIndex, player: seat, position: pos });
     } else {
       // Other player: show action menu
-      setMenuTarget({
-        player: seat,
-        seatIndex,
-        position: { x: window.innerWidth / 2, y: window.innerHeight / 2 },
-      });
+      setMenuTarget({ player: seat, seatIndex, position: pos });
     }
+  };
+
+  const handleTakeSeat = (seatIndex: number) => {
+    getSocket().emit('seat:take', seatIndex, (res: { success?: boolean; error?: string }) => {
+      if (!res?.success && res?.error) useToastStore.getState().addToast(res.error, 'error');
+    });
+  };
+
+  const handleAddBot = (difficulty: BotDifficulty) => {
+    getSocket().emit('room:add_bot', { difficulty }, (res: { success?: boolean; error?: string }) => {
+      if (!res?.success && res?.error) useToastStore.getState().addToast(res.error, 'error');
+    });
+  };
+
+  const handleSwapWithBot = (targetUserId: string) => {
+    getSocket().emit('seat:swap_request', targetUserId, (res: { success?: boolean; error?: string }) => {
+      if (!res?.success && res?.error) useToastStore.getState().addToast(res.error, 'error');
+    });
+  };
+
+  const handleSetBotDifficulty = (botId: string, difficulty: BotDifficulty) => {
+    getSocket().emit('room:set_bot_difficulty', { botId, difficulty }, (res: { success?: boolean; error?: string }) => {
+      if (!res?.success && res?.error) useToastStore.getState().addToast(res.error, 'error');
+    });
+  };
+
+  const handleRemoveBot = (botId: string) => {
+    getSocket().emit('room:remove_bot', { botId }, (res: { success?: boolean; error?: string }) => {
+      if (!res?.success && res?.error) useToastStore.getState().addToast(res.error, 'error');
+    });
   };
 
   /* Swap respond handler */
@@ -308,7 +334,6 @@ export default function RoomPage() {
                 观战
               </Button>
             )}
-            {isOwner && seatedPlayers.length < 10 && <BotAddButton />}
             <Button
               variant="secondary"
               onClick={leaveRoom}
@@ -357,6 +382,21 @@ export default function RoomPage() {
           requesterName={swapRequest.requesterName}
           requesterSeatIndex={swapRequest.requesterSeatIndex}
           onRespond={handleSwapRespond}
+        />
+      )}
+      {seatMenu && (
+        <SeatContextMenu
+          seatIndex={seatMenu.seatIndex}
+          player={seatMenu.player}
+          isOwner={isOwner}
+          isMeSeated={!!myPlayer}
+          position={seatMenu.position}
+          onClose={() => setSeatMenu(null)}
+          onTakeSeat={() => handleTakeSeat(seatMenu.seatIndex)}
+          onAddBot={handleAddBot}
+          onSwapRequest={handleSwapWithBot}
+          onSetBotDifficulty={handleSetBotDifficulty}
+          onRemoveBot={handleRemoveBot}
         />
       )}
       {menuTarget && (

--- a/packages/client/src/features/game/pages/RoomPage.tsx
+++ b/packages/client/src/features/game/pages/RoomPage.tsx
@@ -214,8 +214,8 @@ export default function RoomPage() {
     });
   };
 
-  const handleAddBot = (difficulty: BotDifficulty) => {
-    getSocket().emit('room:add_bot', { difficulty }, (res: { success?: boolean; error?: string }) => {
+  const handleAddBot = (difficulty: BotDifficulty, seatIndex: number) => {
+    getSocket().emit('room:add_bot', { difficulty, seatIndex }, (res: { success?: boolean; error?: string }) => {
       if (!res?.success && res?.error) useToastStore.getState().addToast(res.error, 'error');
     });
   };

--- a/packages/client/src/features/lobby/pages/LobbyPage.tsx
+++ b/packages/client/src/features/lobby/pages/LobbyPage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Upload, X, ClipboardPaste, Music, Volume2, VolumeX, ArrowRight, BookOpen, Sparkles } from 'lucide-react';
 import { useRoomStore } from '@/shared/stores/room-store';
+import { SEAT_COUNT } from '@uno-online/shared';
 import { useSettingsStore } from '@/shared/stores/settings-store';
 import { loadCardPack, clearCardPack, isPackLoaded } from '@/shared/utils/card-images';
 import { getSocket, connectSocket } from '@/shared/socket';
@@ -42,7 +43,7 @@ export default function LobbyPage() {
     const checkRoom = () => {
       socket.emit('user:current_room', (res) => {
         if (cancelled || !res.roomCode) return;
-        setRoom(res.roomCode, [], null);
+        localStorage.setItem('lastRoomCode', res.roomCode);
         navigate(`/room/${res.roomCode}`);
       });
     };
@@ -59,8 +60,8 @@ export default function LobbyPage() {
     connectSocket();
     getSocket().emit('room:create', {}, (res: any) => {
       setLoading(false);
-      if (res.success) {
-        setRoom(res.roomCode, res.players, res.room);
+      if (res.success && res.roomCode) {
+        setRoom(res.roomCode, Array.from({ length: SEAT_COUNT }, () => null), [], res.room as any ?? { ownerId: '', status: 'waiting', settings: {} });
         navigate(`/room/${res.roomCode}`);
       }
     });
@@ -92,7 +93,7 @@ export default function LobbyPage() {
     getSocket().emit('room:join', code, (res: any) => {
       setLoading(false);
       if (res.success) {
-        setRoom(code, res.players, res.room);
+        setRoom(code, Array.from({ length: SEAT_COUNT }, () => null), [], res.room as any ?? { ownerId: '', status: 'waiting', settings: {} });
         navigate(res.rejoin ? `/game/${code}` : `/room/${code}`);
       } else {
         setError(res.error || '加入失败');

--- a/packages/client/src/shared/socket.ts
+++ b/packages/client/src/shared/socket.ts
@@ -2,7 +2,7 @@ import { io, type Socket as SocketType } from 'socket.io-client';
 import { getApiUrl } from './env';
 import type { ServerToClientEvents, ClientToServerEvents, PlayerView } from '@uno-online/shared';
 import { useGameStore } from '@/features/game/stores/game-store';
-import { useRoomStore, type RoomPlayer, type RoomData } from './stores/room-store';
+import { useRoomStore } from './stores/room-store';
 import { useToastStore } from './stores/toast-store';
 import { playSound } from './sound/sound-manager';
 import { useGatewayStore, type PlayerVoicePresence } from './voice/gateway-store';
@@ -35,11 +35,17 @@ export function getSocket(): TypedSocket {
       reconnectionDelayMax: 10000,
     });
 
-    socket.on('room:updated', (data) => {
-      useRoomStore.getState().updateRoom(data as unknown as { players?: RoomPlayer[]; room?: RoomData });
+    socket.on('room:updated', (data: Record<string, unknown>) => {
+      if (data.room) {
+        useRoomStore.getState().updateRoom({ room: data.room as any });
+      }
       if (useGameStore.getState().ownerTransferAt !== null) {
         useGameStore.getState().setOwnerTransferAt(null);
       }
+    });
+
+    socket.on('seat:updated', (data: { seats: unknown[]; spectators: unknown[] }) => {
+      useRoomStore.getState().updateSeats(data as any);
     });
 
     socket.on('voice:presence', (presence) => {
@@ -123,10 +129,10 @@ export function getSocket(): TypedSocket {
       }
     });
 
-    socket.on('game:back_to_room', (data: { players?: unknown[]; room?: unknown }) => {
+    socket.on('game:back_to_room', (data: { seats?: unknown[]; spectators?: unknown[]; room?: unknown }) => {
       const roomCode = useRoomStore.getState().roomCode;
-      if (data.players && data.room && roomCode) {
-        useRoomStore.getState().setRoom(roomCode, data.players as any, data.room as any);
+      if (data.seats && data.spectators && data.room && roomCode) {
+        useRoomStore.getState().setRoom(roomCode, data.seats as any, data.spectators as any, data.room as any);
       }
       useGameStore.getState().clearGame();
     });

--- a/packages/client/src/shared/stores/room-store.ts
+++ b/packages/client/src/shared/stores/room-store.ts
@@ -1,55 +1,46 @@
 import { create } from 'zustand';
-import type { RoomSettings, BotConfig } from '@uno-online/shared';
+import type { RoomSeatPlayer, RoomSpectator, RoomSeats } from '@uno-online/shared';
+import { SEAT_COUNT } from '@uno-online/shared';
 
-export interface RoomPlayer {
-  userId: string;
-  nickname: string;
-  avatarUrl?: string | null;
-  ready: boolean;
-  spectator?: boolean;
-  role?: string;
-  isBot: boolean;
-  botConfig?: BotConfig;
-}
+export type { RoomSeatPlayer, RoomSpectator, RoomSeats };
+export type RoomPlayer = RoomSeatPlayer;
 
-export interface RoomData {
+interface RoomData {
   ownerId: string;
   status: string;
-  settings: RoomSettings;
+  settings: Record<string, unknown>;
 }
 
 interface RoomState {
   roomCode: string | null;
-  players: RoomPlayer[];
+  seats: RoomSeats;
+  spectators: RoomSpectator[];
   room: RoomData | null;
-  setRoom: (roomCode: string, players: RoomPlayer[], room: RoomData | null) => void;
-  updateRoom: (data: { players?: RoomPlayer[]; room?: RoomData }) => void;
+  setRoom: (roomCode: string, seats: RoomSeats, spectators: RoomSpectator[], room: RoomData) => void;
+  updateSeats: (data: { seats: RoomSeats; spectators: RoomSpectator[] }) => void;
+  updateRoom: (data: { room?: RoomData }) => void;
   clearRoom: () => void;
 }
 
-function dedup(players: RoomPlayer[]): RoomPlayer[] {
-  const seen = new Set<string>();
-  return players.filter((p) => {
-    if (seen.has(p.userId)) return false;
-    seen.add(p.userId);
-    return true;
-  });
+function emptySeats(): RoomSeats {
+  return Array.from({ length: SEAT_COUNT }, () => null);
 }
 
 export const useRoomStore = create<RoomState>((set) => ({
-  roomCode: localStorage.getItem('roomCode'),
-  players: [],
+  roomCode: null,
+  seats: emptySeats(),
+  spectators: [],
   room: null,
-  setRoom: (roomCode, players, room) => {
-    localStorage.setItem('roomCode', roomCode);
-    set({ roomCode, players: dedup(players), room });
+  setRoom: (roomCode, seats, spectators, room) => {
+    localStorage.setItem('lastRoomCode', roomCode);
+    set({ roomCode, seats, spectators, room: room as RoomData });
   },
+  updateSeats: (data) => set({ seats: data.seats, spectators: data.spectators }),
   updateRoom: (data) => set((state) => ({
-    players: dedup(data.players ?? state.players),
-    room: data.room ?? state.room,
+    room: data.room ? data.room as RoomData : state.room,
   })),
   clearRoom: () => {
-    localStorage.removeItem('roomCode');
-    set({ roomCode: null, players: [], room: null });
+    localStorage.removeItem('lastRoomCode');
+    set({ roomCode: null, seats: emptySeats(), spectators: [], room: null });
   },
 }));

--- a/packages/client/src/shared/voice/voice-runtime.ts
+++ b/packages/client/src/shared/voice/voice-runtime.ts
@@ -75,10 +75,11 @@ function isMumbleUserForceMuted(mumbleUserId: number): boolean {
 
   const normalize = (name: string) => name.trim().replace(/[^\p{L}\p{N}_ .-]/gu, '').slice(0, 32).toLocaleLowerCase();
   const mumbleName = normalize(mumbleUser.name);
-  const { players } = useRoomStore.getState();
+  const { seats } = useRoomStore.getState();
+  const seatedPlayers = seats.filter((s): s is NonNullable<typeof s> => s !== null);
 
   return forceMutedIds.some(gameUserId => {
-    const player = players.find(p => p.userId === gameUserId);
+    const player = seatedPlayers.find(p => p.userId === gameUserId);
     return player && normalize(player.nickname) === mumbleName;
   });
 }

--- a/packages/mcp/src/socket-client.ts
+++ b/packages/mcp/src/socket-client.ts
@@ -173,6 +173,14 @@ export class UnoSocketClient {
     return this.request('game:kick_player', payload);
   }
 
+  takeSeat(seatIndex: number): Promise<Record<string, unknown>> {
+    return this.request('seat:take', seatIndex);
+  }
+
+  leaveSeat(): Promise<Record<string, unknown>> {
+    return this.request('seat:leave');
+  }
+
   rematch(): Promise<Record<string, unknown>> {
     return this.request('game:rematch');
   }

--- a/packages/mcp/src/tools/room.ts
+++ b/packages/mcp/src/tools/room.ts
@@ -72,4 +72,17 @@ export function registerRoomTools(server: McpUnoServer): void {
     { targetId: z.string().describe('目标玩家 ID') },
     (args) => wrapTool(() => server.getClient().kickPlayer({ targetId: args.targetId })),
   );
+
+  mcp.tool(
+    'take_seat',
+    '入座指定座位（0-9），加入房间后默认在观战席',
+    { seatIndex: z.number().min(0).max(9).describe('座位号（0-9）') },
+    (args) => wrapTool(() => server.getClient().takeSeat(args.seatIndex)),
+  );
+
+  mcp.tool(
+    'leave_seat',
+    '离开座位回到观战席',
+    () => wrapTool(() => server.getClient().leaveSeat()),
+  );
 }

--- a/packages/server/src/plugins/core/admin/routes.ts
+++ b/packages/server/src/plugins/core/admin/routes.ts
@@ -149,11 +149,7 @@ export function registerAdminRoutes(fastify: FastifyInstance, ctx: PluginContext
   fastify.get('/admin/rooms', { preHandler }, async () => {
     const roomKeys = await kv.keys('room:*');
     // Extract unique room codes (keys are like room:CODE, room:CODE:players)
-    const roomCodes = [...new Set(
-      roomKeys
-        .filter(k => !k.includes(':players') && !k.includes(':game'))
-        .map(k => k.replace('room:', ''))
-    )];
+    const roomCodes = [...new Set(roomKeys.map(k => k.split(':')[1]!))];
 
     const rooms = await Promise.all(
       roomCodes.map(async (code) => {

--- a/packages/server/src/plugins/core/admin/routes.ts
+++ b/packages/server/src/plugins/core/admin/routes.ts
@@ -3,7 +3,7 @@ import type { PluginContext } from '../../../plugin-context.js';
 import type { UserRole } from '@uno-online/shared';
 import type { AuthenticatedRequest } from '../auth/service.js';
 import { adminOnly } from './middleware.js';
-import { getRoom, getRoomPlayers, deleteRoom } from '../room/store.js';
+import { getRoom, getRoomSeats, getSeatedPlayers, deleteRoom } from '../room/store.js';
 import { sql } from 'kysely';
 
 export function registerAdminRoutes(fastify: FastifyInstance, ctx: PluginContext) {
@@ -159,13 +159,14 @@ export function registerAdminRoutes(fastify: FastifyInstance, ctx: PluginContext
       roomCodes.map(async (code) => {
         const room = await getRoom(kv, code);
         if (!room) return null;
-        const players = await getRoomPlayers(kv, code);
+        const seats = await getRoomSeats(kv, code);
+        const players = getSeatedPlayers(seats);
         return {
           code,
           ownerId: room.ownerId,
           status: room.status,
           playerCount: players.length,
-          players: players.map(p => ({ userId: p.userId, nickname: p.nickname })),
+          players: players.map((p: { userId: string; nickname: string }) => ({ userId: p.userId, nickname: p.nickname })),
           createdAt: room.createdAt,
         };
       })

--- a/packages/server/src/plugins/core/room/manager.ts
+++ b/packages/server/src/plugins/core/room/manager.ts
@@ -1,11 +1,13 @@
 import type { KvStore } from '../../../kv/types.js';
 import type { RoomSettings } from '@uno-online/shared';
-import { MAX_PLAYERS, ROOM_CODE_LENGTH, ROOM_CODE_CHARS, DEFAULT_HOUSE_RULES } from '@uno-online/shared';
+import { SEAT_COUNT, ROOM_CODE_LENGTH, ROOM_CODE_CHARS, DEFAULT_HOUSE_RULES } from '@uno-online/shared';
 import {
-  createRoom, getRoom, addPlayerToRoom, removePlayerFromRoom,
-  getRoomPlayers, setPlayerReady, setRoomOwner, deleteRoom,
-  setPlayerSpectator, resetAllPlayersReady,
+  createRoom, getRoom, deleteRoom,
+  getRoomSeats, takeSeat, clearSeatByUserId, setSeatPlayerReady,
+  resetAllSeatsReady, setRoomOwner, getSeatedPlayers, getFirstEmptySeatIndex,
+  getRoomSpectators, addSpectatorToRoom, removeSpectatorFromRoom,
 } from './store.js';
+import type { RoomSeatPlayer, RoomSpectator } from './store.js';
 
 function generateRoomCode(): string {
   let code = '';
@@ -18,7 +20,11 @@ function generateRoomCode(): string {
 export class RoomManager {
   constructor(private redis: KvStore) {}
 
-  async createRoom(ownerId: string, ownerNickname: string, settings: RoomSettings = { turnTimeLimit: 30, targetScore: 1000, houseRules: DEFAULT_HOUSE_RULES, allowSpectators: true, spectatorMode: 'hidden' }, avatarUrl?: string | null, role?: string, isBot?: boolean): Promise<string> {
+  async createRoom(
+    ownerId: string, ownerNickname: string,
+    settings: RoomSettings = { turnTimeLimit: 30, targetScore: 1000, houseRules: DEFAULT_HOUSE_RULES, allowSpectators: true, spectatorMode: 'hidden' },
+    avatarUrl?: string | null, role?: string, _isBot?: boolean,
+  ): Promise<string> {
     let code = generateRoomCode();
     let existing = await getRoom(this.redis, code);
     while (existing) {
@@ -26,58 +32,67 @@ export class RoomManager {
       existing = await getRoom(this.redis, code);
     }
     await createRoom(this.redis, code, ownerId, settings);
-    await addPlayerToRoom(this.redis, code, { userId: ownerId, nickname: ownerNickname, avatarUrl, role, isBot });
+    const player: RoomSeatPlayer = {
+      userId: ownerId, nickname: ownerNickname,
+      avatarUrl: avatarUrl ?? null, ready: false, connected: true,
+      role: role ?? 'normal', isBot: false,
+    };
+    await takeSeat(this.redis, code, 0, player);
     return code;
   }
 
-  async joinRoom(roomCode: string, userId: string, nickname: string, avatarUrl?: string | null, role?: string, isBot?: boolean): Promise<void> {
+  async joinRoom(
+    roomCode: string, userId: string, nickname: string,
+    avatarUrl?: string | null, role?: string, _isBot?: boolean,
+  ): Promise<void> {
     const room = await getRoom(this.redis, roomCode);
     if (!room) throw new Error('Room not found');
     if (room.status !== 'waiting') throw new Error('Game already in progress');
-    const players = await getRoomPlayers(this.redis, roomCode);
-    if (players.some((p) => p.userId === userId)) throw new Error('Already in room');
-    // MAX_PLAYERS gates the active roster, not the spectator bench — joining
-    // as a player should still succeed when the only thing filling the room
-    // is in-room spectators.
-    const activePlayers = players.filter((p) => !p.spectator);
-    if (activePlayers.length >= MAX_PLAYERS) throw new Error('Room is full');
-    await addPlayerToRoom(this.redis, roomCode, { userId, nickname, avatarUrl, role, isBot });
+    const seats = await getRoomSeats(this.redis, roomCode);
+    const spectators = await getRoomSpectators(this.redis, roomCode);
+    const alreadySeated = seats.some(s => s !== null && s.userId === userId);
+    const alreadySpectating = spectators.some(s => s.userId === userId);
+    if (alreadySeated || alreadySpectating) throw new Error('Already in room');
+    const spectator: RoomSpectator = {
+      userId, nickname, avatarUrl: avatarUrl ?? null, role: role ?? 'normal',
+    };
+    await addSpectatorToRoom(this.redis, roomCode, spectator);
   }
 
   async leaveRoom(roomCode: string, userId: string): Promise<{ deleted: boolean }> {
-    await removePlayerFromRoom(this.redis, roomCode, userId);
-    const players = await getRoomPlayers(this.redis, roomCode);
-    if (players.length === 0 || players.every(p => p.isBot)) {
-      for (const bot of players) {
-        await removePlayerFromRoom(this.redis, roomCode, bot.userId);
-      }
+    await clearSeatByUserId(this.redis, roomCode, userId);
+    await removeSpectatorFromRoom(this.redis, roomCode, userId);
+    const seats = await getRoomSeats(this.redis, roomCode);
+    const spectators = await getRoomSpectators(this.redis, roomCode);
+    const seatedPlayers = getSeatedPlayers(seats);
+    const allParticipants = [...seatedPlayers, ...spectators];
+    const hasHumans = allParticipants.some(p => !('isBot' in p && p.isBot));
+    if (allParticipants.length === 0 || !hasHumans) {
       await deleteRoom(this.redis, roomCode);
       return { deleted: true };
     }
     const room = await getRoom(this.redis, roomCode);
     if (room && room.ownerId === userId) {
-      const nextOwner = players.find((p) => !p.isBot)!;
-      await setRoomOwner(this.redis, roomCode, nextOwner.userId);
+      const nextOwner = seatedPlayers.find(p => !p.isBot) ?? spectators[0];
+      if (nextOwner) {
+        await setRoomOwner(this.redis, roomCode, nextOwner.userId);
+      }
     }
     return { deleted: false };
   }
 
   async setReady(roomCode: string, userId: string, ready: boolean): Promise<void> {
-    await setPlayerReady(this.redis, roomCode, userId, ready);
+    await setSeatPlayerReady(this.redis, roomCode, userId, ready);
   }
 
   async areAllReady(roomCode: string): Promise<boolean> {
-    const players = await getRoomPlayers(this.redis, roomCode);
-    const activePlayers = players.filter((p) => !p.spectator);
-    if (activePlayers.length < 2) return false;
-    return activePlayers.every((p) => p.ready);
-  }
-
-  async setSpectator(roomCode: string, userId: string, spectator: boolean): Promise<void> {
-    await setPlayerSpectator(this.redis, roomCode, userId, spectator);
+    const seats = await getRoomSeats(this.redis, roomCode);
+    const seated = getSeatedPlayers(seats);
+    if (seated.length < 2) return false;
+    return seated.every(p => p.ready);
   }
 
   async resetReady(roomCode: string): Promise<void> {
-    await resetAllPlayersReady(this.redis, roomCode);
+    await resetAllSeatsReady(this.redis, roomCode);
   }
 }

--- a/packages/server/src/plugins/core/room/store.ts
+++ b/packages/server/src/plugins/core/room/store.ts
@@ -1,5 +1,10 @@
 import type { KvStore } from '../../../kv/types.js';
 import type { RoomSettings, BotConfig } from '@uno-online/shared';
+import { SEAT_COUNT } from '@uno-online/shared';
+import type { RoomSeatPlayer, RoomSpectator, RoomSeats } from '@uno-online/shared';
+
+export type { RoomSeatPlayer, RoomSpectator, RoomSeats };
+export type RoomPlayer = RoomSeatPlayer;  // backward compat alias
 
 export interface RoomData {
   ownerId: string;
@@ -9,34 +14,27 @@ export interface RoomData {
   lastActivityAt: string;
 }
 
-export interface RoomPlayer {
-  userId: string;
-  nickname: string;
-  avatarUrl?: string | null;
-  ready: boolean;
-  spectator: boolean;
-  role?: string;
-  isBot: boolean;
-  botConfig?: BotConfig;
-}
+// ─── Lock ──────────────────────────────────────────────────────────────────
 
-const roomPlayerLocks = new Map<string, Promise<void>>();
+const roomSeatLocks = new Map<string, Promise<void>>();
 
-async function withRoomPlayerLock<T>(roomCode: string, fn: () => Promise<T>): Promise<T> {
-  const key = `room:${roomCode}:players`;
-  while (roomPlayerLocks.has(key)) {
-    await roomPlayerLocks.get(key);
+async function withRoomSeatLock<T>(roomCode: string, fn: () => Promise<T>): Promise<T> {
+  const key = `room:${roomCode}:seats`;
+  while (roomSeatLocks.has(key)) {
+    await roomSeatLocks.get(key);
   }
   let resolve!: () => void;
   const promise = new Promise<void>(r => { resolve = r; });
-  roomPlayerLocks.set(key, promise);
+  roomSeatLocks.set(key, promise);
   try {
     return await fn();
   } finally {
-    roomPlayerLocks.delete(key);
+    roomSeatLocks.delete(key);
     resolve();
   }
 }
+
+// ─── Room CRUD (unchanged) ─────────────────────────────────────────────────
 
 export async function createRoom(kv: KvStore, roomCode: string, ownerId: string, settings: RoomSettings): Promise<void> {
   const now = new Date().toISOString();
@@ -77,73 +75,11 @@ export async function setRoomOwner(kv: KvStore, roomCode: string, ownerId: strin
   await kv.hset(`room:${roomCode}`, { ownerId });
 }
 
-export async function getRoomPlayers(kv: KvStore, roomCode: string): Promise<RoomPlayer[]> {
-  const raw = await kv.get(`room:${roomCode}:players`);
-  if (!raw) return [];
-  return JSON.parse(raw) as RoomPlayer[];
-}
-
-async function setRoomPlayers(kv: KvStore, roomCode: string, players: RoomPlayer[]): Promise<void> {
-  if (players.length === 0) {
-    await kv.del(`room:${roomCode}:players`);
-  } else {
-    await kv.set(`room:${roomCode}:players`, JSON.stringify(players));
-  }
-}
-
-export async function addPlayerToRoom(kv: KvStore, roomCode: string, player: { userId: string; nickname: string; avatarUrl?: string | null; role?: string; isBot?: boolean; botConfig?: BotConfig }): Promise<void> {
-  await withRoomPlayerLock(roomCode, async () => {
-    const existing = await getRoomPlayers(kv, roomCode);
-    if (existing.some(p => p.userId === player.userId)) return;
-    existing.push({ userId: player.userId, nickname: player.nickname, avatarUrl: player.avatarUrl ?? null, ready: false, spectator: false, role: player.role ?? 'normal', isBot: player.isBot ?? false, botConfig: player.botConfig });
-    await setRoomPlayers(kv, roomCode, existing);
-  });
-}
-
-export async function removePlayerFromRoom(kv: KvStore, roomCode: string, userId: string): Promise<void> {
-  await withRoomPlayerLock(roomCode, async () => {
-    const players = await getRoomPlayers(kv, roomCode);
-    const remaining = players.filter((p) => p.userId !== userId);
-    await setRoomPlayers(kv, roomCode, remaining);
-  });
-}
-
-export async function setPlayerReady(kv: KvStore, roomCode: string, userId: string, ready: boolean): Promise<void> {
-  await withRoomPlayerLock(roomCode, async () => {
-    const players = await getRoomPlayers(kv, roomCode);
-    const updated = players.map((p) => p.userId === userId ? { ...p, ready } : p);
-    await setRoomPlayers(kv, roomCode, updated);
-  });
-}
-
-export async function setPlayerSpectator(kv: KvStore, roomCode: string, userId: string, spectator: boolean): Promise<void> {
-  await withRoomPlayerLock(roomCode, async () => {
-    const players = await getRoomPlayers(kv, roomCode);
-    const updated = players.map((p) => p.userId === userId ? { ...p, spectator, ready: spectator ? false : p.ready } : p);
-    await setRoomPlayers(kv, roomCode, updated);
-  });
-}
-
-export async function setPlayerBotConfig(kv: KvStore, roomCode: string, userId: string, botConfig: BotConfig): Promise<void> {
-  await withRoomPlayerLock(roomCode, async () => {
-    const players = await getRoomPlayers(kv, roomCode);
-    const updated = players.map((p) => p.userId === userId ? { ...p, botConfig } : p);
-    await setRoomPlayers(kv, roomCode, updated);
-  });
-}
-
-export async function resetAllPlayersReady(kv: KvStore, roomCode: string): Promise<void> {
-  await withRoomPlayerLock(roomCode, async () => {
-    const players = await getRoomPlayers(kv, roomCode);
-    const updated = players.map((p) => ({ ...p, ready: false }));
-    await setRoomPlayers(kv, roomCode, updated);
-  });
-}
-
 export async function deleteRoom(kv: KvStore, roomCode: string): Promise<void> {
   await kv.del(
     `room:${roomCode}`,
-    `room:${roomCode}:players`,
+    `room:${roomCode}:seats`,
+    `room:${roomCode}:spectators`,
     `game:${roomCode}:state`,
   );
 }
@@ -169,4 +105,195 @@ export async function ensureNotInRoom(kv: KvStore, userId: string, targetRoomCod
     return null;
   }
   return `你已在房间 ${existingRoom} 中，请先退出当前房间`;
+}
+
+// ─── Seat helpers ──────────────────────────────────────────────────────────
+
+function emptySeats(): RoomSeats {
+  return Array.from({ length: SEAT_COUNT }, () => null);
+}
+
+export async function getRoomSeats(kv: KvStore, roomCode: string): Promise<RoomSeats> {
+  const raw = await kv.get(`room:${roomCode}:seats`);
+  if (!raw) return emptySeats();
+  const parsed = JSON.parse(raw) as RoomSeats;
+  // Pad to SEAT_COUNT if stored array is shorter
+  while (parsed.length < SEAT_COUNT) {
+    parsed.push(null);
+  }
+  return parsed;
+}
+
+export async function setRoomSeats(kv: KvStore, roomCode: string, seats: RoomSeats): Promise<void> {
+  await kv.set(`room:${roomCode}:seats`, JSON.stringify(seats));
+}
+
+export async function takeSeat(
+  kv: KvStore,
+  roomCode: string,
+  seatIndex: number,
+  player: RoomSeatPlayer,
+): Promise<void> {
+  await withRoomSeatLock(roomCode, async () => {
+    if (seatIndex < 0 || seatIndex >= SEAT_COUNT) {
+      throw new Error(`无效座位编号: ${seatIndex}`);
+    }
+    const seats = await getRoomSeats(kv, roomCode);
+    if (seats[seatIndex] !== null) {
+      throw new Error(`座位 ${seatIndex} 已被占用`);
+    }
+    // Clear player from any existing seat first
+    for (let i = 0; i < seats.length; i++) {
+      if (seats[i]?.userId === player.userId) {
+        seats[i] = null;
+        break;
+      }
+    }
+    seats[seatIndex] = player;
+    await setRoomSeats(kv, roomCode, seats);
+  });
+}
+
+export async function leaveSeat(kv: KvStore, roomCode: string, userId: string): Promise<number> {
+  return withRoomSeatLock(roomCode, async () => {
+    const seats = await getRoomSeats(kv, roomCode);
+    const index = seats.findIndex(s => s?.userId === userId);
+    if (index !== -1) {
+      seats[index] = null;
+      await setRoomSeats(kv, roomCode, seats);
+    }
+    return index;
+  });
+}
+
+export async function swapSeats(
+  kv: KvStore,
+  roomCode: string,
+  userId1: string,
+  userId2: string,
+): Promise<{ seat1: number; seat2: number }> {
+  return withRoomSeatLock(roomCode, async () => {
+    const seats = await getRoomSeats(kv, roomCode);
+    const seat1 = seats.findIndex(s => s?.userId === userId1);
+    const seat2 = seats.findIndex(s => s?.userId === userId2);
+    if (seat1 === -1) throw new Error(`用户 ${userId1} 未就座`);
+    if (seat2 === -1) throw new Error(`用户 ${userId2} 未就座`);
+    [seats[seat1], seats[seat2]] = [seats[seat2], seats[seat1]];
+    await setRoomSeats(kv, roomCode, seats);
+    return { seat1, seat2 };
+  });
+}
+
+export async function setSeatPlayerReady(
+  kv: KvStore,
+  roomCode: string,
+  userId: string,
+  ready: boolean,
+): Promise<void> {
+  await withRoomSeatLock(roomCode, async () => {
+    const seats = await getRoomSeats(kv, roomCode);
+    const index = seats.findIndex(s => s?.userId === userId);
+    if (index !== -1) {
+      seats[index] = { ...seats[index]!, ready };
+      await setRoomSeats(kv, roomCode, seats);
+    }
+  });
+}
+
+export async function setSeatPlayerConnected(
+  kv: KvStore,
+  roomCode: string,
+  userId: string,
+  connected: boolean,
+): Promise<void> {
+  await withRoomSeatLock(roomCode, async () => {
+    const seats = await getRoomSeats(kv, roomCode);
+    const index = seats.findIndex(s => s?.userId === userId);
+    if (index !== -1) {
+      seats[index] = {
+        ...seats[index]!,
+        connected,
+        // When disconnecting, also mark as not ready
+        ready: connected ? seats[index]!.ready : false,
+      };
+      await setRoomSeats(kv, roomCode, seats);
+    }
+  });
+}
+
+export async function setSeatPlayerBotConfig(
+  kv: KvStore,
+  roomCode: string,
+  userId: string,
+  botConfig: BotConfig,
+): Promise<void> {
+  await withRoomSeatLock(roomCode, async () => {
+    const seats = await getRoomSeats(kv, roomCode);
+    const index = seats.findIndex(s => s?.userId === userId);
+    if (index !== -1) {
+      seats[index] = { ...seats[index]!, botConfig };
+      await setRoomSeats(kv, roomCode, seats);
+    }
+  });
+}
+
+export async function clearSeatByUserId(kv: KvStore, roomCode: string, userId: string): Promise<number> {
+  return withRoomSeatLock(roomCode, async () => {
+    const seats = await getRoomSeats(kv, roomCode);
+    const index = seats.findIndex(s => s?.userId === userId);
+    if (index !== -1) {
+      seats[index] = null;
+      await setRoomSeats(kv, roomCode, seats);
+    }
+    return index;
+  });
+}
+
+export async function resetAllSeatsReady(kv: KvStore, roomCode: string): Promise<void> {
+  await withRoomSeatLock(roomCode, async () => {
+    const seats = await getRoomSeats(kv, roomCode);
+    const updated = seats.map(s => s !== null ? { ...s, ready: false } : null);
+    await setRoomSeats(kv, roomCode, updated);
+  });
+}
+
+export function getFirstEmptySeatIndex(seats: RoomSeats): number {
+  return seats.findIndex(s => s === null);
+}
+
+export function getSeatedPlayers(seats: RoomSeats): RoomSeatPlayer[] {
+  return seats.filter((s): s is RoomSeatPlayer => s !== null);
+}
+
+// ─── Spectator CRUD ────────────────────────────────────────────────────────
+
+export async function getRoomSpectators(kv: KvStore, roomCode: string): Promise<RoomSpectator[]> {
+  const raw = await kv.get(`room:${roomCode}:spectators`);
+  if (!raw) return [];
+  return JSON.parse(raw) as RoomSpectator[];
+}
+
+async function setRoomSpectators(kv: KvStore, roomCode: string, spectators: RoomSpectator[]): Promise<void> {
+  if (spectators.length === 0) {
+    await kv.del(`room:${roomCode}:spectators`);
+  } else {
+    await kv.set(`room:${roomCode}:spectators`, JSON.stringify(spectators));
+  }
+}
+
+export async function addSpectatorToRoom(kv: KvStore, roomCode: string, spectator: RoomSpectator): Promise<void> {
+  await withRoomSeatLock(roomCode, async () => {
+    const spectators = await getRoomSpectators(kv, roomCode);
+    if (spectators.some(s => s.userId === spectator.userId)) return;
+    spectators.push(spectator);
+    await setRoomSpectators(kv, roomCode, spectators);
+  });
+}
+
+export async function removeSpectatorFromRoom(kv: KvStore, roomCode: string, userId: string): Promise<void> {
+  await withRoomSeatLock(roomCode, async () => {
+    const spectators = await getRoomSpectators(kv, roomCode);
+    const remaining = spectators.filter(s => s.userId !== userId);
+    await setRoomSpectators(kv, roomCode, remaining);
+  });
 }

--- a/packages/server/src/plugins/core/room/store.ts
+++ b/packages/server/src/plugins/core/room/store.ts
@@ -178,7 +178,7 @@ export async function swapSeats(
     const seat2 = seats.findIndex(s => s?.userId === userId2);
     if (seat1 === -1) throw new Error(`用户 ${userId1} 未就座`);
     if (seat2 === -1) throw new Error(`用户 ${userId2} 未就座`);
-    [seats[seat1], seats[seat2]] = [seats[seat2], seats[seat1]];
+    [seats[seat1], seats[seat2]] = [seats[seat2]!, seats[seat1]!];
     await setRoomSeats(kv, roomCode, seats);
     return { seat1, seat2 };
   });

--- a/packages/server/src/plugins/core/spectate/routes.ts
+++ b/packages/server/src/plugins/core/spectate/routes.ts
@@ -7,11 +7,10 @@ import { getRoom, getRoomSeats, getSeatedPlayers } from '../room/store.js';
 
 export async function getActiveRooms(kv: KvStore, io: SocketIOServer): Promise<ActiveRoomInfo[]> {
   const allKeys = await kv.keys('room:*');
-  const roomKeys = allKeys.filter(k => !k.includes(':players') && !k.includes(':state'));
+  const roomCodes = [...new Set(allKeys.map(k => k.split(':')[1]!))].filter(Boolean);
 
   const activeRooms: ActiveRoomInfo[] = [];
-  for (const key of roomKeys) {
-    const roomCode = key.replace('room:', '');
+  for (const roomCode of roomCodes) {
     const room = await getRoom(kv, roomCode);
     if (!room || room.status !== 'playing') continue;
 

--- a/packages/server/src/plugins/core/spectate/routes.ts
+++ b/packages/server/src/plugins/core/spectate/routes.ts
@@ -3,7 +3,7 @@ import type { Server as SocketIOServer } from 'socket.io';
 import type { ActiveRoomInfo } from '@uno-online/shared';
 import type { PluginContext } from '../../../plugin-context.js';
 import type { KvStore } from '../../../kv/types.js';
-import { getRoom, getRoomPlayers } from '../room/store.js';
+import { getRoom, getRoomSeats, getSeatedPlayers } from '../room/store.js';
 
 export async function getActiveRooms(kv: KvStore, io: SocketIOServer): Promise<ActiveRoomInfo[]> {
   const allKeys = await kv.keys('room:*');
@@ -18,7 +18,8 @@ export async function getActiveRooms(kv: KvStore, io: SocketIOServer): Promise<A
     const settings = room.settings;
     if (!settings.allowSpectators) continue;
 
-    const players = await getRoomPlayers(kv, roomCode);
+    const seats = await getRoomSeats(kv, roomCode);
+    const players = getSeatedPlayers(seats);
     if (players.length === 0) continue;
 
     const spectatorSockets = await io.in(roomCode).fetchSockets();
@@ -26,7 +27,7 @@ export async function getActiveRooms(kv: KvStore, io: SocketIOServer): Promise<A
 
     activeRooms.push({
       roomCode,
-      players: players.map(p => ({ nickname: p.nickname, avatarUrl: p.avatarUrl })),
+      players: players.map((p: { nickname: string; avatarUrl?: string | null }) => ({ nickname: p.nickname, avatarUrl: p.avatarUrl })),
       playerCount: players.length,
       startedAt: room.createdAt,
       spectatorCount,

--- a/packages/server/src/ws/bot-manager.ts
+++ b/packages/server/src/ws/bot-manager.ts
@@ -32,13 +32,16 @@ export async function addBot(
   requesterId: string,
   difficulty: BotDifficulty,
   session?: GameSession,
+  targetSeatIndex?: number,
 ): Promise<{ success: true; botId: string } | { success: false; error: string }> {
   const room = await getRoom(redis, roomCode);
   if (!room) return { success: false, error: '房间不存在' };
   if (room.ownerId !== requesterId) return { success: false, error: '只有房主可以添加机器人' };
 
   const seats = await getRoomSeats(redis, roomCode);
-  const seatIndex = getFirstEmptySeatIndex(seats);
+  const seatIndex = targetSeatIndex !== undefined && targetSeatIndex >= 0 && targetSeatIndex < seats.length && seats[targetSeatIndex] === null
+    ? targetSeatIndex
+    : getFirstEmptySeatIndex(seats);
   if (seatIndex === -1) return { success: false, error: '没有空座位' };
 
   const botId = `bot_${randomUUID()}`;

--- a/packages/server/src/ws/bot-manager.ts
+++ b/packages/server/src/ws/bot-manager.ts
@@ -2,10 +2,10 @@ import { randomUUID } from 'node:crypto';
 import type { Server as SocketIOServer } from 'socket.io';
 import type { KvStore } from '../kv/types.js';
 import type { BotDifficulty, BotPersonality } from '@uno-online/shared';
-import { pickBotName, DIFFICULTY_PARAMS, MAX_PLAYERS, BOT_PERSONALITIES } from '@uno-online/shared';
+import { pickBotName, DIFFICULTY_PARAMS, BOT_PERSONALITIES } from '@uno-online/shared';
 import type { BotConfig } from '@uno-online/shared';
-import { RoomManager } from '../plugins/core/room/manager.js';
-import { getRoom, getRoomPlayers, setPlayerReady, addPlayerToRoom, setPlayerBotConfig } from '../plugins/core/room/store.js';
+import { getRoomSeats, getRoom, takeSeat, clearSeatByUserId, getFirstEmptySeatIndex, getSeatedPlayers, setSeatPlayerBotConfig, getRoomSpectators } from '../plugins/core/room/store.js';
+import type { RoomSeatPlayer } from '../plugins/core/room/store.js';
 import type { GameSession } from '../plugins/core/game/session.js';
 
 /**
@@ -28,7 +28,6 @@ export function calculateBotDelay(difficulty: BotDifficulty, playableCount: numb
 export async function addBot(
   io: SocketIOServer,
   redis: KvStore,
-  roomManager: RoomManager,
   roomCode: string,
   requesterId: string,
   difficulty: BotDifficulty,
@@ -38,51 +37,45 @@ export async function addBot(
   if (!room) return { success: false, error: '房间不存在' };
   if (room.ownerId !== requesterId) return { success: false, error: '只有房主可以添加机器人' };
 
-  const players = await getRoomPlayers(redis, roomCode);
-  const activePlayers = players.filter((p) => !p.spectator);
-  if (activePlayers.length >= MAX_PLAYERS) return { success: false, error: '房间已满' };
+  const seats = await getRoomSeats(redis, roomCode);
+  const seatIndex = getFirstEmptySeatIndex(seats);
+  if (seatIndex === -1) return { success: false, error: '没有空座位' };
 
   const botId = `bot_${randomUUID()}`;
-  const usedNames = new Set(players.map((p) => p.nickname));
+  const usedNames = new Set(getSeatedPlayers(seats).map((p) => p.nickname));
   const name = pickBotName(usedNames);
   const personality: BotPersonality =
     BOT_PERSONALITIES[Math.floor(Math.random() * BOT_PERSONALITIES.length)]!;
   const botConfig: BotConfig = { difficulty, personality };
 
+  const botPlayer: RoomSeatPlayer = {
+    userId: botId,
+    nickname: name,
+    avatarUrl: null,
+    ready: true,
+    connected: true,
+    role: 'normal',
+    isBot: true,
+    botConfig,
+  };
+
   if (room.status === 'waiting') {
-    // Add directly via store so we can include botConfig, since
-    // RoomManager.joinRoom does not accept botConfig.
-    await addPlayerToRoom(redis, roomCode, {
-      userId: botId,
-      nickname: name,
-      avatarUrl: null,
-      role: 'normal',
-      isBot: true,
-      botConfig,
-    });
-    await setPlayerReady(redis, roomCode, botId, true);
+    await takeSeat(redis, roomCode, seatIndex, botPlayer);
   } else if (session) {
-    // Game in progress: add to store and to the live session.
-    await addPlayerToRoom(redis, roomCode, {
-      userId: botId,
-      nickname: name,
-      avatarUrl: null,
-      role: 'normal',
-      isBot: true,
-      botConfig,
-    });
+    // Game in progress: take seat and add to the live session.
+    await takeSeat(redis, roomCode, seatIndex, botPlayer);
     session.addPlayer({ id: botId, name, avatarUrl: null, isBot: true, botConfig }, true);
   } else {
     return { success: false, error: '游戏进行中，无法添加机器人' };
   }
 
-  const [updatedPlayers, updatedRoom] = await Promise.all([
-    getRoomPlayers(redis, roomCode),
-    getRoom(redis, roomCode),
+  const [updatedSeats, spectators] = await Promise.all([
+    getRoomSeats(redis, roomCode),
+    getRoomSpectators(redis, roomCode),
   ]);
 
+  io.to(roomCode).emit('seat:updated', { seats: updatedSeats, spectators });
   io.to(roomCode).emit('room:bot_added', { botId, name, difficulty, personality });
-  io.to(roomCode).emit('room:updated', { players: updatedPlayers, room: updatedRoom });
 
   return { success: true, botId };
 }
@@ -96,7 +89,6 @@ export async function addBot(
 export async function removeBot(
   io: SocketIOServer,
   redis: KvStore,
-  roomManager: RoomManager,
   roomCode: string,
   requesterId: string,
   botId: string,
@@ -106,23 +98,23 @@ export async function removeBot(
   if (!room) return { success: false, error: '房间不存在' };
   if (room.ownerId !== requesterId) return { success: false, error: '只有房主可以移除机器人' };
 
-  const players = await getRoomPlayers(redis, roomCode);
-  const target = players.find((p) => p.userId === botId);
+  const seats = await getRoomSeats(redis, roomCode);
+  const target = seats.find((s) => s !== null && s.userId === botId);
   if (!target) return { success: false, error: '机器人不在房间中' };
   if (!target.isBot) return { success: false, error: '目标玩家不是机器人' };
 
   if (session) {
     session.removePlayer(botId);
   }
-  await roomManager.leaveRoom(roomCode, botId);
+  await clearSeatByUserId(redis, roomCode, botId);
 
-  const [updatedPlayers, updatedRoom] = await Promise.all([
-    getRoomPlayers(redis, roomCode),
-    getRoom(redis, roomCode),
+  const [updatedSeats, spectators] = await Promise.all([
+    getRoomSeats(redis, roomCode),
+    getRoomSpectators(redis, roomCode),
   ]);
 
+  io.to(roomCode).emit('seat:updated', { seats: updatedSeats, spectators });
   io.to(roomCode).emit('room:bot_removed', { botId });
-  io.to(roomCode).emit('room:updated', { players: updatedPlayers, room: updatedRoom });
 
   return { success: true };
 }
@@ -143,8 +135,8 @@ export async function setBotDifficulty(
   if (!room) return { success: false, error: '房间不存在' };
   if (room.ownerId !== requesterId) return { success: false, error: '只有房主可以修改机器人难度' };
 
-  const players = await getRoomPlayers(redis, roomCode);
-  const target = players.find(p => p.userId === botId);
+  const seats = await getRoomSeats(redis, roomCode);
+  const target = seats.find((s) => s !== null && s.userId === botId);
   if (!target || !target.isBot) return { success: false, error: '目标不是人机' };
 
   // Persist to KV store
@@ -152,7 +144,7 @@ export async function setBotDifficulty(
     difficulty,
     personality: target.botConfig?.personality ?? 'balanced',
   };
-  await setPlayerBotConfig(redis, roomCode, botId, newBotConfig);
+  await setSeatPlayerBotConfig(redis, roomCode, botId, newBotConfig);
 
   if (session) {
     session.setPlayerBotConfig(botId, newBotConfig);

--- a/packages/server/src/ws/bot-manager.ts
+++ b/packages/server/src/ws/bot-manager.ts
@@ -152,5 +152,11 @@ export async function setBotDifficulty(
 
   io.to(roomCode).emit('room:bot_updated', { botId, difficulty });
 
+  const [updatedSeats, spectators] = await Promise.all([
+    getRoomSeats(redis, roomCode),
+    getRoomSpectators(redis, roomCode),
+  ]);
+  io.to(roomCode).emit('seat:updated', { seats: updatedSeats, spectators });
+
   return { success: true };
 }

--- a/packages/server/src/ws/game-events.ts
+++ b/packages/server/src/ws/game-events.ts
@@ -6,7 +6,7 @@ import { GameSession } from '../plugins/core/game/session.js';
 import type { GameStatePersister } from '../plugins/core/game/state-store.js';
 import { emitGameUpdate, setAutopilotActionHandler, startTurnTimer, resetPlayerTimeout, clearRoomTimeouts } from './room-events.js';
 import type { TurnTimer } from '../plugins/core/game/turn-timer.js';
-import { getRoom, setRoomStatus, touchRoomActivity, removePlayerFromRoom, setUserRoom, getRoomSeats, getRoomSpectators, getSeatedPlayers, addSpectatorToRoom, resetAllSeatsReady, takeSeat, getFirstEmptySeatIndex } from '../plugins/core/room/store.js';
+import { getRoom, setRoomStatus, touchRoomActivity, clearSeatByUserId, setUserRoom, getRoomSeats, getRoomSpectators, getSeatedPlayers, addSpectatorToRoom, resetAllSeatsReady, takeSeat, getFirstEmptySeatIndex, clearUserRoom } from '../plugins/core/room/store.js';
 import { MAX_PLAYERS } from '@uno-online/shared';
 import { addSpectator, removeSpectator, clearRoomSpectators, broadcastSpectatorList } from '../plugins/core/spectate/ws.js';
 import { broadcastLobbyRooms } from '../plugins/core/spectate/routes.js';
@@ -241,7 +241,7 @@ async function processPendingSpectatorJoins(
         nickname: info.nickname,
         avatarUrl: info.avatarUrl,
         role: info.role,
-        isBot: info.isBot,
+        isBot: info.isBot ?? false,
         ready: false,
         connected: true,
       });
@@ -715,7 +715,8 @@ export function registerGameEvents(
     }
 
     session.removePlayer(targetId);
-    await removePlayerFromRoom(redis, roomCode, targetId);
+    await clearSeatByUserId(redis, roomCode, targetId);
+    await clearUserRoom(redis, targetId);
 
     // Bots are fully removed; human players become spectators
     if (!targetPlayer.isBot) {
@@ -758,7 +759,8 @@ export function registerGameEvents(
     if (!player) return callback?.({ success: false, error: '玩家不在游戏中' });
 
     session.removePlayer(data.user.userId);
-    await removePlayerFromRoom(redis, roomCode, data.user.userId);
+    await clearSeatByUserId(redis, roomCode, data.user.userId);
+    await clearUserRoom(redis, data.user.userId);
 
     (socket.data as SocketData).isSpectator = true;
     addSpectator(roomCode, data.user.userId, player.name, data.user.avatarUrl);

--- a/packages/server/src/ws/game-events.ts
+++ b/packages/server/src/ws/game-events.ts
@@ -6,7 +6,7 @@ import { GameSession } from '../plugins/core/game/session.js';
 import type { GameStatePersister } from '../plugins/core/game/state-store.js';
 import { emitGameUpdate, setAutopilotActionHandler, startTurnTimer, resetPlayerTimeout, clearRoomTimeouts } from './room-events.js';
 import type { TurnTimer } from '../plugins/core/game/turn-timer.js';
-import { getRoom, setRoomStatus, touchRoomActivity, clearSeatByUserId, setUserRoom, getRoomSeats, getRoomSpectators, getSeatedPlayers, addSpectatorToRoom, resetAllSeatsReady, takeSeat, getFirstEmptySeatIndex, clearUserRoom } from '../plugins/core/room/store.js';
+import { getRoom, setRoomStatus, touchRoomActivity, clearSeatByUserId, setUserRoom, getRoomSeats, setRoomSeats, getRoomSpectators, getSeatedPlayers, addSpectatorToRoom, resetAllSeatsReady, takeSeat, getFirstEmptySeatIndex, clearUserRoom } from '../plugins/core/room/store.js';
 import { MAX_PLAYERS } from '@uno-online/shared';
 import { addSpectator, removeSpectator, clearRoomSpectators, broadcastSpectatorList } from '../plugins/core/spectate/ws.js';
 import { broadcastLobbyRooms } from '../plugins/core/spectate/routes.js';
@@ -810,6 +810,23 @@ export function registerGameEvents(
 
     await setRoomStatus(redis, roomCode, 'waiting');
     await resetAllSeatsReady(redis, roomCode);
+
+    // Shuffle seats if house rule enabled
+    const gameSettings = session.getFullState().settings;
+    if (gameSettings.houseRules.shuffleSeats) {
+      const seatsToShuffle = await getRoomSeats(redis, roomCode);
+      const occupied = seatsToShuffle
+        .map((s, i) => ({ player: s, index: i }))
+        .filter(e => e.player !== null);
+      // Fisher-Yates shuffle of occupied players across their seats
+      for (let i = occupied.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        const idxI = occupied[i]!.index;
+        const idxJ = occupied[j]!.index;
+        [seatsToShuffle[idxI], seatsToShuffle[idxJ]] = [seatsToShuffle[idxJ]!, seatsToShuffle[idxI]!];
+      }
+      await setRoomSeats(redis, roomCode, seatsToShuffle);
+    }
 
     const seats = await getRoomSeats(redis, roomCode);
     const seatedIds = new Set(getSeatedPlayers(seats).map(p => p.userId));

--- a/packages/server/src/ws/game-events.ts
+++ b/packages/server/src/ws/game-events.ts
@@ -6,7 +6,7 @@ import { GameSession } from '../plugins/core/game/session.js';
 import type { GameStatePersister } from '../plugins/core/game/state-store.js';
 import { emitGameUpdate, setAutopilotActionHandler, startTurnTimer, resetPlayerTimeout, clearRoomTimeouts } from './room-events.js';
 import type { TurnTimer } from '../plugins/core/game/turn-timer.js';
-import { getRoom, getRoomPlayers, setRoomStatus, touchRoomActivity, removePlayerFromRoom, addPlayerToRoom, resetAllPlayersReady, setUserRoom, setPlayerSpectator } from '../plugins/core/room/store.js';
+import { getRoom, setRoomStatus, touchRoomActivity, removePlayerFromRoom, setUserRoom, getRoomSeats, getRoomSpectators, getSeatedPlayers, addSpectatorToRoom, resetAllSeatsReady, takeSeat, getFirstEmptySeatIndex } from '../plugins/core/room/store.js';
 import { MAX_PLAYERS } from '@uno-online/shared';
 import { addSpectator, removeSpectator, clearRoomSpectators, broadcastSpectatorList } from '../plugins/core/spectate/ws.js';
 import { broadcastLobbyRooms } from '../plugins/core/spectate/routes.js';
@@ -233,13 +233,19 @@ async function processPendingSpectatorJoins(
       role: info.role as any,
       isBot: info.isBot,
     });
-    await addPlayerToRoom(redis, roomCode, {
-      userId,
-      nickname: info.nickname,
-      avatarUrl: info.avatarUrl,
-      role: info.role,
-      isBot: info.isBot,
-    });
+    const seats = await getRoomSeats(redis, roomCode);
+    const seatIdx = getFirstEmptySeatIndex(seats);
+    if (seatIdx !== -1) {
+      await takeSeat(redis, roomCode, seatIdx, {
+        userId,
+        nickname: info.nickname,
+        avatarUrl: info.avatarUrl,
+        role: info.role,
+        isBot: info.isBot,
+        ready: false,
+        connected: true,
+      });
+    }
     userRoomWrites.push(setUserRoom(redis, userId, roomCode));
     joined.push(userId);
   }
@@ -801,31 +807,32 @@ export function registerGameEvents(
     clearPendingSpectatorJoins(roomCode);
 
     await setRoomStatus(redis, roomCode, 'waiting');
-    await resetAllPlayersReady(redis, roomCode);
+    await resetAllSeatsReady(redis, roomCode);
 
-    const currentRoomPlayers = await getRoomPlayers(redis, roomCode);
-    const currentIds = new Set(currentRoomPlayers.map((p) => p.userId));
+    const seats = await getRoomSeats(redis, roomCode);
+    const seatedIds = new Set(getSeatedPlayers(seats).map(p => p.userId));
     const sockets = await io.in(roomCode).fetchSockets();
     for (const s of sockets) {
       const sData = s.data as SocketData;
-      if (sData.isSpectator && !currentIds.has(sData.user.userId)) {
-        await addPlayerToRoom(redis, roomCode, {
+      if (sData.isSpectator && !seatedIds.has(sData.user.userId)) {
+        await addSpectatorToRoom(redis, roomCode, {
           userId: sData.user.userId,
           nickname: sData.user.nickname,
           avatarUrl: sData.user.avatarUrl,
           role: sData.user.role,
-          isBot: sData.user.isBot,
         });
-        await setPlayerSpectator(redis, roomCode, sData.user.userId, true);
       }
       sData.isSpectator = false;
     }
     clearRoomSpectators(roomCode);
 
     await touchRoomActivity(redis, roomCode);
-    const players = await getRoomPlayers(redis, roomCode);
+    const [updatedSeats, spectators] = await Promise.all([
+      getRoomSeats(redis, roomCode),
+      getRoomSpectators(redis, roomCode),
+    ]);
     const updatedRoom = await getRoom(redis, roomCode);
-    io.to(roomCode).emit('game:back_to_room', { players, room: updatedRoom });
+    io.to(roomCode).emit('game:back_to_room', { seats: updatedSeats, spectators, room: updatedRoom });
     io.to(roomCode).emit('chat:cleared');
     broadcastSpectatorList(io, roomCode);
     broadcastLobbyRooms(redis, io);

--- a/packages/server/src/ws/room-events.ts
+++ b/packages/server/src/ws/room-events.ts
@@ -342,13 +342,13 @@ export function registerRoomEvents(
     callback?.({ success: true });
   });
 
-  socket.on('room:add_bot', async (payload: { difficulty: BotDifficulty }, callback) => {
+  socket.on('room:add_bot', async (payload: { difficulty: BotDifficulty; seatIndex?: number }, callback) => {
     const roomCode = data.roomCode;
     if (!roomCode) return callback({ success: false, error: '不在房间中' });
     if (!BOT_DIFFICULTIES.includes(payload.difficulty)) return callback({ success: false, error: '无效的难度等级' });
 
     const session = sessions.get(roomCode);
-    const result = await addBot(io, redis, roomCode, data.user.userId, payload.difficulty, session);
+    const result = await addBot(io, redis, roomCode, data.user.userId, payload.difficulty, session, payload.seatIndex);
 
     if (result.success && session) {
       persister.markDirty(roomCode, session.getFullState());

--- a/packages/server/src/ws/room-events.ts
+++ b/packages/server/src/ws/room-events.ts
@@ -348,7 +348,7 @@ export function registerRoomEvents(
     if (!BOT_DIFFICULTIES.includes(payload.difficulty)) return callback({ success: false, error: '无效的难度等级' });
 
     const session = sessions.get(roomCode);
-    const result = await addBot(io, redis, roomManager, roomCode, data.user.userId, payload.difficulty, session);
+    const result = await addBot(io, redis, roomCode, data.user.userId, payload.difficulty, session);
 
     if (result.success && session) {
       persister.markDirty(roomCode, session.getFullState());
@@ -385,14 +385,14 @@ export function registerRoomEvents(
         turnTimer.stop(roomCode);
         session.removePlayer(payload.botId);
       }
-      await removeBot(io, redis, roomManager, roomCode, data.user.userId, payload.botId, undefined);
+      await removeBot(io, redis, roomCode, data.user.userId, payload.botId, undefined);
       persister.markDirty(roomCode, session.getFullState());
       await emitGameUpdate(io, roomCode, session, redis);
       broadcastLobbyRooms(redis, io);
       return callback({ success: true });
     }
 
-    const result = await removeBot(io, redis, roomManager, roomCode, data.user.userId, payload.botId, session);
+    const result = await removeBot(io, redis, roomCode, data.user.userId, payload.botId, session);
 
     if (result.success && session) {
       persister.markDirty(roomCode, session.getFullState());

--- a/packages/server/src/ws/room-events.ts
+++ b/packages/server/src/ws/room-events.ts
@@ -1,9 +1,9 @@
 import type { Socket, Server as SocketIOServer } from 'socket.io';
 import type { KvStore } from '../kv/types.js';
 import type { GameAction, GameState, RoomSettings, BotDifficulty } from '@uno-online/shared';
-import { MIN_PLAYERS, MAX_PLAYERS, DEFAULT_HOUSE_RULES, chooseAutopilotAction, chooseJumpInAction, chooseBotAction, getPlayableCards, DIFFICULTY_PARAMS, BOT_DIFFICULTIES } from '@uno-online/shared';
+import { MIN_PLAYERS, DEFAULT_HOUSE_RULES, chooseAutopilotAction, chooseJumpInAction, chooseBotAction, getPlayableCards, DIFFICULTY_PARAMS, BOT_DIFFICULTIES } from '@uno-online/shared';
 import { RoomManager } from '../plugins/core/room/manager.js';
-import { getRoom, getRoomPlayers, setRoomSettings, setRoomStatus, setRoomOwner, touchRoomActivity, ensureNotInRoom } from '../plugins/core/room/store.js';
+import { getRoom, getRoomSeats, getRoomSpectators, setRoomSettings, setRoomStatus, setRoomOwner, touchRoomActivity, ensureNotInRoom, removeSpectatorFromRoom, getSeatedPlayers } from '../plugins/core/room/store.js';
 import { joinRoomSocket, leaveRoomSocket } from './socket-room.js';
 import { GameSession } from '../plugins/core/game/session.js';
 import type { GameStatePersister } from '../plugins/core/game/state-store.js';
@@ -106,8 +106,9 @@ export function registerRoomEvents(
     const code = await roomManager.createRoom(data.user.userId, data.user.nickname, roomSettings, data.user.avatarUrl, data.user.role, data.user.isBot);
     const voiceChannelId = await voiceChannels?.ensureRoomChannel(code) ?? null;
     await joinRoomSocket(redis, socket, code);
-    const [room, players] = await Promise.all([getRoom(redis, code), getRoomPlayers(redis, code)]);
-    callback({ success: true, roomCode: code, players, room, voiceChannelId });
+    const [room, seats, spectators] = await Promise.all([getRoom(redis, code), getRoomSeats(redis, code), getRoomSpectators(redis, code)]);
+    callback({ success: true, roomCode: code, players: getSeatedPlayers(seats), room, voiceChannelId });
+    io.to(code).emit('seat:updated', { seats, spectators });
   });
 
   socket.on('room:join', async (roomCode: string, callback) => {
@@ -115,8 +116,9 @@ export function registerRoomEvents(
       const room = await getRoom(redis, roomCode);
       if (!room) return callback({ success: false, error: 'Room not found' });
 
-      const players = await getRoomPlayers(redis, roomCode);
-      const alreadyInRoom = players.some(p => p.userId === data.user.userId);
+      const [seats, spectators] = await Promise.all([getRoomSeats(redis, roomCode), getRoomSpectators(redis, roomCode)]);
+      const seatedPlayers = getSeatedPlayers(seats);
+      const alreadyInRoom = seatedPlayers.some(p => p.userId === data.user.userId) || spectators.some(s => s.userId === data.user.userId);
 
       if (alreadyInRoom) {
         await joinRoomSocket(redis, socket, roomCode);
@@ -124,7 +126,7 @@ export function registerRoomEvents(
           socket.emit('room:rejoin_redirect', { roomCode });
         }
         const voiceChannelId = await voiceChannels?.getRoomChannel(roomCode) ?? null;
-        return callback({ success: true, players, room, rejoin: room.status !== 'waiting', voiceChannelId });
+        return callback({ success: true, players: seatedPlayers, room, rejoin: room.status !== 'waiting', voiceChannelId });
       }
 
       const conflict = await ensureNotInRoom(redis, data.user.userId, roomCode);
@@ -133,12 +135,13 @@ export function registerRoomEvents(
       await roomManager.joinRoom(roomCode, data.user.userId, data.user.nickname, data.user.avatarUrl, data.user.role, data.user.isBot);
       await touchRoomActivity(redis, roomCode);
       await joinRoomSocket(redis, socket, roomCode);
-      const [voiceChannelId, updatedPlayers] = await Promise.all([
+      const [voiceChannelId, updatedSeats, updatedSpectators] = await Promise.all([
         voiceChannels?.getRoomChannel(roomCode) ?? null,
-        getRoomPlayers(redis, roomCode),
+        getRoomSeats(redis, roomCode),
+        getRoomSpectators(redis, roomCode),
       ]);
-      io.to(roomCode).emit('room:updated', { players: updatedPlayers, room });
-      callback({ success: true, players: updatedPlayers, room, voiceChannelId });
+      io.to(roomCode).emit('seat:updated', { seats: updatedSeats, spectators: updatedSpectators });
+      callback({ success: true, players: getSeatedPlayers(updatedSeats), room, voiceChannelId });
     } catch (err) {
       callback({ success: false, error: (err as Error).message });
     }
@@ -147,11 +150,16 @@ export function registerRoomEvents(
   socket.on('room:leave', async (callback) => {
     const roomCode = data.roomCode;
     if (!roomCode) return callback?.({ success: false, error: 'Not in a room' });
-    if (data.isSpectator) {
+
+    const spectators = await getRoomSpectators(redis, roomCode);
+    const isRoomSpectator = spectators.some(s => s.userId === data.user.userId);
+
+    if (isRoomSpectator) {
       const { userId, nickname } = data.user;
 
-      const players = await getRoomPlayers(redis, roomCode);
-      const remainingHumans = players.filter(p => !p.isBot && p.userId !== userId);
+      const seats = await getRoomSeats(redis, roomCode);
+      const seatedPlayers = getSeatedPlayers(seats);
+      const remainingHumans = [...seatedPlayers.filter(p => !p.isBot), ...spectators.filter(s => s.userId !== userId)];
 
       // No humans will remain after this spectator leaves — dissolve
       if (remainingHumans.length === 0) {
@@ -163,13 +171,19 @@ export function registerRoomEvents(
       // Transfer ownership if the leaving spectator was the owner
       const room = await getRoom(redis, roomCode);
       if (room?.ownerId === userId) {
-        await setRoomOwner(redis, roomCode, remainingHumans[0]!.userId);
+        const nextOwner = seatedPlayers.find(p => !p.isBot) ?? spectators.find(s => s.userId !== userId);
+        if (nextOwner) {
+          await setRoomOwner(redis, roomCode, nextOwner.userId);
+        }
         const updatedRoom = await getRoom(redis, roomCode);
-        io.to(roomCode).emit('room:updated', { players, room: updatedRoom });
+        io.to(roomCode).emit('room:updated', { room: updatedRoom });
       }
 
+      await removeSpectatorFromRoom(redis, roomCode, userId);
       await leaveRoomSocket(redis, socket, roomCode);
       broadcastSpectatorLeft(io, roomCode, userId, nickname);
+      const [updatedSeats, updatedSpectators] = await Promise.all([getRoomSeats(redis, roomCode), getRoomSpectators(redis, roomCode)]);
+      io.to(roomCode).emit('seat:updated', { seats: updatedSeats, spectators: updatedSpectators });
       return callback?.({ success: true });
     }
     const room = await getRoom(redis, roomCode);
@@ -218,8 +232,11 @@ export function registerRoomEvents(
     // If the leaver was the owner, manager.leaveRoom has just transferred
     // ownership to players[0]; the cached `room` still has the stale ownerId.
     const updatedRoom = wasOwner ? await getRoom(redis, roomCode) : room;
-    const players = await getRoomPlayers(redis, roomCode);
-    io.to(roomCode).emit('room:updated', { players, room: updatedRoom });
+    const [seats, updatedSpectators] = await Promise.all([getRoomSeats(redis, roomCode), getRoomSpectators(redis, roomCode)]);
+    io.to(roomCode).emit('seat:updated', { seats, spectators: updatedSpectators });
+    if (wasOwner) {
+      io.to(roomCode).emit('room:updated', { room: updatedRoom });
+    }
     callback?.({ success: true });
   });
 
@@ -228,33 +245,8 @@ export function registerRoomEvents(
     if (!roomCode) return callback?.({ success: false });
     await roomManager.setReady(roomCode, data.user.userId, ready);
     await touchRoomActivity(redis, roomCode);
-    const players = await getRoomPlayers(redis, roomCode);
-    io.to(roomCode).emit('room:updated', { players });
-    callback?.({ success: true });
-  });
-
-  socket.on('room:toggle_spectator', async (spectator: boolean, callback) => {
-    const roomCode = data.roomCode;
-    if (!roomCode) return callback?.({ success: false });
-    const room = await getRoom(redis, roomCode);
-    if (!room || room.status !== 'waiting') return callback?.({ success: false });
-
-    // When switching back from the spectator bench to a player seat, make
-    // sure we don't blow past the active-roster cap (e.g. 10 active + 1
-    // bench, where toggling back would yield 11 active).
-    if (!spectator) {
-      const players = await getRoomPlayers(redis, roomCode);
-      const me = players.find((p) => p.userId === data.user.userId);
-      const activeCount = players.filter((p) => !p.spectator).length;
-      if (me?.spectator && activeCount >= MAX_PLAYERS) {
-        return callback?.({ success: false, error: '玩家席位已满' });
-      }
-    }
-
-    await roomManager.setSpectator(roomCode, data.user.userId, spectator);
-    await touchRoomActivity(redis, roomCode);
-    const players = await getRoomPlayers(redis, roomCode);
-    io.to(roomCode).emit('room:updated', { players });
+    const [seats, spectators] = await Promise.all([getRoomSeats(redis, roomCode), getRoomSpectators(redis, roomCode)]);
+    io.to(roomCode).emit('seat:updated', { seats, spectators });
     callback?.({ success: true });
   });
 
@@ -285,9 +277,8 @@ export function registerRoomEvents(
 
     await setRoomSettings(redis, roomCode, nextSettings);
     await touchRoomActivity(redis, roomCode);
-    const players = await getRoomPlayers(redis, roomCode);
     const updatedRoom = await getRoom(redis, roomCode);
-    io.to(roomCode).emit('room:updated', { players, room: updatedRoom });
+    io.to(roomCode).emit('room:updated', { room: updatedRoom });
     callback?.({ success: true, room: updatedRoom });
   });
 
@@ -310,12 +301,14 @@ export function registerRoomEvents(
     if (room.ownerId !== data.user.userId) return callback?.({ success: false, error: '只有房主可以移交' });
     if (room.status !== 'waiting') return callback?.({ success: false, error: '游戏进行中无法移交房主' });
     if (payload.targetId === data.user.userId) return callback?.({ success: false, error: '不能移交给自己' });
-    const players = await getRoomPlayers(redis, roomCode);
-    if (!players.some(p => p.userId === payload.targetId)) return callback?.({ success: false, error: '目标玩家不在房间中' });
+    const [seats, spectators] = await Promise.all([getRoomSeats(redis, roomCode), getRoomSpectators(redis, roomCode)]);
+    const allUsers = [...getSeatedPlayers(seats), ...spectators];
+    if (!allUsers.some(p => p.userId === payload.targetId)) return callback?.({ success: false, error: '目标玩家不在房间中' });
     await setRoomOwner(redis, roomCode, payload.targetId);
     await touchRoomActivity(redis, roomCode);
     const updatedRoom = await getRoom(redis, roomCode);
-    io.to(roomCode).emit('room:updated', { players, room: updatedRoom });
+    io.to(roomCode).emit('room:updated', { room: updatedRoom });
+    io.to(roomCode).emit('seat:updated', { seats, spectators });
     callback?.({ success: true });
   });
 
@@ -327,8 +320,9 @@ export function registerRoomEvents(
     if (room.ownerId !== data.user.userId) return callback?.({ success: false, error: '只有房主可以踢人' });
     if (room.status === 'playing') return callback?.({ success: false, error: '游戏进行中无法踢人' });
     if (payload.targetId === data.user.userId) return callback?.({ success: false, error: '不能踢自己' });
-    const players = await getRoomPlayers(redis, roomCode);
-    if (!players.some(p => p.userId === payload.targetId)) return callback?.({ success: false, error: '目标玩家不在房间中' });
+    const [seats, spectators] = await Promise.all([getRoomSeats(redis, roomCode), getRoomSpectators(redis, roomCode)]);
+    const allUsers = [...getSeatedPlayers(seats), ...spectators];
+    if (!allUsers.some(p => p.userId === payload.targetId)) return callback?.({ success: false, error: '目标玩家不在房间中' });
     await roomManager.leaveRoom(roomCode, payload.targetId);
     removeVoicePresence(io, roomCode, payload.targetId);
     const targetSockets = await io.in(roomCode).fetchSockets();
@@ -341,9 +335,10 @@ export function registerRoomEvents(
     }
     await Promise.all(cleanups);
     await touchRoomActivity(redis, roomCode);
-    const updatedPlayers = await getRoomPlayers(redis, roomCode);
+    const [updatedSeats, updatedSpectators] = await Promise.all([getRoomSeats(redis, roomCode), getRoomSpectators(redis, roomCode)]);
     const updatedRoom = await getRoom(redis, roomCode);
-    io.to(roomCode).emit('room:updated', { players: updatedPlayers, room: updatedRoom });
+    io.to(roomCode).emit('seat:updated', { seats: updatedSeats, spectators: updatedSpectators });
+    io.to(roomCode).emit('room:updated', { room: updatedRoom });
     callback?.({ success: true });
   });
 
@@ -426,8 +421,9 @@ export function registerRoomEvents(
     if (!room) return callback?.({ success: false, error: '房间不存在' });
     if (room.ownerId !== data.user.userId) return callback?.({ success: false, error: '只有房主可以强制静音' });
     if (payload.targetId === data.user.userId) return callback?.({ success: false, error: '不能静音自己' });
-    const players = await getRoomPlayers(redis, roomCode);
-    if (!players.some(p => p.userId === payload.targetId)) return callback?.({ success: false, error: '目标玩家不在房间中' });
+    const [seats, spectators] = await Promise.all([getRoomSeats(redis, roomCode), getRoomSpectators(redis, roomCode)]);
+    const allUsers = [...getSeatedPlayers(seats), ...spectators];
+    if (!allUsers.some(p => p.userId === payload.targetId)) return callback?.({ success: false, error: '目标玩家不在房间中' });
     setForceMuted(io, roomCode, payload.targetId, payload.muted);
     callback?.({ success: true });
   });
@@ -439,15 +435,9 @@ export function registerRoomEvents(
     if (!room || room.ownerId !== data.user.userId) {
       return callback?.({ success: false, error: 'Only room owner can start' });
     }
-    const rawPlayers = await getRoomPlayers(redis, roomCode);
-    const seen = new Set<string>();
-    const players = rawPlayers.filter(p => {
-      if (seen.has(p.userId)) return false;
-      seen.add(p.userId);
-      return true;
-    });
-    const activePlayers = players.filter((p) => !p.spectator);
-    const roomSpectatorPlayers = players.filter((p) => p.spectator);
+    const seats = await getRoomSeats(redis, roomCode);
+    const spectators = await getRoomSpectators(redis, roomCode);
+    const activePlayers = getSeatedPlayers(seats);
 
     if (activePlayers.length < MIN_PLAYERS) {
       return callback?.({ success: false, error: 'Not enough players' });
@@ -470,13 +460,12 @@ export function registerRoomEvents(
     const sockets = await io.in(roomCode).fetchSockets();
     for (const s of sockets) {
       const sData = s.data as SocketData;
-      const sUserId = sData.user.userId;
-      if (roomSpectatorPlayers.some((p) => p.userId === sUserId)) {
+      if (spectators.some(sp => sp.userId === sData.user.userId)) {
         sData.isSpectator = true;
-        addSpectator(roomCode, sUserId, sData.user.nickname, sData.user.avatarUrl);
+        addSpectator(roomCode, sData.user.userId, sData.user.nickname, sData.user.avatarUrl);
         s.emit('game:state', session.getSpectatorView(spectatorMode));
       } else {
-        s.emit('game:state', session.getPlayerView(sUserId));
+        s.emit('game:state', session.getPlayerView(sData.user.userId));
       }
     }
 

--- a/packages/server/src/ws/room-lifecycle.ts
+++ b/packages/server/src/ws/room-lifecycle.ts
@@ -7,6 +7,7 @@ import type { GameStatePersister } from '../plugins/core/game/state-store.js';
 import type { VoiceChannelManager } from '../voice/channel-manager.js';
 import { clearRoomTimeouts } from './room-events.js';
 import { clearPendingSpectatorJoins } from './game-events.js';
+import { clearPendingSwapRequests } from './seat-events.js';
 import { leaveRoomSocket } from './socket-room.js';
 import { clearVoicePresence } from './voice-presence.js';
 import { clearRoomSpectators } from '../plugins/core/spectate/ws.js';
@@ -26,6 +27,7 @@ export async function dissolveRoom(
   clearRoomTimeouts(roomCode);
   clearPendingSpectatorJoins(roomCode);
   clearRoomSpectators(roomCode);
+  clearPendingSwapRequests(roomCode);
   persister.cleanup(roomCode);
   const session = sessions.get(roomCode);
   session?.clearChatHistory();

--- a/packages/server/src/ws/seat-events.ts
+++ b/packages/server/src/ws/seat-events.ts
@@ -213,7 +213,7 @@ export function registerSeatEvents(
   socket.on(
     'seat:swap_request',
     async (
-      payload: { targetUserId: string },
+      targetUserId: string,
       callback: (res: { success: boolean; error?: string }) => void,
     ) => {
       const roomCode = data.roomCode;
@@ -231,7 +231,7 @@ export function registerSeatEvents(
 
       const seats = await getRoomSeats(redis, roomCode);
       const requesterSeatIndex = seats.findIndex(s => s?.userId === requesterId);
-      const targetSeatIndex = seats.findIndex(s => s?.userId === payload.targetUserId);
+      const targetSeatIndex = seats.findIndex(s => s?.userId === targetUserId);
 
       if (requesterSeatIndex === -1) return callback({ success: false, error: '你没有在座位上' });
       if (targetSeatIndex === -1) return callback({ success: false, error: '目标玩家没有在座位上' });
@@ -244,7 +244,7 @@ export function registerSeatEvents(
       // If target is a bot: immediately swap
       if (targetSeat.isBot) {
         try {
-          await swapSeats(redis, roomCode, requesterId, payload.targetUserId);
+          await swapSeats(redis, roomCode, requesterId, targetUserId);
         } catch (err) {
           return callback({ success: false, error: (err as Error).message });
         }
@@ -253,25 +253,24 @@ export function registerSeatEvents(
         io.to(roomCode).emit('seat:swap_resolved', {
           accepted: true,
           requesterId,
-          targetUserId: payload.targetUserId,
+          targetUserId,
         });
         callback({ success: true });
         return;
       }
 
       // Target is a human player
-      const pendingKey = `${roomCode}:${payload.targetUserId}`;
+      const pendingKey = `${roomCode}:${targetUserId}`;
       if (pendingSwapRequests.has(pendingKey)) {
         return callback({ success: false, error: '该玩家已有待处理的换座请求' });
       }
 
       const timer = setTimeout(() => {
         pendingSwapRequests.delete(pendingKey);
-        // Notify requester that the request timed out (auto-reject)
         io.to(roomCode).emit('seat:swap_resolved', {
           accepted: false,
           requesterId,
-          targetUserId: payload.targetUserId,
+          targetUserId,
           reason: 'timeout',
         });
       }, SWAP_REQUEST_TIMEOUT_MS);
@@ -284,10 +283,9 @@ export function registerSeatEvents(
         timer,
       });
 
-      // Notify the target player's sockets
       const targetSockets = await io.in(roomCode).fetchSockets();
       for (const s of targetSockets) {
-        if ((s.data as SocketData).user.userId === payload.targetUserId) {
+        if ((s.data as SocketData).user.userId === targetUserId) {
           s.emit('seat:swap_requested', {
             requesterId,
             requesterName: data.user.nickname,
@@ -305,7 +303,7 @@ export function registerSeatEvents(
   socket.on(
     'seat:swap_respond',
     async (
-      payload: { accept: boolean },
+      payload: { requesterId: string; accept: boolean },
       callback: (res: { success: boolean; error?: string }) => void,
     ) => {
       const roomCode = data.roomCode;
@@ -315,7 +313,9 @@ export function registerSeatEvents(
       const pendingKey = `${roomCode}:${responderId}`;
       const pending = pendingSwapRequests.get(pendingKey);
 
-      if (!pending) return callback({ success: false, error: '没有待处理的换座请求' });
+      if (!pending || pending.requesterId !== payload.requesterId) {
+        return callback({ success: false, error: '没有待处理的换座请求' });
+      }
 
       clearTimeout(pending.timer);
       pendingSwapRequests.delete(pendingKey);

--- a/packages/server/src/ws/seat-events.ts
+++ b/packages/server/src/ws/seat-events.ts
@@ -1,0 +1,374 @@
+import type { Socket, Server as SocketIOServer } from 'socket.io';
+import type { KvStore } from '../kv/types.js';
+import { SEAT_COUNT, SWAP_COOLDOWN_MS, SWAP_REQUEST_TIMEOUT_MS } from '@uno-online/shared';
+import {
+  getRoom,
+  getRoomSeats,
+  getRoomSpectators,
+  takeSeat,
+  leaveSeat,
+  swapSeats,
+  removeSpectatorFromRoom,
+  addSpectatorToRoom,
+  touchRoomActivity,
+} from '../plugins/core/room/store.js';
+import type { RoomSeatPlayer, RoomSpectator } from '../plugins/core/room/store.js';
+import type { SocketData } from './types.js';
+
+// ─── In-memory state ──────────────────────────────────────────────────────────
+
+/** Maps `roomCode:userId` → expiry timestamp */
+const swapCooldowns = new Map<string, number>();
+
+interface PendingSwapRequest {
+  requesterId: string;
+  requesterName: string;
+  requesterSeatIndex: number;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+/** Maps `roomCode:targetUserId` → request data */
+const pendingSwapRequests = new Map<string, PendingSwapRequest>();
+
+// ─── Helper functions ─────────────────────────────────────────────────────────
+
+function isOnCooldown(roomCode: string, userId: string): boolean {
+  const key = `${roomCode}:${userId}`;
+  const expiry = swapCooldowns.get(key);
+  if (expiry === undefined) return false;
+  if (Date.now() >= expiry) {
+    swapCooldowns.delete(key);
+    return false;
+  }
+  return true;
+}
+
+function setCooldown(roomCode: string, userId: string): void {
+  swapCooldowns.set(`${roomCode}:${userId}`, Date.now() + SWAP_COOLDOWN_MS);
+}
+
+/** Clear all pending swap requests for a room (cancel timers). Exported. */
+export function clearPendingSwapRequests(roomCode: string): void {
+  const prefix = `${roomCode}:`;
+  for (const [key, req] of pendingSwapRequests) {
+    if (key.startsWith(prefix)) {
+      clearTimeout(req.timer);
+      pendingSwapRequests.delete(key);
+    }
+  }
+}
+
+/** Clear pending swap requests where userId is the requester. Exported. */
+export function clearUserSwapRequests(roomCode: string, userId: string): void {
+  const prefix = `${roomCode}:`;
+  for (const [key, req] of pendingSwapRequests) {
+    if (key.startsWith(prefix) && req.requesterId === userId) {
+      clearTimeout(req.timer);
+      pendingSwapRequests.delete(key);
+    }
+  }
+}
+
+async function emitSeatUpdate(io: SocketIOServer, kv: KvStore, roomCode: string): Promise<void> {
+  const [seats, spectators] = await Promise.all([
+    getRoomSeats(kv, roomCode),
+    getRoomSpectators(kv, roomCode),
+  ]);
+  io.to(roomCode).emit('seat:updated', { seats, spectators });
+}
+
+// ─── Register seat event handlers ────────────────────────────────────────────
+
+export function registerSeatEvents(
+  socket: Socket,
+  io: SocketIOServer,
+  redis: KvStore,
+): void {
+  const data = socket.data as SocketData;
+
+  // ── seat:take ──────────────────────────────────────────────────────────────
+  socket.on(
+    'seat:take',
+    async (
+      payload: { seatIndex: number },
+      callback: (res: { success: boolean; error?: string }) => void,
+    ) => {
+      const roomCode = data.roomCode;
+      if (!roomCode) return callback({ success: false, error: '不在房间中' });
+
+      const room = await getRoom(redis, roomCode);
+      if (!room) return callback({ success: false, error: '房间不存在' });
+      if (room.status !== 'waiting') return callback({ success: false, error: '游戏进行中无法换座' });
+
+      const { seatIndex } = payload;
+      if (typeof seatIndex !== 'number' || seatIndex < 0 || seatIndex >= SEAT_COUNT) {
+        return callback({ success: false, error: '无效座位编号' });
+      }
+
+      if (isOnCooldown(roomCode, data.user.userId)) {
+        return callback({ success: false, error: '操作太频繁，请稍后再试' });
+      }
+
+      const [seats, spectators] = await Promise.all([
+        getRoomSeats(redis, roomCode),
+        getRoomSpectators(redis, roomCode),
+      ]);
+
+      if (seats[seatIndex] !== null) {
+        return callback({ success: false, error: '该座位已被占用' });
+      }
+
+      const userId = data.user.userId;
+      const existingSeatIndex = seats.findIndex(s => s?.userId === userId);
+      const isSpectator = spectators.some(s => s.userId === userId);
+
+      // Caller must be either a spectator or already seated
+      if (existingSeatIndex === -1 && !isSpectator) {
+        return callback({ success: false, error: '你不在该房间中' });
+      }
+
+      // If already seated, must be unready to move
+      if (existingSeatIndex !== -1) {
+        const currentSeat = seats[existingSeatIndex]!;
+        if (currentSeat.ready) {
+          return callback({ success: false, error: '请先取消准备再换座' });
+        }
+      }
+
+      let player: RoomSeatPlayer;
+
+      if (isSpectator) {
+        // Build player from spectator data
+        const spectatorData = spectators.find(s => s.userId === userId)!;
+        player = {
+          userId: data.user.userId,
+          nickname: data.user.nickname,
+          avatarUrl: spectatorData.avatarUrl ?? null,
+          ready: false,
+          connected: true,
+          role: data.user.role,
+          isBot: data.user.isBot ?? false,
+        };
+        await removeSpectatorFromRoom(redis, roomCode, userId);
+      } else {
+        // Reuse existing player data, reset ready
+        const existing = seats[existingSeatIndex]!;
+        player = { ...existing, ready: false };
+      }
+
+      try {
+        await takeSeat(redis, roomCode, seatIndex, player);
+      } catch (err) {
+        return callback({ success: false, error: (err as Error).message });
+      }
+
+      setCooldown(roomCode, userId);
+      await touchRoomActivity(redis, roomCode);
+      await emitSeatUpdate(io, redis, roomCode);
+      callback({ success: true });
+    },
+  );
+
+  // ── seat:leave ─────────────────────────────────────────────────────────────
+  socket.on(
+    'seat:leave',
+    async (
+      callback: (res: { success: boolean; error?: string }) => void,
+    ) => {
+      const roomCode = data.roomCode;
+      if (!roomCode) return callback({ success: false, error: '不在房间中' });
+
+      const room = await getRoom(redis, roomCode);
+      if (!room) return callback({ success: false, error: '房间不存在' });
+      if (room.status !== 'waiting') return callback({ success: false, error: '游戏进行中无法离座' });
+
+      const userId = data.user.userId;
+      const seats = await getRoomSeats(redis, roomCode);
+      const seatIndex = seats.findIndex(s => s?.userId === userId);
+
+      if (seatIndex === -1) return callback({ success: false, error: '你没有在座位上' });
+
+      const currentSeat = seats[seatIndex]!;
+      if (currentSeat.ready) return callback({ success: false, error: '请先取消准备再离座' });
+
+      await leaveSeat(redis, roomCode, userId);
+
+      const spectator: RoomSpectator = {
+        userId: data.user.userId,
+        nickname: data.user.nickname,
+        avatarUrl: data.user.avatarUrl ?? null,
+        role: data.user.role,
+      };
+      await addSpectatorToRoom(redis, roomCode, spectator);
+
+      // Clear any pending swap requests where this user is the requester
+      clearUserSwapRequests(roomCode, userId);
+
+      await touchRoomActivity(redis, roomCode);
+      await emitSeatUpdate(io, redis, roomCode);
+      callback({ success: true });
+    },
+  );
+
+  // ── seat:swap_request ──────────────────────────────────────────────────────
+  socket.on(
+    'seat:swap_request',
+    async (
+      payload: { targetUserId: string },
+      callback: (res: { success: boolean; error?: string }) => void,
+    ) => {
+      const roomCode = data.roomCode;
+      if (!roomCode) return callback({ success: false, error: '不在房间中' });
+
+      const room = await getRoom(redis, roomCode);
+      if (!room) return callback({ success: false, error: '房间不存在' });
+      if (room.status !== 'waiting') return callback({ success: false, error: '游戏进行中无法申请换座' });
+
+      const requesterId = data.user.userId;
+
+      if (isOnCooldown(roomCode, requesterId)) {
+        return callback({ success: false, error: '操作太频繁，请稍后再试' });
+      }
+
+      const seats = await getRoomSeats(redis, roomCode);
+      const requesterSeatIndex = seats.findIndex(s => s?.userId === requesterId);
+      const targetSeatIndex = seats.findIndex(s => s?.userId === payload.targetUserId);
+
+      if (requesterSeatIndex === -1) return callback({ success: false, error: '你没有在座位上' });
+      if (targetSeatIndex === -1) return callback({ success: false, error: '目标玩家没有在座位上' });
+
+      const requesterSeat = seats[requesterSeatIndex]!;
+      if (requesterSeat.ready) return callback({ success: false, error: '请先取消准备再申请换座' });
+
+      const targetSeat = seats[targetSeatIndex]!;
+
+      // If target is a bot: immediately swap
+      if (targetSeat.isBot) {
+        try {
+          await swapSeats(redis, roomCode, requesterId, payload.targetUserId);
+        } catch (err) {
+          return callback({ success: false, error: (err as Error).message });
+        }
+        setCooldown(roomCode, requesterId);
+        await emitSeatUpdate(io, redis, roomCode);
+        io.to(roomCode).emit('seat:swap_resolved', {
+          accepted: true,
+          requesterId,
+          targetUserId: payload.targetUserId,
+        });
+        callback({ success: true });
+        return;
+      }
+
+      // Target is a human player
+      const pendingKey = `${roomCode}:${payload.targetUserId}`;
+      if (pendingSwapRequests.has(pendingKey)) {
+        return callback({ success: false, error: '该玩家已有待处理的换座请求' });
+      }
+
+      const timer = setTimeout(() => {
+        pendingSwapRequests.delete(pendingKey);
+        // Notify requester that the request timed out (auto-reject)
+        io.to(roomCode).emit('seat:swap_resolved', {
+          accepted: false,
+          requesterId,
+          targetUserId: payload.targetUserId,
+          reason: 'timeout',
+        });
+      }, SWAP_REQUEST_TIMEOUT_MS);
+      timer.unref?.();
+
+      pendingSwapRequests.set(pendingKey, {
+        requesterId,
+        requesterName: data.user.nickname,
+        requesterSeatIndex,
+        timer,
+      });
+
+      // Notify the target player's sockets
+      const targetSockets = await io.in(roomCode).fetchSockets();
+      for (const s of targetSockets) {
+        if ((s.data as SocketData).user.userId === payload.targetUserId) {
+          s.emit('seat:swap_requested', {
+            requesterId,
+            requesterName: data.user.nickname,
+            requesterSeatIndex,
+            targetSeatIndex,
+          });
+        }
+      }
+
+      callback({ success: true });
+    },
+  );
+
+  // ── seat:swap_respond ──────────────────────────────────────────────────────
+  socket.on(
+    'seat:swap_respond',
+    async (
+      payload: { accept: boolean },
+      callback: (res: { success: boolean; error?: string }) => void,
+    ) => {
+      const roomCode = data.roomCode;
+      if (!roomCode) return callback({ success: false, error: '不在房间中' });
+
+      const responderId = data.user.userId;
+      const pendingKey = `${roomCode}:${responderId}`;
+      const pending = pendingSwapRequests.get(pendingKey);
+
+      if (!pending) return callback({ success: false, error: '没有待处理的换座请求' });
+
+      clearTimeout(pending.timer);
+      pendingSwapRequests.delete(pendingKey);
+
+      if (!payload.accept) {
+        io.to(roomCode).emit('seat:swap_resolved', {
+          accepted: false,
+          requesterId: pending.requesterId,
+          targetUserId: responderId,
+        });
+        callback({ success: true });
+        return;
+      }
+
+      // Accept: validate responder is unready
+      const seats = await getRoomSeats(redis, roomCode);
+      const responderSeatIndex = seats.findIndex(s => s?.userId === responderId);
+      if (responderSeatIndex === -1) {
+        io.to(roomCode).emit('seat:swap_resolved', {
+          accepted: false,
+          requesterId: pending.requesterId,
+          targetUserId: responderId,
+          reason: 'responder_left_seat',
+        });
+        return callback({ success: false, error: '你已不在座位上' });
+      }
+
+      const responderSeat = seats[responderSeatIndex]!;
+      if (responderSeat.ready) {
+        io.to(roomCode).emit('seat:swap_resolved', {
+          accepted: false,
+          requesterId: pending.requesterId,
+          targetUserId: responderId,
+          reason: 'responder_ready',
+        });
+        return callback({ success: false, error: '请先取消准备再同意换座' });
+      }
+
+      try {
+        await swapSeats(redis, roomCode, pending.requesterId, responderId);
+      } catch (err) {
+        return callback({ success: false, error: (err as Error).message });
+      }
+
+      setCooldown(roomCode, pending.requesterId);
+      await emitSeatUpdate(io, redis, roomCode);
+      io.to(roomCode).emit('seat:swap_resolved', {
+        accepted: true,
+        requesterId: pending.requesterId,
+        targetUserId: responderId,
+      });
+      callback({ success: true });
+    },
+  );
+}

--- a/packages/server/src/ws/seat-events.ts
+++ b/packages/server/src/ws/seat-events.ts
@@ -90,7 +90,7 @@ export function registerSeatEvents(
   socket.on(
     'seat:take',
     async (
-      payload: { seatIndex: number },
+      seatIndex: number,
       callback: (res: { success: boolean; error?: string }) => void,
     ) => {
       const roomCode = data.roomCode;
@@ -100,7 +100,6 @@ export function registerSeatEvents(
       if (!room) return callback({ success: false, error: '房间不存在' });
       if (room.status !== 'waiting') return callback({ success: false, error: '游戏进行中无法换座' });
 
-      const { seatIndex } = payload;
       if (typeof seatIndex !== 'number' || seatIndex < 0 || seatIndex >= SEAT_COUNT) {
         return callback({ success: false, error: '无效座位编号' });
       }

--- a/packages/server/src/ws/socket-handler.ts
+++ b/packages/server/src/ws/socket-handler.ts
@@ -7,7 +7,8 @@ import { GameSession } from '../plugins/core/game/session.js';
 import { registerRoomEvents, emitGameUpdate, startTurnTimer, executeAutopilot, notifyAutopilotAction, resetPlayerTimeout } from './room-events.js';
 import { getAutopilotActionPlayerId, canPlayerAutopilotOnce } from './autopilot-action-player.js';
 import { registerGameEvents, addAutopilotVote, clearChatTimestamps, getRoundEndVoteState, getPendingSpectatorQueue, getRoundEndAt } from './game-events.js';
-import { getRoom, getRoomPlayers, setRoomOwner, clearUserRoom, getUserRoom } from '../plugins/core/room/store.js';
+import { getRoom, setRoomOwner, clearUserRoom, getUserRoom, setSeatPlayerConnected, getRoomSeats, getRoomSpectators, getSeatedPlayers } from '../plugins/core/room/store.js';
+import { registerSeatEvents, clearPendingSwapRequests, clearUserSwapRequests } from './seat-events.js';
 import { joinRoomSocket, leaveRoomSocket } from './socket-room.js';
 import { loadGameState, GameStatePersister } from '../plugins/core/game/state-store.js';
 import { getActiveRooms } from '../plugins/core/spectate/routes.js';
@@ -268,8 +269,11 @@ export function setupSocketHandlers(
         await emitGameUpdate(io, roomCode, session, redis);
         io.to(roomCode).emit('player:reconnected', { playerId: userId });
         io.to(roomCode).emit('player:autopilot', { playerId: userId, enabled: false });
-        const players = await getRoomPlayers(redis, roomCode);
-        callback?.({ success: true, gameState: session.getPlayerView(userId), players, room });
+        const [seats, spectators] = await Promise.all([
+          getRoomSeats(redis, roomCode),
+          getRoomSpectators(redis, roomCode),
+        ]);
+        callback?.({ success: true, gameState: session.getPlayerView(userId), seats, spectators, room });
         socket.emit('chat:history', session.getChatHistory());
         socket.emit('room:spectator_list', { spectators: getSpectatorNames(roomCode) });
         const voteState = getRoundEndVoteState(roomCode, session);
@@ -281,23 +285,36 @@ export function setupSocketHandlers(
           startTurnTimer(io, redis, roomCode, session, turnTimer, sessions, persister);
         }
       } else {
-        const players = await getRoomPlayers(redis, roomCode);
-        const alreadyInRoom = players.some(p => p.userId === userId);
-        if (!alreadyInRoom) {
+        const seats = await getRoomSeats(redis, roomCode);
+        const spectators = await getRoomSpectators(redis, roomCode);
+        const isSeated = seats.some(s => s !== null && s.userId === userId);
+        const isSpectator = spectators.some(s => s.userId === userId);
+
+        if (!isSeated && !isSpectator) {
+          // Re-add as spectator
           try {
             await roomManager.joinRoom(roomCode, userId, socket.data.user.nickname, socket.data.user.avatarUrl, socket.data.user.role, socket.data.user.isBot);
           } catch {
             return callback?.({ success: false, error: 'Cannot rejoin room' });
           }
         }
+
+        if (isSeated) {
+          await setSeatPlayerConnected(redis, roomCode, userId, true);
+        }
+
         await joinRoomSocket(redis, socket, roomCode);
-        const updatedPlayers = await getRoomPlayers(redis, roomCode);
-        io.to(roomCode).emit('room:updated', { players: updatedPlayers, room });
-        callback?.({ success: true, players: updatedPlayers, room });
+        const [updatedSeats, updatedSpectators] = await Promise.all([
+          getRoomSeats(redis, roomCode),
+          getRoomSpectators(redis, roomCode),
+        ]);
+        io.to(roomCode).emit('seat:updated', { seats: updatedSeats, spectators: updatedSpectators });
+        callback?.({ success: true, seats: updatedSeats, spectators: updatedSpectators, room });
       }
     });
 
     registerRoomEvents(socket, io, redis, roomManager, turnTimer, sessions, persister, voiceChannels);
+    registerSeatEvents(socket, io, redis);
     registerGameEvents(socket, io, redis, turnTimer, sessions, persister);
     registerInteractionEvents(socket, io);
     registerVoicePresenceEvents(socket, io, (roomCode) => voiceChannels.getRoomChannel(roomCode));
@@ -415,8 +432,9 @@ export function setupSocketHandlers(
               if (!nextOwner) return;
               await setRoomOwner(redis, roomCode, nextOwner.id);
               const updatedRoom = await getRoom(redis, roomCode);
-              const rp = await getRoomPlayers(redis, roomCode);
-              io.to(roomCode).emit('room:updated', { players: rp, room: updatedRoom });
+              const [seats, spectators] = await Promise.all([getRoomSeats(redis, roomCode), getRoomSpectators(redis, roomCode)]);
+              io.to(roomCode).emit('seat:updated', { seats, spectators });
+              io.to(roomCode).emit('room:updated', { room: updatedRoom });
             }, OWNER_TRANSFER_DELAY_S * 1000);
             timer.unref?.();
             ownerTransferTimers.set(roomCode, timer);
@@ -425,8 +443,9 @@ export function setupSocketHandlers(
             if (nextOwner) {
               await setRoomOwner(redis, roomCode, nextOwner.id);
               const updatedRoom = await getRoom(redis, roomCode);
-              const rp = await getRoomPlayers(redis, roomCode);
-              io.to(roomCode).emit('room:updated', { players: rp, room: updatedRoom });
+              const [seats, spectators] = await Promise.all([getRoomSeats(redis, roomCode), getRoomSpectators(redis, roomCode)]);
+              io.to(roomCode).emit('seat:updated', { seats, spectators });
+              io.to(roomCode).emit('room:updated', { room: updatedRoom });
             }
           }
         }
@@ -448,6 +467,15 @@ export function setupSocketHandlers(
         }, RECONNECT_TIMEOUT_MS);
         disconnectTimers.set(userId, timer);
       } else {
+        // Mark player as disconnected in seat (also cancels ready)
+        await setSeatPlayerConnected(redis, roomCode, userId, false);
+        clearUserSwapRequests(roomCode, userId);
+        const [disconnectSeats, disconnectSpectators] = await Promise.all([
+          getRoomSeats(redis, roomCode),
+          getRoomSpectators(redis, roomCode),
+        ]);
+        io.to(roomCode).emit('seat:updated', { seats: disconnectSeats, spectators: disconnectSpectators });
+
         // Start reconnect window before removing from room
         const timer = setTimeout(async () => {
           disconnectTimers.delete(userId);
@@ -456,11 +484,16 @@ export function setupSocketHandlers(
             clearUserRoom(redis, userId),
           ]);
           if (!deleted) {
-            const [room, players] = await Promise.all([
+            const [room, seats, spectators] = await Promise.all([
               getRoom(redis, roomCode),
-              getRoomPlayers(redis, roomCode),
+              getRoomSeats(redis, roomCode),
+              getRoomSpectators(redis, roomCode),
             ]);
-            io.to(roomCode).emit('room:updated', { players, room });
+            io.to(roomCode).emit('seat:updated', { seats, spectators });
+            // If leaver was owner, room:updated already emitted by leaveRoom's transfer
+            if (room) {
+              io.to(roomCode).emit('room:updated', { room });
+            }
           } else {
             // Route through dissolveRoom to stay in sync with the other
             // dissolve sites — chiefly so the Mumble channel actually gets

--- a/packages/server/tests/room/room-manager.test.ts
+++ b/packages/server/tests/room/room-manager.test.ts
@@ -1,9 +1,21 @@
 import { describe, it, expect, beforeEach, afterAll } from 'vitest';
 import { MemoryKvStore } from '../../src/kv/memory';
 import { RoomManager } from '../../src/plugins/core/room/manager';
-import { getRoom, getRoomPlayers, setRoomOwner } from '../../src/plugins/core/room/store';
+import {
+  getRoom,
+  getRoomSeats,
+  getRoomSpectators,
+  setRoomOwner,
+  getSeatedPlayers,
+  takeSeat,
+} from '../../src/plugins/core/room/store';
+import type { RoomSeatPlayer } from '../../src/plugins/core/room/store';
 
 const kv = new MemoryKvStore();
+
+function makePlayer(userId: string, nickname: string): RoomSeatPlayer {
+  return { userId, nickname, avatarUrl: null, ready: false, connected: true, role: 'normal', isBot: false };
+}
 
 beforeEach(async () => {
   const keys = await kv.keys('room:*');
@@ -22,31 +34,25 @@ describe('RoomManager', () => {
     const room = await getRoom(kv, code);
     expect(room).not.toBeNull();
     expect(room!.ownerId).toBe('owner-1');
-    const players = await getRoomPlayers(kv, code);
+    const seats = await getRoomSeats(kv, code);
+    const players = getSeatedPlayers(seats);
     expect(players).toHaveLength(1);
     expect(players[0]!.userId).toBe('owner-1');
   });
 
-  it('joins an existing room', async () => {
+  it('joins an existing room as spectator', async () => {
     const manager = new RoomManager(kv);
     const code = await manager.createRoom('owner-1', 'Alice');
     await manager.joinRoom(code, 'p2', 'Bob');
-    const players = await getRoomPlayers(kv, code);
-    expect(players).toHaveLength(2);
+    // joinRoom adds to spectators
+    const spectators = await getRoomSpectators(kv, code);
+    expect(spectators).toHaveLength(1);
+    expect(spectators[0]!.userId).toBe('p2');
   });
 
   it('rejects joining a non-existent room', async () => {
     const manager = new RoomManager(kv);
     await expect(manager.joinRoom('NONEXIST', 'p1', 'Alice')).rejects.toThrow('Room not found');
-  });
-
-  it('rejects joining when room is full (10 players)', async () => {
-    const manager = new RoomManager(kv);
-    const code = await manager.createRoom('owner', 'Owner');
-    for (let i = 1; i < 10; i++) {
-      await manager.joinRoom(code, `p${i}`, `Player${i}`);
-    }
-    await expect(manager.joinRoom(code, 'p10', 'Player10')).rejects.toThrow('Room is full');
   });
 
   it('rejects duplicate player', async () => {
@@ -55,15 +61,31 @@ describe('RoomManager', () => {
     await expect(manager.joinRoom(code, 'owner-1', 'Alice')).rejects.toThrow('Already in room');
   });
 
+  it('rejects joining when room is full (10 seats occupied)', async () => {
+    const manager = new RoomManager(kv);
+    const code = await manager.createRoom('owner', 'Owner');
+    // Fill all 10 seats (owner is already in seat 0)
+    for (let i = 1; i < 10; i++) {
+      await takeSeat(kv, code, i, makePlayer(`p${i}`, `Player${i}`));
+    }
+    // joinRoom goes to spectators, so test that takeSeat on a full room fails
+    await expect(
+      takeSeat(kv, code, 0, makePlayer('extra', 'Extra')),
+    ).rejects.toThrow(/已被占用/);
+  });
+
   it('leaves room and transfers ownership', async () => {
     const manager = new RoomManager(kv);
     const code = await manager.createRoom('owner-1', 'Alice');
-    await manager.joinRoom(code, 'p2', 'Bob');
+    // Put p2 in seat 1 so they can inherit ownership
+    await takeSeat(kv, code, 1, makePlayer('p2', 'Bob'));
     await manager.leaveRoom(code, 'owner-1');
     const room = await getRoom(kv, code);
     expect(room!.ownerId).toBe('p2');
-    const players = await getRoomPlayers(kv, code);
+    const seats = await getRoomSeats(kv, code);
+    const players = getSeatedPlayers(seats);
     expect(players).toHaveLength(1);
+    expect(players[0]!.userId).toBe('p2');
   });
 
   it('deletes room when last player leaves', async () => {
@@ -74,10 +96,11 @@ describe('RoomManager', () => {
     expect(room).toBeNull();
   });
 
-  it('checks all players ready', async () => {
+  it('checks all players ready (requires 2+ seated players)', async () => {
     const manager = new RoomManager(kv);
     const code = await manager.createRoom('owner-1', 'Alice');
-    await manager.joinRoom(code, 'p2', 'Bob');
+    // Place p2 in seat 1 for the ready check to be meaningful
+    await takeSeat(kv, code, 1, makePlayer('p2', 'Bob'));
     expect(await manager.areAllReady(code)).toBe(false);
     await manager.setReady(code, 'owner-1', true);
     await manager.setReady(code, 'p2', true);
@@ -87,22 +110,24 @@ describe('RoomManager', () => {
   it('transfers ownership to a specific player', async () => {
     const manager = new RoomManager(kv);
     const code = await manager.createRoom('owner-1', 'Alice');
-    await manager.joinRoom(code, 'p2', 'Bob');
-    await manager.joinRoom(code, 'p3', 'Carol');
+    await takeSeat(kv, code, 1, makePlayer('p2', 'Bob'));
+    await takeSeat(kv, code, 2, makePlayer('p3', 'Carol'));
     await setRoomOwner(kv, code, 'p3');
     const room = await getRoom(kv, code);
     expect(room!.ownerId).toBe('p3');
-    const players = await getRoomPlayers(kv, code);
+    const seats = await getRoomSeats(kv, code);
+    const players = getSeatedPlayers(seats);
     expect(players).toHaveLength(3);
   });
 
   it('kick removes target player from room without affecting others', async () => {
     const manager = new RoomManager(kv);
     const code = await manager.createRoom('owner-1', 'Alice');
-    await manager.joinRoom(code, 'p2', 'Bob');
-    await manager.joinRoom(code, 'p3', 'Carol');
+    await takeSeat(kv, code, 1, makePlayer('p2', 'Bob'));
+    await takeSeat(kv, code, 2, makePlayer('p3', 'Carol'));
     await manager.leaveRoom(code, 'p2');
-    const players = await getRoomPlayers(kv, code);
+    const seats = await getRoomSeats(kv, code);
+    const players = getSeatedPlayers(seats);
     expect(players).toHaveLength(2);
     expect(players.map(p => p.userId)).toEqual(['owner-1', 'p3']);
     const room = await getRoom(kv, code);

--- a/packages/server/tests/room/room-store.test.ts
+++ b/packages/server/tests/room/room-store.test.ts
@@ -3,15 +3,21 @@ import { MemoryKvStore } from '../../src/kv/memory';
 import {
   createRoom,
   getRoom,
-  addPlayerToRoom,
-  removePlayerFromRoom,
-  getRoomPlayers,
-  setPlayerReady,
   deleteRoom,
+  getRoomSeats,
+  takeSeat,
+  leaveSeat,
+  setSeatPlayerReady,
+  getSeatedPlayers,
 } from '../../src/plugins/core/room/store';
+import type { RoomSeatPlayer } from '../../src/plugins/core/room/store';
 
 const kv = new MemoryKvStore();
 const TEST_CODE = 'TEST01';
+
+function makePlayer(userId: string, username: string): RoomSeatPlayer {
+  return { userId, nickname: username, avatarUrl: null, ready: false, connected: true, role: 'normal', isBot: false };
+}
 
 beforeEach(async () => {
   const keys = await kv.keys(`room:${TEST_CODE}*`);
@@ -31,40 +37,43 @@ describe('room-store', () => {
     expect(room!.status).toBe('waiting');
   });
 
-  it('adds and lists players', async () => {
+  it('adds and lists players via seats', async () => {
     await createRoom(kv, TEST_CODE, 'owner-1', { turnTimeLimit: 30, targetScore: 500 });
-    await addPlayerToRoom(kv, TEST_CODE, { userId: 'p1', username: 'Alice' });
-    await addPlayerToRoom(kv, TEST_CODE, { userId: 'p2', username: 'Bob' });
+    await takeSeat(kv, TEST_CODE, 0, makePlayer('p1', 'Alice'));
+    await takeSeat(kv, TEST_CODE, 1, makePlayer('p2', 'Bob'));
 
-    const players = await getRoomPlayers(kv, TEST_CODE);
+    const seats = await getRoomSeats(kv, TEST_CODE);
+    const players = getSeatedPlayers(seats);
     expect(players).toHaveLength(2);
     expect(players[0]!.userId).toBe('p1');
     expect(players[1]!.userId).toBe('p2');
   });
 
-  it('removes a player', async () => {
+  it('removes a player from their seat', async () => {
     await createRoom(kv, TEST_CODE, 'owner-1', { turnTimeLimit: 30, targetScore: 500 });
-    await addPlayerToRoom(kv, TEST_CODE, { userId: 'p1', username: 'Alice' });
-    await addPlayerToRoom(kv, TEST_CODE, { userId: 'p2', username: 'Bob' });
+    await takeSeat(kv, TEST_CODE, 0, makePlayer('p1', 'Alice'));
+    await takeSeat(kv, TEST_CODE, 1, makePlayer('p2', 'Bob'));
 
-    await removePlayerFromRoom(kv, TEST_CODE, 'p1');
-    const players = await getRoomPlayers(kv, TEST_CODE);
+    await leaveSeat(kv, TEST_CODE, 'p1');
+    const seats = await getRoomSeats(kv, TEST_CODE);
+    const players = getSeatedPlayers(seats);
     expect(players).toHaveLength(1);
     expect(players[0]!.userId).toBe('p2');
   });
 
   it('sets player ready', async () => {
     await createRoom(kv, TEST_CODE, 'owner-1', { turnTimeLimit: 30, targetScore: 500 });
-    await addPlayerToRoom(kv, TEST_CODE, { userId: 'p1', username: 'Alice' });
+    await takeSeat(kv, TEST_CODE, 0, makePlayer('p1', 'Alice'));
 
-    await setPlayerReady(kv, TEST_CODE, 'p1', true);
-    const players = await getRoomPlayers(kv, TEST_CODE);
+    await setSeatPlayerReady(kv, TEST_CODE, 'p1', true);
+    const seats = await getRoomSeats(kv, TEST_CODE);
+    const players = getSeatedPlayers(seats);
     expect(players[0]!.ready).toBe(true);
   });
 
   it('deletes a room and its players', async () => {
     await createRoom(kv, TEST_CODE, 'owner-1', { turnTimeLimit: 30, targetScore: 500 });
-    await addPlayerToRoom(kv, TEST_CODE, { userId: 'p1', username: 'Alice' });
+    await takeSeat(kv, TEST_CODE, 0, makePlayer('p1', 'Alice'));
 
     await deleteRoom(kv, TEST_CODE);
     const room = await getRoom(kv, TEST_CODE);

--- a/packages/shared/src/constants/deck.ts
+++ b/packages/shared/src/constants/deck.ts
@@ -7,5 +7,9 @@ export const INITIAL_HAND_SIZE = 7;
 export const MIN_PLAYERS = 2;
 export const MAX_PLAYERS = 10;
 
+export const SEAT_COUNT = 10;
+export const SWAP_COOLDOWN_MS = 5000;
+export const SWAP_REQUEST_TIMEOUT_MS = 15000;
+
 export const ROOM_CODE_LENGTH = 6;
 export const ROOM_CODE_CHARS = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -6,5 +6,6 @@ export * from './role.js';
 export * from './server.js';
 export * from './event.js';
 export * from './chat.js';
+export * from './room.js';
 export type { PlayerView, PlayerViewPlayer } from './player-view.js';
 export type { ServerToClientEvents, ClientToServerEvents, SocketCallbackResult, ActiveRoomInfo } from './socket-events.js';

--- a/packages/shared/src/types/room.ts
+++ b/packages/shared/src/types/room.ts
@@ -1,0 +1,21 @@
+import type { BotConfig } from './bot.js';
+
+export interface RoomSeatPlayer {
+  userId: string;
+  nickname: string;
+  avatarUrl?: string | null;
+  ready: boolean;
+  connected: boolean;
+  role?: string;
+  isBot: boolean;
+  botConfig?: BotConfig;
+}
+
+export type RoomSeats = (RoomSeatPlayer | null)[];
+
+export interface RoomSpectator {
+  userId: string;
+  nickname: string;
+  avatarUrl?: string | null;
+  role?: string;
+}

--- a/packages/shared/src/types/socket-events.ts
+++ b/packages/shared/src/types/socket-events.ts
@@ -85,7 +85,7 @@ export interface ClientToServerEvents {
   'room:dissolve': (callback?: (res: SocketCallbackResult) => void) => void;
   'room:transfer_owner': (payload: { targetId: string }, callback?: (res: SocketCallbackResult) => void) => void;
   'room:kick': (payload: { targetId: string }, callback?: (res: SocketCallbackResult) => void) => void;
-  'room:add_bot': (payload: { difficulty: BotDifficulty }, callback: (res: SocketCallbackResult & { botId?: string }) => void) => void;
+  'room:add_bot': (payload: { difficulty: BotDifficulty; seatIndex?: number }, callback: (res: SocketCallbackResult & { botId?: string }) => void) => void;
   'room:remove_bot': (payload: { botId: string }, callback: (res: SocketCallbackResult) => void) => void;
   'room:set_bot_difficulty': (payload: { botId: string; difficulty: BotDifficulty }, callback: (res: SocketCallbackResult) => void) => void;
   'seat:take': (seatIndex: number, callback: (res: SocketCallbackResult) => void) => void;

--- a/packages/shared/src/types/socket-events.ts
+++ b/packages/shared/src/types/socket-events.ts
@@ -3,6 +3,7 @@ import type { PlayerView } from './player-view.js';
 import type { ChatMessage } from './chat.js';
 import type { RoomSettings } from './game.js';
 import type { BotDifficulty, BotPersonality } from './bot.js';
+import type { RoomSeats, RoomSpectator } from './room.js';
 
 export interface SocketCallbackResult {
   success: boolean;
@@ -64,6 +65,9 @@ export interface ServerToClientEvents {
   'room:bot_updated': (data: { botId: string; difficulty: BotDifficulty }) => void;
   'room:owner_transfer_pending': (data: { transferAt: number }) => void;
   'room:owner_transfer_cancelled': () => void;
+  'seat:updated': (data: { seats: RoomSeats; spectators: RoomSpectator[] }) => void;
+  'seat:swap_requested': (data: { requesterId: string; requesterName: string; requesterSeatIndex: number }) => void;
+  'seat:swap_resolved': (data: { accepted: boolean; seat1: number; seat2: number }) => void;
   'game:spectator_queue': (data: { queue: string[]; nickname: string; joined: boolean }) => void;
   'game:cheat_detected': () => void;
   'voice:presence': (presence: Record<string, unknown>) => void;
@@ -84,6 +88,10 @@ export interface ClientToServerEvents {
   'room:add_bot': (payload: { difficulty: BotDifficulty }, callback: (res: SocketCallbackResult & { botId?: string }) => void) => void;
   'room:remove_bot': (payload: { botId: string }, callback: (res: SocketCallbackResult) => void) => void;
   'room:set_bot_difficulty': (payload: { botId: string; difficulty: BotDifficulty }, callback: (res: SocketCallbackResult) => void) => void;
+  'seat:take': (seatIndex: number, callback: (res: SocketCallbackResult) => void) => void;
+  'seat:leave': (callback: (res: SocketCallbackResult) => void) => void;
+  'seat:swap_request': (targetUserId: string, callback: (res: SocketCallbackResult) => void) => void;
+  'seat:swap_respond': (payload: { requesterId: string; accept: boolean }, callback: (res: SocketCallbackResult) => void) => void;
   'voice:force_mute': (payload: { targetId: string; muted: boolean }, callback?: (res: SocketCallbackResult) => void) => void;
   'room:spectate': (roomCode: string, callback?: (res: SocketCallbackResult) => void) => void;
   'game:start': (callback: (res: SocketCallbackResult & { gameState?: PlayerView }) => void) => void;


### PR DESCRIPTION
## Summary

- 将房间玩家列表替换为固定 10 座位系统，座位顺序决定游戏中的上下家
- 新玩家加入房间默认进入观战席，点击空座位入座
- 支持玩家间请求交换座位（需对方确认，15 秒超时自动拒绝）
- 与 Bot 交换座位无需确认，直接交换
- 换座操作有 5 秒冷却，防止滥用
- 断线玩家标记 `connected: false` 并自动取消准备，60 秒内可重连恢复座位
- 房间页面从列表布局改为圆桌布局，设置面板改为右侧滑出抽屉
- 观战席移至圆桌下方横排显示
- 移动端自适应缩放（compact 模式）
- MCP 新增 `take_seat` / `leave_seat` 工具
- 村规 `shuffleSeats` 适配：返回房间时随机打乱已占座位

## Test plan

- [ ] 创建房间 → 房主自动入座 1 号位
- [ ] 添加 Bot → Bot 入座第一个空位
- [ ] 第二个玩家加入 → 默认进入观战席，点击空座位入座
- [ ] 已入座玩家点击其他玩家 → 弹出菜单含"请求换座"
- [ ] 发起换座请求 → 对方收到确认弹窗，15 秒超时自动拒绝
- [ ] 接受换座 → 两人座位交换，发起方 5 秒冷却
- [ ] 点击 Bot 座位 → 直接交换，无需确认
- [ ] 点击空座位（已入座）→ 移动到该座位
- [ ] 准备状态下无法换座/离座
- [ ] 断线 → 显示断线图标，自动取消准备；60 秒内重连恢复座位
- [ ] 设置齿轮按钮 → 右侧滑出设置抽屉
- [ ] 移动端 375px → 圆桌和座位缩小为 compact 模式
- [ ] 开始游戏 → 按座位顺序决定上下家
- [ ] 村规 shuffleSeats 开启 → 返回房间后座位随机重排

🤖 Generated with [Claude Code](https://claude.com/claude-code)