### PR TITLE
feat: 游戏计时器、延迟显示及房间生命周期修复

### DIFF
--- a/packages/client/src/app/router.tsx
+++ b/packages/client/src/app/router.tsx
@@ -1,11 +1,17 @@
 import { Suspense } from 'react';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, useNavigate } from 'react-router-dom';
 import ProtectedRoute from '@/shared/components/ProtectedRoute';
 import { authRoutes, authProtectedRoutes } from '@/features/auth/routes';
 import { gameProtectedRoutes } from '@/features/game/routes';
 import { profileProtectedRoutes } from '@/features/profile/routes';
 import CheatOverlayMount from '@/features/game/components/CheatOverlayMount';
+import { setGlobalNavigate } from '@/shared/utils/global-navigate';
 import RootSwitch from './RootSwitch';
+
+function NavigateRegistrar() {
+  setGlobalNavigate(useNavigate());
+  return null;
+}
 
 const allPublicRoutes = [...authRoutes];
 const allProtectedRoutes = [
@@ -17,6 +23,7 @@ const allProtectedRoutes = [
 export default function AppRouter() {
   return (
     <BrowserRouter>
+      <NavigateRegistrar />
       <Suspense
         fallback={
           <div className="flex items-center justify-center h-screen text-muted-foreground">

--- a/packages/client/src/features/game/components/CheatOverlay.tsx
+++ b/packages/client/src/features/game/components/CheatOverlay.tsx
@@ -7,7 +7,13 @@ const DURATION = 500;
 const TICK = 35;
 const MAX_OFFSET = 80;
 
-export default function CheatOverlay() {
+const DISSOLVE_REASON_LABEL: Record<string, string> = {
+  host_closed: '房主解散了房间',
+  idle_timeout: '房间长时间没有活动，已自动解散',
+  empty: '所有玩家已离开，房间已解散',
+};
+
+export default function CheatOverlay({ dissolvedReason }: { dissolvedReason?: string | null }) {
   const navigate = useNavigate();
   const canvasRef = useRef<HTMLDivElement>(null);
   const realRef = useRef<HTMLDivElement>(null);
@@ -80,6 +86,11 @@ export default function CheatOverlay() {
       </div>
       <div className="cheat-glitch-canvas" ref={canvasRef} />
       <div className="cheat-flash" />
+      {dissolvedReason && (
+        <div className="fixed bottom-6 right-8 text-xs text-white/30 select-text pointer-events-auto">
+          {DISSOLVE_REASON_LABEL[dissolvedReason] ?? dissolvedReason}
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/client/src/features/game/components/CheatOverlayMount.tsx
+++ b/packages/client/src/features/game/components/CheatOverlayMount.tsx
@@ -1,14 +1,9 @@
 import { useGameStore } from '../stores/game-store';
 import CheatOverlay from './CheatOverlay';
 
-/**
- * Top-level mount point for `CheatOverlay`. Lives inside the router so any
- * page (RoomPage waiting lobby, GamePage in-game) can surface the glitch
- * overlay when triggered — either by genuine cheat detection or by the host
- * dissolving the room (`game:cheat_detected` emit covers both).
- */
 export default function CheatOverlayMount() {
   const cheatDetected = useGameStore((s) => s.cheatDetected);
-  if (!cheatDetected) return null;
-  return <CheatOverlay />;
+  const dissolvedReason = useGameStore((s) => s.dissolvedReason);
+  if (!cheatDetected && !dissolvedReason) return null;
+  return <CheatOverlay dissolvedReason={dissolvedReason} />;
 }

--- a/packages/client/src/features/game/components/TopBar.tsx
+++ b/packages/client/src/features/game/components/TopBar.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Eye, Volume2, VolumeX, Music, Spade, DoorOpen, LogOut, Bot, HelpCircle, Keyboard, Trash2 } from 'lucide-react';
+import { Eye, Volume2, VolumeX, Music, Spade, DoorOpen, LogOut, Bot, HelpCircle, Keyboard, Trash2, Wifi, Clock, RotateCw } from 'lucide-react';
 import type { Card, Color } from '@uno-online/shared';
 import TurnTimer from './TurnTimer';
 import { useSettingsStore } from '@/shared/stores/settings-store';
@@ -7,7 +7,9 @@ import { useRoomStore } from '@/shared/stores/room-store';
 import { useGameStore } from '../stores/game-store';
 import { useEffectiveUserId } from '../hooks/useEffectiveUserId';
 import { useLeaveRoom } from '../hooks/useLeaveRoom';
+import { useElapsedTimer, formatElapsed } from '../hooks/useElapsedTimer';
 import { getSocket } from '@/shared/socket';
+import { useServerStore } from '@/shared/stores/server-store';
 import { showConfirm } from '@/shared/stores/confirm-store';
 import { cn } from '@/shared/lib/utils';
 import { BUILD_VERSION } from '@/shared/build-info';
@@ -40,6 +42,51 @@ function getCardLabel(card: Card): string {
     case 'wild': return '变色';
     case 'wild_draw_four': return '+4';
   }
+}
+
+function getPingColor(ms: number | null | undefined) {
+  if (ms == null) return { dot: '#666', text: 'text-muted-foreground' };
+  if (ms < 50) return { dot: '#22c55e', text: 'text-green-400' };
+  if (ms <= 150) return { dot: '#fbbf24', text: 'text-yellow-400' };
+  return { dot: '#ef4444', text: 'text-red-400' };
+}
+
+function LatencyIndicator() {
+  const currentServerId = useServerStore((s) => s.currentServerId);
+  const latency = useServerStore((s) => s.latencyMap[currentServerId]);
+  const ping = getPingColor(latency);
+
+  return (
+    <span className={cn('hidden sm:inline-flex items-center gap-1 text-xs', ping.text)} title="网络延迟">
+      <Wifi size={12} />
+      <span
+        className="w-1.5 h-1.5 rounded-full"
+        style={{ background: ping.dot, boxShadow: `0 0 4px ${ping.dot}60` }}
+      />
+      {latency != null ? `${latency}ms` : '--'}
+    </span>
+  );
+}
+
+function ElapsedTimers() {
+  const gameStartedAt = useGameStore((s) => s.gameStartedAt);
+  const turnStartedAt = useGameStore((s) => s.turnStartedAt);
+  const phase = useGameStore((s) => s.phase);
+  const gameElapsed = useElapsedTimer(gameStartedAt);
+  const turnElapsed = useElapsedTimer(turnStartedAt);
+  const showTurn = turnElapsed !== null && phase !== 'round_end' && phase !== 'game_over';
+
+  if (gameElapsed === null) return null;
+
+  return (
+    <span className="hidden sm:inline-flex items-center gap-1.5 text-xs text-muted-foreground" title="全局计时 | 回合计时">
+      <Clock size={12} />
+      <span>{formatElapsed(gameElapsed)}</span>
+      <span className="opacity-40">|</span>
+      <RotateCw size={10} className="opacity-60" />
+      <span>{showTurn ? formatElapsed(turnElapsed) : '--:--'}</span>
+    </span>
+  );
 }
 
 function GameStatus() {
@@ -132,6 +179,8 @@ export default function TopBar({ roomCode, onOpenHotkeys }: TopBarProps) {
         <span className="font-bold text-primary font-game"><Spade size={18} className="inline align-middle" /> UNO Online</span>
         <span className="text-muted-foreground">房间: {roomCode}</span>
         <span className="text-muted-foreground/50 text-xs hidden md:inline">v{BUILD_VERSION}</span>
+        <LatencyIndicator />
+        <ElapsedTimers />
       </div>
       <GameStatus />
       <div className="flex items-center gap-3 justify-end">

--- a/packages/client/src/features/game/hooks/useElapsedTimer.ts
+++ b/packages/client/src/features/game/hooks/useElapsedTimer.ts
@@ -1,0 +1,30 @@
+import { useState, useEffect } from 'react';
+import { serverNow } from '@/shared/server-time';
+
+export function useElapsedTimer(startTime: number | null): number | null {
+  const [elapsed, setElapsed] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (startTime === null) {
+      setElapsed(null);
+      return;
+    }
+    const tick = () => {
+      setElapsed(Math.max(0, Math.floor((serverNow() - startTime) / 1000)));
+    };
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, [startTime]);
+
+  return elapsed;
+}
+
+export function formatElapsed(seconds: number): string {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = seconds % 60;
+  const mm = String(m).padStart(h > 0 ? 2 : 1, '0');
+  const ss = String(s).padStart(2, '0');
+  return h > 0 ? `${h}:${mm}:${ss}` : `${mm}:${ss}`;
+}

--- a/packages/client/src/features/game/hooks/useGameSocket.ts
+++ b/packages/client/src/features/game/hooks/useGameSocket.ts
@@ -89,10 +89,12 @@ export function useGameSocket(roomCode: string | undefined) {
     return () => onConnectionStatus(() => {});
   }, [roomCode, setGameState, setRoom]);
 
-  // Warn before page unload during active game
+  // Warn before page unload during active game (not for spectators)
   useEffect(() => {
     if (!phase || phase === 'game_over') return;
     const handler = (e: BeforeUnloadEvent) => {
+      const { phase: p, isSpectator: s } = useGameStore.getState();
+      if (!p || p === 'game_over' || s) return;
       e.preventDefault();
     };
     window.addEventListener('beforeunload', handler);

--- a/packages/client/src/features/game/pages/RoomPage.tsx
+++ b/packages/client/src/features/game/pages/RoomPage.tsx
@@ -190,7 +190,7 @@ export default function RoomPage() {
 
     if (!seat) {
       // Empty seat: if spectator, take directly; if seated/owner, show context menu
-      if (isSpectator) {
+      if (isSpectator && !isOwner) {
         getSocket().emit('seat:take', seatIndex, (res: { success?: boolean; error?: string }) => {
           if (!res?.success && res?.error) useToastStore.getState().addToast(res.error, 'error');
         });

--- a/packages/client/src/features/game/stores/game-store.ts
+++ b/packages/client/src/features/game/stores/game-store.ts
@@ -56,8 +56,12 @@ interface GameState {
   roundEndAt: number | null;
   gameOverAt: number | null;
   cheatDetected: boolean;
+  dissolvedReason: string | null;
   ownerTransferAt: number | null;
+  gameStartedAt: number | null;
+  turnStartedAt: number | null;
   setCheatDetected: (value: boolean) => void;
+  setDissolvedReason: (reason: string | null) => void;
   setOwnerTransferAt: (transferAt: number | null) => void;
   setSpectator: (value: boolean) => void;
   infoDrawerOpen: boolean;
@@ -101,8 +105,12 @@ export const useGameStore = create<GameState>((set) => ({
   roundEndAt: null,
   gameOverAt: null,
   cheatDetected: false,
+  dissolvedReason: null,
   ownerTransferAt: null,
+  gameStartedAt: null,
+  turnStartedAt: null,
   setCheatDetected: (value) => set({ cheatDetected: value }),
+  setDissolvedReason: (reason) => set({ dissolvedReason: reason }),
   setOwnerTransferAt: (transferAt) => set({ ownerTransferAt: transferAt }),
   setSpectator: (value) => set({ isSpectator: value }),
   infoDrawerOpen: false,
@@ -133,6 +141,8 @@ export const useGameStore = create<GameState>((set) => ({
       return {
         phase,
         viewerId,
+        gameStartedAt: view.gameStartedAt ?? state.gameStartedAt,
+        turnStartedAt: view.turnStartedAt ?? state.turnStartedAt,
         players: shallowPlayersEqual(state.players, players) ? state.players : players,
         currentPlayerIndex,
         direction: view.direction,
@@ -191,7 +201,10 @@ export const useGameStore = create<GameState>((set) => ({
       roundEndAt: null,
       gameOverAt: null,
       cheatDetected: false,
+      dissolvedReason: null,
       ownerTransferAt: null,
+      gameStartedAt: null,
+      turnStartedAt: null,
       infoDrawerOpen: false,
       infoDrawerTab: 'rules' as InfoDrawerTab,
     }),

--- a/packages/client/src/features/lobby/pages/LobbyPage.tsx
+++ b/packages/client/src/features/lobby/pages/LobbyPage.tsx
@@ -17,6 +17,13 @@ import GameTopBar from '@/shared/components/GameTopBar';
 import ServerStatusBar from '@/shared/components/ServerStatusBar';
 import { openChangelog } from '@/shared/components/ChangelogModal';
 import { useLobbyStore } from '../stores/lobby-store';
+import { useElapsedTimer, formatElapsed } from '@/features/game/hooks/useElapsedTimer';
+
+function GameDuration({ startedAt }: { startedAt: number }) {
+  const elapsed = useElapsedTimer(startedAt);
+  if (elapsed === null) return null;
+  return <span>{formatElapsed(elapsed)}</span>;
+}
 
 export default function LobbyPage() {
   const setRoom = useRoomStore((s) => s.setRoom);
@@ -280,7 +287,7 @@ export default function LobbyPage() {
                   {room.players.map(p => p.nickname).join(' vs ')}
                 </div>
                 <div className="text-xs text-[#475569] mt-1 flex justify-between items-center">
-                  <span>{room.playerCount} 人 · {room.spectatorCount} 人观战</span>
+                  <span>{room.playerCount} 人 · {room.spectatorCount} 人观战 · <GameDuration startedAt={room.gameStartedAt} /></span>
                   <span className="text-[#fbbf24] text-xs font-semibold opacity-0 -translate-x-1 transition-all group-hover:opacity-100 group-hover:translate-x-0">
                     观战 ›
                   </span>

--- a/packages/client/src/shared/socket.ts
+++ b/packages/client/src/shared/socket.ts
@@ -13,6 +13,7 @@ import { setServerTimeOffset } from './server-time';
 import { useSpectatorStore } from '@/features/game/stores/spectator-store';
 import { useLobbyStore } from '@/features/lobby/stores/lobby-store';
 import { resetClientRoomState } from './stores/reset-room';
+import { globalNavigate } from './utils/global-navigate';
 
 type TypedSocket = SocketType<ServerToClientEvents, ClientToServerEvents>;
 
@@ -264,7 +265,7 @@ export function getSocket(): TypedSocket {
       sendNotification('kicked', data.reason || '你已被移出房间');
       useToastStore.getState().addToast(data.reason || '你已被移出游戏', 'error');
       if (window.location.pathname !== '/') {
-        window.location.assign('/');
+        globalNavigate('/');
       }
     });
 
@@ -274,15 +275,7 @@ export function getSocket(): TypedSocket {
 
     socket.on('room:dissolved', (data) => {
       if (useGameStore.getState().cheatDetected) return;
-      resetClientRoomState();
-      const message = data?.reason === 'idle_timeout'
-        ? '房间长时间没有活动，已自动解散'
-        : '房间已被房主解散';
-      sendNotification('roomDissolved', message);
-      useToastStore.getState().addToast(message, 'info');
-      if (window.location.pathname !== '/') {
-        window.location.assign('/');
-      }
+      useGameStore.getState().setDissolvedReason(data?.reason ?? 'host_closed');
     });
   }
   return socket;

--- a/packages/client/src/shared/utils/global-navigate.ts
+++ b/packages/client/src/shared/utils/global-navigate.ts
@@ -1,0 +1,15 @@
+import type { NavigateFunction } from 'react-router-dom';
+
+let _navigate: NavigateFunction | null = null;
+
+export function setGlobalNavigate(fn: NavigateFunction): void {
+  _navigate = fn;
+}
+
+export function globalNavigate(to: string): void {
+  if (_navigate) {
+    _navigate(to);
+  } else {
+    window.location.assign(to);
+  }
+}

--- a/packages/server/src/plugins/core/game/session.ts
+++ b/packages/server/src/plugins/core/game/session.ts
@@ -35,9 +35,12 @@ export class GameSession {
   static create(players: { id: string; name: string; avatarUrl?: string | null; role?: UserRole; isBot?: boolean; botConfig?: BotConfig }[], settings?: RoomSettings): GameSession {
     const state = initializeGame(players, settings?.houseRules);
     const deckHash = GameSession.computeDeckHash(state);
+    const now = Date.now();
     const stateWithExtras = {
       ...state,
       deckHash,
+      gameStartedAt: now,
+      turnStartedAt: now,
       ...(settings ? { settings } : {}),
     };
     const session = new GameSession(stateWithExtras);
@@ -102,6 +105,8 @@ export class GameSession {
       pendingDrawPlayerId: this.state.pendingDrawPlayerId,
       lastAction: this.state.lastAction,
       ...(truncated ? { discardPileCount: fullPile.length } : {}),
+      gameStartedAt: this.state.gameStartedAt,
+      turnStartedAt: this.state.turnStartedAt,
     };
   }
 
@@ -135,7 +140,9 @@ export class GameSession {
       }
     }
 
-    this.state = newState;
+    this.state = newState.currentPlayerIndex !== prevState.currentPlayerIndex
+      ? { ...newState, turnStartedAt: Date.now() }
+      : newState;
     return { success: true, drawnCard };
   }
 
@@ -276,8 +283,9 @@ export class GameSession {
   }
 
   startNextRound(): void {
+    const gameStartedAt = this.state.gameStartedAt;
     this.state = initializeNextRound(this.state);
-    this.state = { ...this.state, deckHash: GameSession.computeDeckHash(this.state) };
+    this.state = { ...this.state, deckHash: GameSession.computeDeckHash(this.state), gameStartedAt, turnStartedAt: Date.now() };
     this.initialDeckSerialized = serializeDecks(this.state.deckLeft, this.state.deckRight);
   }
 
@@ -286,7 +294,8 @@ export class GameSession {
     const settings = this.state.settings;
     const fresh = initializeGame(players, settings.houseRules);
     const deckHash = GameSession.computeDeckHash(fresh);
-    this.state = { ...fresh, settings, deckHash, chatHistory: [] };
+    const now = Date.now();
+    this.state = { ...fresh, settings, deckHash, chatHistory: [], gameStartedAt: now, turnStartedAt: now };
     this.initialDeckSerialized = serializeDecks(fresh.deckLeft, fresh.deckRight);
   }
 

--- a/packages/server/src/plugins/core/spectate/routes.ts
+++ b/packages/server/src/plugins/core/spectate/routes.ts
@@ -4,6 +4,7 @@ import type { ActiveRoomInfo } from '@uno-online/shared';
 import type { PluginContext } from '../../../plugin-context.js';
 import type { KvStore } from '../../../kv/types.js';
 import { getRoom, getRoomSeats, getSeatedPlayers } from '../room/store.js';
+import { loadGameState } from '../game/state-store.js';
 
 export async function getActiveRooms(kv: KvStore, io: SocketIOServer): Promise<ActiveRoomInfo[]> {
   const allKeys = await kv.keys('room:*');
@@ -24,11 +25,13 @@ export async function getActiveRooms(kv: KvStore, io: SocketIOServer): Promise<A
     const spectatorSockets = await io.in(roomCode).fetchSockets();
     const spectatorCount = spectatorSockets.filter(s => (s.data as { isSpectator?: boolean }).isSpectator).length;
 
+    const gameState = await loadGameState(kv, roomCode);
+
     activeRooms.push({
       roomCode,
       players: players.map((p: { nickname: string; avatarUrl?: string | null }) => ({ nickname: p.nickname, avatarUrl: p.avatarUrl })),
       playerCount: players.length,
-      startedAt: room.createdAt,
+      gameStartedAt: gameState?.gameStartedAt ?? Date.now(),
       spectatorCount,
       spectatorMode: settings.spectatorMode,
     });

--- a/packages/server/src/ws/room-lifecycle.ts
+++ b/packages/server/src/ws/room-lifecycle.ts
@@ -35,15 +35,7 @@ export async function dissolveRoom(
   io.to(roomCode).emit('chat:cleared');
   clearVoicePresence(io, roomCode);
 
-  // host_closed = the owner explicitly chose to dissolve. Surface that with
-  // the glitch overlay (reused from cheat detection) instead of the standard
-  // "room dissolved" toast/navigate path, so it feels deliberate and dramatic.
-  // Other reasons (idle_timeout, empty) keep the quieter notification.
-  if (reason === 'host_closed') {
-    io.to(roomCode).emit('game:cheat_detected');
-  } else {
-    io.to(roomCode).emit('room:dissolved', { reason });
-  }
+  io.to(roomCode).emit('room:dissolved', { reason });
 
   const sockets = await io.in(roomCode).fetchSockets();
   await Promise.all(sockets.map((s) => leaveRoomSocket(kv, s, roomCode)));

--- a/packages/server/src/ws/socket-handler.ts
+++ b/packages/server/src/ws/socket-handler.ts
@@ -397,10 +397,11 @@ export function setupSocketHandlers(
 
         const state = session.getFullState();
         const connectedCount = state.players.filter((p) => p.connected).length;
+        const connectedHumanCount = state.players.filter((p) => p.connected && !p.isBot).length;
         if (connectedCount < 2) {
           turnTimer.stop(roomCode);
         }
-        if (connectedCount === 0 && !allDisconnectTimers.has(roomCode)) {
+        if (connectedHumanCount === 0 && !allDisconnectTimers.has(roomCode)) {
           const dissolutionTimer = setTimeout(async () => {
             allDisconnectTimers.delete(roomCode);
             if (!sessions.has(roomCode)) return;
@@ -429,7 +430,11 @@ export function setupSocketHandlers(
               const st = s.getFullState();
               if (st.players.find(p => p.id === userId && p.connected)) return;
               const nextOwner = st.players.find(p => p.id !== userId && p.connected && !p.isBot);
-              if (!nextOwner) return;
+              if (!nextOwner) {
+                stopAutoPlayForRoom(roomCode);
+                await dissolveRoom(io, redis, roomCode, sessions, turnTimer, persister, 'empty', voiceChannels);
+                return;
+              }
               await setRoomOwner(redis, roomCode, nextOwner.id);
               const updatedRoom = await getRoom(redis, roomCode);
               const [seats, spectators] = await Promise.all([getRoomSeats(redis, roomCode), getRoomSpectators(redis, roomCode)]);
@@ -446,6 +451,9 @@ export function setupSocketHandlers(
               const [seats, spectators] = await Promise.all([getRoomSeats(redis, roomCode), getRoomSpectators(redis, roomCode)]);
               io.to(roomCode).emit('seat:updated', { seats, spectators });
               io.to(roomCode).emit('room:updated', { room: updatedRoom });
+            } else {
+              stopAutoPlayForRoom(roomCode);
+              await dissolveRoom(io, redis, roomCode, sessions, turnTimer, persister, 'empty', voiceChannels);
             }
           }
         }
@@ -463,6 +471,12 @@ export function setupSocketHandlers(
             await emitGameUpdate(io, roomCode, s, redis);
             io.to(roomCode).emit('player:autopilot', { playerId: userId, enabled: true });
             startAutoPlay(userId, roomCode);
+
+            const hasConnectedHuman = s.getFullState().players.some(p => p.connected && !p.isBot);
+            if (!hasConnectedHuman) {
+              stopAutoPlayForRoom(roomCode);
+              await dissolveRoom(io, redis, roomCode, sessions, turnTimer, persister, 'empty', voiceChannels);
+            }
           }
         }, RECONNECT_TIMEOUT_MS);
         disconnectTimers.set(userId, timer);

--- a/packages/shared/src/types/game.ts
+++ b/packages/shared/src/types/game.ts
@@ -67,6 +67,8 @@ export interface GameState {
   deckHash: string;
   settings: RoomSettings;
   chatHistory?: ChatMessage[];
+  gameStartedAt?: number;
+  turnStartedAt?: number;
 }
 
 export interface PendingPenaltyDraw {

--- a/packages/shared/src/types/player-view.ts
+++ b/packages/shared/src/types/player-view.ts
@@ -40,4 +40,6 @@ export interface PlayerView {
   lastAction: GameState['lastAction'];
   deckHash?: string;
   discardPileCount?: number;
+  gameStartedAt?: number;
+  turnStartedAt?: number;
 }

--- a/packages/shared/src/types/socket-events.ts
+++ b/packages/shared/src/types/socket-events.ts
@@ -28,7 +28,7 @@ export interface ActiveRoomInfo {
   roomCode: string;
   players: { nickname: string; avatarUrl?: string | null }[];
   playerCount: number;
-  startedAt: string;
+  gameStartedAt: number;
   spectatorCount: number;
   spectatorMode: 'full' | 'hidden';
 }


### PR DESCRIPTION
## Summary
- TopBar 左侧新增网络延迟指示器、全局游戏计时和回合计时（服务端时间戳，断线恢复不丢失）
- 大厅活跃对局列表显示游戏时长
- 房间解散统一走恶搞覆盖层，右下角小字显示实际解散原因
- 修复房主观战时点空位直接入座、观战者 beforeunload 弹窗、bot 导致全员断线检测失效、房主转移失败静默返回导致死局等多个 bug

## Test plan
- [ ] 开局后 TopBar 左侧可见延迟 ms、全局计时、回合计时
- [ ] 回合结束时回合计时显示 --:--，全局计时继续
- [ ] 刷新页面后计时从服务端恢复，不归零
- [ ] 大厅活跃对局卡片显示游戏时长
- [ ] 房主在观战席点空位弹出菜单（入座/添加 Bot）
- [ ] 房主解散房间 → 所有人看到恶搞覆盖层 + 右下角原因
- [ ] 1 人 + bot 房间，关闭浏览器后 10 秒内房间自动解散
- [ ] 观战者在房间解散时不弹浏览器原生确认框

🤖 Generated with [Claude Code](https://claude.com/claude-code)