### PR TITLE
feat: 移动端游戏布局适配与托管遮罩

### DIFF
--- a/packages/client/src/features/game/components/AutopilotOverlay.tsx
+++ b/packages/client/src/features/game/components/AutopilotOverlay.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { Hand, Bot } from 'lucide-react';
+import { useGameStore } from '../stores/game-store';
+import { useEffectiveUserId } from '../hooks/useEffectiveUserId';
+import { getSocket } from '@/shared/socket';
+
+const COOLDOWN_MS = 3000;
+
+export default function AutopilotOverlay() {
+  const players = useGameStore((s) => s.players);
+  const phase = useGameStore((s) => s.phase);
+  const userId = useEffectiveUserId();
+  const myAutopilot = players.find((p) => p.id === userId)?.autopilot ?? false;
+  const [cooldown, setCooldown] = useState(false);
+
+  const handleTakeOver = () => {
+    if (cooldown) return;
+    setCooldown(true);
+    getSocket().emit('player:toggle-autopilot', () => {});
+    setTimeout(() => setCooldown(false), COOLDOWN_MS);
+  };
+
+  const visible = myAutopilot
+    && (phase === 'playing' || phase === 'choosing_color' || phase === 'challenging' || phase === 'choosing_swap_target');
+
+  return (
+    <AnimatePresence>
+      {visible && (
+        <motion.div
+          className="fixed bottom-0 inset-x-0 z-autopilot pointer-events-none"
+          initial={{ y: 48, opacity: 0 }}
+          animate={{ y: 0, opacity: 1 }}
+          exit={{ y: 48, opacity: 0 }}
+          transition={{ type: 'spring', damping: 26, stiffness: 300 }}
+        >
+          <div className="flex items-center justify-center gap-3 bg-black/85 backdrop-blur-lg border-t border-white/[0.08] px-5 py-3 pointer-events-auto">
+            <button
+              onClick={handleTakeOver}
+              disabled={cooldown}
+              className="flex items-center gap-2.5 rounded-lg border border-white/25 bg-white/[0.08] px-5 py-2.5 text-sm font-game text-white/90 transition-all hover:bg-white/15 hover:border-white/40 active:scale-[0.97] disabled:opacity-30 disabled:cursor-not-allowed shrink-0"
+            >
+              <Hand size={16} className="opacity-80" />
+              <span>接管游戏</span>
+            </button>
+
+            <div className="h-4 w-px bg-white/15 mx-1 shrink-0" />
+
+            <div className="flex items-center gap-5 text-xs text-white/50 min-w-0">
+              <span className="inline-flex items-center gap-2 shrink-0">
+                <span className="relative flex h-2 w-2">
+                  <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-400 opacity-75" />
+                  <span className="relative inline-flex h-2 w-2 rounded-full bg-green-400" />
+                </span>
+                <span>牌局正常运行中</span>
+              </span>
+              <span className="inline-flex items-center gap-2 shrink-0">
+                <Bot size={13} className="text-accent/70" />
+                <span>代理托管作战正常运行中</span>
+              </span>
+            </div>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/packages/client/src/features/game/components/MobileGameCenter.tsx
+++ b/packages/client/src/features/game/components/MobileGameCenter.tsx
@@ -1,0 +1,137 @@
+import { RotateCw, RotateCcw } from 'lucide-react';
+import type { Color } from '@uno-online/shared';
+import Card from './Card';
+import { useGameStore } from '../stores/game-store';
+import { useEffectiveUserId } from '../hooks/useEffectiveUserId';
+import { useIsMyTurn } from '../hooks/useIsMyTurn';
+import { usePlayableCardIds } from '../hooks/usePlayableCardIds';
+import { cn } from '@/shared/lib/utils';
+
+const COLOR_HEX: Record<Color, string> = {
+  red: 'var(--color-uno-red)',
+  blue: 'var(--color-uno-blue)',
+  green: 'var(--color-uno-green)',
+  yellow: 'var(--color-uno-yellow)',
+};
+
+interface MobileGameCenterProps {
+  onDraw: (side: 'left' | 'right') => void;
+}
+
+function useCanDraw(side: 'left' | 'right') {
+  const deckCount = useGameStore((s) => side === 'left' ? s.deckLeftCount : s.deckRightCount);
+  const discardPileLength = useGameStore((s) => s.discardPile.length);
+  const phase = useGameStore((s) => s.phase);
+  const hasDrawnThisTurn = useGameStore((s) => s.hasDrawnThisTurn);
+  const pendingPenaltyDraws = useGameStore((s) => s.pendingPenaltyDraws);
+  const drawStack = useGameStore((s) => s.drawStack);
+  const settings = useGameStore((s) => s.settings);
+  const isMyTurn = useIsMyTurn();
+  const playableIds = usePlayableCardIds();
+
+  const remainingPenaltyDraws = pendingPenaltyDraws > 0 ? pendingPenaltyDraws : drawStack;
+  const isPenaltyDrawing = remainingPenaltyDraws > 0;
+  const mustDrawUntilPlayable = Boolean(settings?.houseRules?.drawUntilPlayable || settings?.houseRules?.deathDraw);
+  const canStartDrawUntilPlayable = !mustDrawUntilPlayable || playableIds.size === 0;
+  const canContinueDrawUntilPlayable = !isPenaltyDrawing && mustDrawUntilPlayable && hasDrawnThisTurn && playableIds.size === 0;
+  const hasCardsAvailable = deckCount > 0 || discardPileLength > 1;
+
+  return isMyTurn && phase === 'playing' && hasCardsAvailable
+    && (isPenaltyDrawing || (!hasDrawnThisTurn && canStartDrawUntilPlayable) || canContinueDrawUntilPlayable);
+}
+
+function DeckBack({ count, label, canDraw, onDraw }: {
+  count: number; label: string; canDraw: boolean; onDraw: () => void;
+}) {
+  return (
+    <div className="flex flex-col items-center gap-1">
+      <button
+        onClick={canDraw ? onDraw : undefined}
+        disabled={!canDraw}
+        className={cn(
+          'rounded-lg border flex items-center justify-center transition-all',
+          canDraw
+            ? 'border-primary/60 shadow-draw-ready animate-draw-pulse active:scale-95'
+            : 'border-white/15',
+          count === 0 && !canDraw && 'opacity-25',
+          !canDraw && count > 0 && 'opacity-50',
+        )}
+        style={{
+          width: 44, height: 62,
+          background: 'linear-gradient(135deg, var(--color-card-back-from), var(--color-card-back-to))',
+          cursor: canDraw ? 'pointer' : 'default',
+        }}
+      >
+        <span className="text-xs font-bold text-white/70 font-game">{count}</span>
+      </button>
+      <span className={cn(
+        'text-[9px]',
+        count <= 10 && count > 0 ? 'text-destructive font-bold' : 'text-muted-foreground/50',
+      )}>
+        {label}
+      </span>
+    </div>
+  );
+}
+
+export default function MobileGameCenter({ onDraw }: MobileGameCenterProps) {
+  const discardPile = useGameStore((s) => s.discardPile);
+  const currentColor = useGameStore((s) => s.currentColor);
+  const drawStack = useGameStore((s) => s.drawStack);
+  const direction = useGameStore((s) => s.direction);
+  const phase = useGameStore((s) => s.phase);
+  const players = useGameStore((s) => s.players);
+  const currentPlayerIndex = useGameStore((s) => s.currentPlayerIndex);
+  const userId = useEffectiveUserId();
+
+  const canDrawLeft = useCanDraw('left');
+  const canDrawRight = useCanDraw('right');
+  const deckLeftCount = useGameStore((s) => s.deckLeftCount);
+  const deckRightCount = useGameStore((s) => s.deckRightCount);
+
+  const topCard = discardPile[discardPile.length - 1];
+  const currentPlayer = players[currentPlayerIndex];
+  const isMyTurn = currentPlayer?.id === userId;
+
+  if (phase === 'round_end' || phase === 'game_over') return null;
+
+  const DirIcon = direction === 'clockwise' ? RotateCw : RotateCcw;
+
+  return (
+    <div className="flex items-center justify-center gap-6 flex-1 min-h-0">
+      <DeckBack count={deckLeftCount} label="左牌堆" canDraw={canDrawLeft} onDraw={() => onDraw('left')} />
+
+      <div className="flex flex-col items-center gap-2">
+        <div className="relative">
+          {topCard ? (
+            <div style={{ width: 64, height: 92 }}>
+              <Card card={topCard} mini style={{ width: 64, height: 92 }} />
+            </div>
+          ) : (
+            <div className="rounded-xl bg-white/5 border border-dashed border-white/20" style={{ width: 64, height: 92 }} />
+          )}
+          {drawStack > 0 && (
+            <span className="absolute -top-2 -right-2 bg-destructive text-white text-[10px] font-bold rounded-full min-w-5 h-5 flex items-center justify-center px-1 shadow-lg">
+              +{drawStack}
+            </span>
+          )}
+          {currentColor && (
+            <span
+              className="absolute -bottom-1.5 left-1/2 -translate-x-1/2 w-4 h-4 rounded-full border-2 border-black/40 shadow"
+              style={{ background: COLOR_HEX[currentColor] }}
+            />
+          )}
+        </div>
+
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <DirIcon size={12} className="opacity-60" />
+          <span className={isMyTurn ? 'text-primary font-bold font-game' : 'font-game'}>
+            {isMyTurn ? '你的回合' : currentPlayer?.name ?? ''}
+          </span>
+        </div>
+      </div>
+
+      <DeckBack count={deckRightCount} label="右牌堆" canDraw={canDrawRight} onDraw={() => onDraw('right')} />
+    </div>
+  );
+}

--- a/packages/client/src/features/game/components/MobileMenuSheet.tsx
+++ b/packages/client/src/features/game/components/MobileMenuSheet.tsx
@@ -1,0 +1,77 @@
+import type { ReactNode } from 'react';
+import { Eye, Volume2, VolumeX, Music, Bot, DoorOpen, LogOut, Trash2 } from 'lucide-react';
+import BottomSheet from './BottomSheet';
+import { useSettingsStore } from '@/shared/stores/settings-store';
+import { useRoomStore } from '@/shared/stores/room-store';
+import { useEffectiveUserId } from '../hooks/useEffectiveUserId';
+import { useGameStore } from '../stores/game-store';
+import { useLeaveRoom } from '../hooks/useLeaveRoom';
+import { getSocket } from '@/shared/socket';
+import { showConfirm } from '@/shared/stores/confirm-store';
+import { cn } from '@/shared/lib/utils';
+
+interface MobileMenuSheetProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function MobileMenuSheet({ open, onClose }: MobileMenuSheetProps) {
+  const { colorBlindMode, toggleColorBlind, soundEnabled, toggleSound, bgmEnabled, toggleBgm } = useSettingsStore();
+  const ownerId = useRoomStore((s) => s.room?.ownerId);
+  const userId = useEffectiveUserId();
+  const isHost = ownerId === userId;
+  const players = useGameStore((s) => s.players);
+  const myAutopilot = players.find(p => p.id === userId)?.autopilot ?? false;
+  const leaveRoom = useLeaveRoom();
+
+  const handleToggleAutopilot = () => {
+    getSocket().emit('player:toggle-autopilot', () => {});
+    onClose();
+  };
+
+  const handleLeave = async () => {
+    onClose();
+    const ok = isHost
+      ? await showConfirm({ title: '退出对局', message: '你是房主，离开后房主权将转让给其他玩家。', confirmText: '退出' })
+      : await showConfirm({ title: '退出对局', message: '确定要退出对局吗？', confirmText: '退出' });
+    if (ok) leaveRoom();
+  };
+
+  const handleDissolve = async () => {
+    onClose();
+    const ok = await showConfirm({ title: '解散房间', message: '确定要解散房间吗？所有玩家将被踢出。', confirmText: '解散', variant: 'danger' });
+    if (ok) getSocket().emit('room:dissolve', () => {});
+  };
+
+  return (
+    <BottomSheet open={open} onClose={onClose} title="游戏菜单">
+      <div className="flex flex-col gap-1">
+        <Item icon={<Bot size={16} />} label={myAutopilot ? '关闭自动托管' : '开启自动托管'} active={myAutopilot} onClick={handleToggleAutopilot} />
+        <Item icon={<Eye size={16} />} label={colorBlindMode ? '关闭色盲模式' : '开启色盲模式'} active={colorBlindMode} onClick={() => { toggleColorBlind(); onClose(); }} />
+        <Item icon={<Music size={16} />} label={bgmEnabled ? '关闭背景音乐' : '开启背景音乐'} active={bgmEnabled} onClick={() => { toggleBgm(); onClose(); }} />
+        <Item icon={soundEnabled ? <Volume2 size={16} /> : <VolumeX size={16} />} label={soundEnabled ? '关闭音效' : '开启音效'} active={soundEnabled} onClick={() => { toggleSound(); onClose(); }} />
+        <div className="h-px bg-white/10 my-1" />
+        <Item icon={isHost ? <DoorOpen size={16} /> : <LogOut size={16} />} label={isHost ? '离开并转让房主' : '退出对局'} danger onClick={handleLeave} />
+        {isHost && <Item icon={<Trash2 size={16} />} label="解散房间" danger onClick={handleDissolve} />}
+      </div>
+    </BottomSheet>
+  );
+}
+
+function Item({ icon, label, active, danger, onClick }: {
+  icon: ReactNode; label: string; active?: boolean; danger?: boolean; onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        'flex items-center gap-3 w-full px-3 py-2.5 rounded-lg text-sm text-left transition-colors',
+        danger ? 'text-destructive hover:bg-destructive/10' :
+        active ? 'text-accent bg-accent/10' : 'text-foreground hover:bg-white/10',
+      )}
+    >
+      {icon}
+      <span>{label}</span>
+    </button>
+  );
+}

--- a/packages/client/src/features/game/components/MobilePlayerStrip.tsx
+++ b/packages/client/src/features/game/components/MobilePlayerStrip.tsx
@@ -1,0 +1,85 @@
+import { Fragment } from 'react';
+import { Bot, ChevronRight, ChevronLeft } from 'lucide-react';
+import { useGameStore } from '../stores/game-store';
+import { useEffectiveUserId } from '../hooks/useEffectiveUserId';
+import { useRoomStore } from '@/shared/stores/room-store';
+import { cn } from '@/shared/lib/utils';
+
+const AVATAR_COLORS = [
+  'var(--color-avatar-1)', 'var(--color-avatar-2)', 'var(--color-avatar-3)',
+  'var(--color-avatar-4)', 'var(--color-avatar-5)', 'var(--color-avatar-6)',
+  'var(--color-avatar-7)', 'var(--color-avatar-8)', 'var(--color-avatar-9)',
+];
+
+export default function MobilePlayerStrip() {
+  const players = useGameStore((s) => s.players);
+  const currentPlayerIndex = useGameStore((s) => s.currentPlayerIndex);
+  const direction = useGameStore((s) => s.direction);
+  const phase = useGameStore((s) => s.phase);
+  const userId = useEffectiveUserId();
+  const ownerId = useRoomStore((s) => s.room?.ownerId);
+
+  if (phase === 'round_end' || phase === 'game_over') return null;
+
+  const Arrow = direction === 'clockwise' ? ChevronRight : ChevronLeft;
+
+  return (
+    <div className="flex items-center gap-0.5 px-2 py-1 overflow-x-auto scrollbar-hidden">
+      {players.map((player, i) => {
+        const isCurrent = i === currentPlayerIndex;
+        const isMe = player.id === userId;
+        const isHost = player.id === ownerId;
+
+        return (
+          <Fragment key={player.id}>
+            {i > 0 && (
+              <Arrow size={10} className="text-muted-foreground/30 shrink-0 mx-px" />
+            )}
+            <div
+              className={cn(
+                'flex items-center gap-1 rounded-full pl-1 pr-2 py-0.5 shrink-0 text-xs transition-colors',
+                isCurrent && 'bg-primary/20 ring-1 ring-primary/40',
+                isMe && !isCurrent && 'bg-white/8',
+              )}
+            >
+              <div className="relative shrink-0">
+                <div
+                  className="w-5 h-5 rounded-full flex items-center justify-center text-[10px] font-bold text-white overflow-hidden"
+                  style={{ background: AVATAR_COLORS[i % AVATAR_COLORS.length] }}
+                >
+                  {player.avatarUrl
+                    ? <img src={player.avatarUrl} className="w-full h-full object-cover" alt="" />
+                    : player.name[0]?.toUpperCase()
+                  }
+                </div>
+                {isHost && (
+                  <span className="absolute -top-1 -right-1 text-[8px] leading-none">👑</span>
+                )}
+              </div>
+              <span className={cn(
+                'max-w-12 truncate font-game leading-none',
+                isCurrent ? 'text-primary' : isMe ? 'text-foreground' : 'text-muted-foreground',
+              )}>
+                {player.name}
+              </span>
+              <span className="text-muted-foreground/50 tabular-nums">{player.handCount}</span>
+              {(player.score > 0 || (player.roundWins ?? 0) > 0) && (
+                <span className="text-[9px] text-accent/70 tabular-nums">
+                  {player.score > 0 && `${player.score}分`}
+                  {(player.roundWins ?? 0) > 0 && `🏆${player.roundWins}`}
+                </span>
+              )}
+              {player.calledUno && (
+                <span className="text-[8px] text-primary font-black leading-none">UNO</span>
+              )}
+              {player.autopilot && <Bot size={9} className="text-uno-blue" />}
+              {!player.connected && (
+                <span className="w-1.5 h-1.5 rounded-full bg-destructive shrink-0" />
+              )}
+            </div>
+          </Fragment>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/client/src/features/game/components/MobileStatusBar.tsx
+++ b/packages/client/src/features/game/components/MobileStatusBar.tsx
@@ -1,0 +1,85 @@
+import { Menu } from 'lucide-react';
+import type { Card, Color } from '@uno-online/shared';
+import { useGameStore } from '../stores/game-store';
+import TurnTimer from './TurnTimer';
+
+const COLOR_HEX: Record<Color, string> = {
+  red: 'var(--color-uno-red)',
+  blue: 'var(--color-uno-blue)',
+  green: 'var(--color-uno-green)',
+  yellow: 'var(--color-uno-yellow)',
+};
+
+const COLOR_LABEL: Record<Color, string> = {
+  red: '红', blue: '蓝', green: '绿', yellow: '黄',
+};
+
+const PHASE_LABEL: Record<string, string> = {
+  choosing_color: '选色中…',
+  challenging: '质疑中…',
+  choosing_swap_target: '选交换…',
+};
+
+function getCardLabel(card: Card): string {
+  switch (card.type) {
+    case 'number': return `${card.value}`;
+    case 'skip': return '禁';
+    case 'reverse': return '转';
+    case 'draw_two': return '+2';
+    case 'wild': return '变色';
+    case 'wild_draw_four': return '+4';
+  }
+}
+
+interface MobileStatusBarProps {
+  onOpenMenu: () => void;
+}
+
+export default function MobileStatusBar({ onOpenMenu }: MobileStatusBarProps) {
+  const topCard = useGameStore((s) => s.discardPile?.[s.discardPile.length - 1]);
+  const currentColor = useGameStore((s) => s.currentColor);
+  const drawStack = useGameStore((s) => s.drawStack);
+  const phase = useGameStore((s) => s.phase);
+
+  const showCard = topCard && currentColor && phase !== 'round_end' && phase !== 'game_over';
+
+  return (
+    <div className="flex items-center justify-between px-3 py-1.5 bg-black/40 text-xs z-topbar">
+      <div className="flex items-center gap-2">
+        {showCard && (
+          <div
+            className="flex items-center gap-1 rounded-full px-2 py-0.5 font-game"
+            style={{
+              background: `color-mix(in srgb, ${COLOR_HEX[currentColor]} 25%, transparent)`,
+              color: COLOR_HEX[currentColor],
+            }}
+          >
+            <span className="w-2 h-2 rounded-full shrink-0" style={{ background: COLOR_HEX[currentColor] }} />
+            <span>{COLOR_LABEL[currentColor]}</span>
+            <span className="opacity-50">·</span>
+            <span>{getCardLabel(topCard)}</span>
+          </div>
+        )}
+        {drawStack > 0 && (
+          <span className="rounded-full bg-destructive/20 text-destructive px-2 py-0.5 font-game font-bold">
+            +{drawStack}
+          </span>
+        )}
+        {phase && PHASE_LABEL[phase] && (
+          <span className="rounded-full bg-white/10 text-muted-foreground px-2 py-0.5 font-game">
+            {PHASE_LABEL[phase]}
+          </span>
+        )}
+      </div>
+      <div className="flex items-center gap-2">
+        <TurnTimer />
+        <button
+          onClick={onOpenMenu}
+          className="w-7 h-7 flex items-center justify-center rounded-lg bg-white/10 text-muted-foreground active:bg-white/20"
+        >
+          <Menu size={14} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/features/game/components/PlayerHand.tsx
+++ b/packages/client/src/features/game/components/PlayerHand.tsx
@@ -24,12 +24,10 @@ interface HandLayout {
 
 const CARD_WIDTH = 70;
 const CARD_HEIGHT = 100;
-const CARD_WIDTH_SM = 52;
-const CARD_HEIGHT_SM = 76;
+const CARD_WIDTH_SM = 64;
+const CARD_HEIGHT_SM = 92;
 const HAND_SIDE_PADDING = 20;
-const MIN_VISIBLE_STRIDE = 18;
 const COMFORTABLE_STRIDE = 78;
-const ACTIVE_LIFT = 34;
 const ACTIVE_SCALE = 1.12;
 const NEAR_EXPAND = 16;
 const TOUCH_DRAG_THRESHOLD = 5;
@@ -52,18 +50,20 @@ function isColorBoundary(sorted: CardType[], index: number): boolean {
 }
 
 function calculateHandLayout(count: number, containerWidth: number): HandLayout {
-  const compactViewport = containerWidth > 0 && containerWidth < 768;
-  const cardWidth = compactViewport ? CARD_WIDTH_SM : CARD_WIDTH;
-  const cardHeight = compactViewport ? CARD_HEIGHT_SM : CARD_HEIGHT;
+  const isMobile = containerWidth > 0 && containerWidth < 768;
+  const cardWidth = isMobile ? CARD_WIDTH_SM : CARD_WIDTH;
+  const cardHeight = isMobile ? CARD_HEIGHT_SM : CARD_HEIGHT;
+  const minStride = isMobile ? 18 : 10;
+
   if (count <= 0 || containerWidth <= 0) {
     return { cardWidth, cardHeight, stride: cardWidth, baseWidth: cardWidth, padX: HAND_SIDE_PADDING, scrollable: false };
   }
 
   const available = Math.max(cardWidth, containerWidth - HAND_SIDE_PADDING * 2);
   const fitStride = count === 1 ? cardWidth : (available - cardWidth) / (count - 1);
-  const stride = Math.min(COMFORTABLE_STRIDE, Math.max(MIN_VISIBLE_STRIDE, fitStride));
+  const stride = Math.min(COMFORTABLE_STRIDE, Math.max(minStride, fitStride));
   const baseWidth = cardWidth + stride * (count - 1);
-  const scrollable = baseWidth > available;
+  const scrollable = isMobile && baseWidth > available;
   const padX = scrollable ? HAND_SIDE_PADDING : Math.max(HAND_SIDE_PADDING, (containerWidth - baseWidth) / 2);
 
   return { cardWidth, cardHeight, stride, baseWidth, padX, scrollable };
@@ -118,6 +118,9 @@ export default function PlayerHand({ onPlayCard }: PlayerHandProps) {
   const [containerWidth, setContainerWidth] = useState(0);
   const [activeIndex, setActiveIndex] = useState<number | null>(null);
   const [isDraggingHand, setIsDraggingHand] = useState(false);
+
+  const isMobile = containerWidth > 0 && containerWidth < 768;
+  const activeLift = isMobile ? 34 : 20;
 
   const layout = useMemo(
     () => calculateHandLayout(sorted.length, containerWidth),
@@ -187,17 +190,15 @@ export default function PlayerHand({ onPlayCard }: PlayerHandProps) {
     if (Math.abs(deltaX) > TOUCH_DRAG_THRESHOLD) {
       drag.hasDragged = true;
       drag.suppressClick = true;
-      setIsDraggingHand(true);
-      if (!scrollEl.hasPointerCapture(event.pointerId)) {
-        scrollEl.setPointerCapture(event.pointerId);
+      if (layout.scrollable) {
+        setIsDraggingHand(true);
+        if (!scrollEl.hasPointerCapture(event.pointerId)) {
+          scrollEl.setPointerCapture(event.pointerId);
+        }
+        event.preventDefault();
+        scrollEl.scrollLeft = drag.scrollLeft - deltaX;
+        setActiveFromPointer(event.clientX);
       }
-    }
-    if (!drag.hasDragged) return;
-
-    event.preventDefault();
-    if (layout.scrollable) {
-      scrollEl.scrollLeft = drag.scrollLeft - deltaX;
-      setActiveFromPointer(event.clientX);
     }
   };
 
@@ -211,9 +212,7 @@ export default function PlayerHand({ onPlayCard }: PlayerHandProps) {
     if (scrollEl?.hasPointerCapture(event.pointerId)) {
       scrollEl.releasePointerCapture(event.pointerId);
     }
-    window.setTimeout(() => {
-      handDragRef.current.suppressClick = false;
-    }, 0);
+    window.setTimeout(() => { handDragRef.current.suppressClick = false; }, 0);
   };
 
   const handleHandPointerCancel = (event: React.PointerEvent<HTMLDivElement>) => {
@@ -248,7 +247,7 @@ export default function PlayerHand({ onPlayCard }: PlayerHandProps) {
     onPlayCard(card.id);
   };
 
-  const handHeight = layout.cardHeight + ACTIVE_LIFT + 28;
+  const handHeight = layout.cardHeight + activeLift + (isMobile ? 28 : 8);
   const spreadAngle = getSpreadAngle(sorted.length);
   const center = (sorted.length - 1) / 2;
   const boundaryGap = Math.min(10, Math.max(3, layout.stride * 0.35));
@@ -267,7 +266,7 @@ export default function PlayerHand({ onPlayCard }: PlayerHandProps) {
   if (!me) return null;
 
   return (
-    <div className="relative z-actions overflow-visible pt-12 -mt-12 pointer-events-none">
+    <div className="relative z-actions overflow-visible pt-8 -mt-8 pointer-events-none">
       {pendingColorCardId && (
         <ColorPicker
           onPick={(color) => {
@@ -278,9 +277,11 @@ export default function PlayerHand({ onPlayCard }: PlayerHandProps) {
       )}
       <div
         ref={handViewportRef}
-        className={`relative rounded-t-2xl px-0 pt-8 pb-hand-pb overflow-x-auto overflow-y-visible scrollbar-hidden pointer-events-auto touch-none ${
-          isDraggingHand ? 'cursor-grabbing' : 'cursor-default'
-        }`}
+        className={
+          isMobile
+            ? `relative px-0 pt-2 pb-hand-pb overflow-x-auto overflow-y-hidden scrollbar-hidden pointer-events-auto touch-none ${isDraggingHand ? 'cursor-grabbing' : 'cursor-default'}`
+            : 'relative px-0 overflow-visible pointer-events-auto touch-none'
+        }
         style={{ height: handHeight }}
         onPointerDown={handleHandPointerDown}
         onPointerMove={handleHandPointerMove}
@@ -292,11 +293,8 @@ export default function PlayerHand({ onPlayCard }: PlayerHandProps) {
         onClickCapture={handleHandClickCapture}
         onClick={playSelectedCard}
       >
-        <span className="absolute top-1 left-1/2 -translate-x-1/2 text-2xs text-muted-foreground whitespace-nowrap pointer-events-none">
-          我的手牌 · {sorted.length}张
-        </span>
         <div
-          className="relative overflow-visible"
+          className="relative overflow-visible pointer-events-none"
           style={{ width: contentWidth, height: handHeight }}
         >
           <AnimatePresence mode="popLayout">
@@ -317,7 +315,7 @@ export default function PlayerHand({ onPlayCard }: PlayerHandProps) {
               const boundaryOffset = boundaryOffsets[i] ?? 0;
               const x = layout.padX + i * layout.stride + boundaryOffset + localExpand;
               const angle = isActive ? 0 : (i - center) * spreadAngle * Math.min(1, layout.stride / 36);
-              const y = isActive ? 0 : (isPlayable ? ACTIVE_LIFT - 10 : ACTIVE_LIFT);
+              const y = isActive ? 0 : (isPlayable ? activeLift - 10 : activeLift);
 
               return (
                 <AnimatedCard
@@ -327,7 +325,7 @@ export default function PlayerHand({ onPlayCard }: PlayerHandProps) {
                   playable={hintedIds.has(card.id)}
                   clickable={false}
                   dimmed={isDimmed}
-                  className="absolute left-0 top-8 pointer-events-none"
+                  className={`absolute left-0 ${isMobile ? 'top-2' : 'top-0'} pointer-events-none`}
                   cardClassName="!transition-none pointer-events-none"
                   forceCornerLabel
                   disableHoverLift

--- a/packages/client/src/features/game/hooks/useIsMobile.ts
+++ b/packages/client/src/features/game/hooks/useIsMobile.ts
@@ -1,0 +1,16 @@
+import { useState, useEffect } from 'react';
+
+const MOBILE_QUERY = '(max-width: 767px)';
+
+export function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState(() => window.matchMedia(MOBILE_QUERY).matches);
+
+  useEffect(() => {
+    const mq = window.matchMedia(MOBILE_QUERY);
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+
+  return isMobile;
+}

--- a/packages/client/src/features/game/pages/GamePage.tsx
+++ b/packages/client/src/features/game/pages/GamePage.tsx
@@ -9,6 +9,7 @@ import { usePlayableCardIds } from '../hooks/usePlayableCardIds';
 import { useGameSocket } from '../hooks/useGameSocket';
 import { useGameLogTracker } from '../hooks/useGameLogTracker';
 import { useAutoPlay } from '../hooks/useAutoPlay';
+import { useEffectiveUserId } from '../hooks/useEffectiveUserId';
 import { useGameActions } from '../hooks/useGameActions';
 import { useGameHotkeys } from '../hooks/useGameHotkeys';
 import { playSound } from '@/shared/sound/sound-manager';
@@ -38,6 +39,12 @@ import GameStartRulesModal from '../components/GameStartRulesModal';
 import ColorWave from '../components/ColorWave';
 import HotkeySettingsModal from '../components/HotkeySettingsModal';
 import OwnerTransferBanner from '../components/OwnerTransferBanner';
+import AutopilotOverlay from '../components/AutopilotOverlay';
+import MobileStatusBar from '../components/MobileStatusBar';
+import MobilePlayerStrip from '../components/MobilePlayerStrip';
+import MobileGameCenter from '../components/MobileGameCenter';
+import MobileMenuSheet from '../components/MobileMenuSheet';
+import { useIsMobile } from '../hooks/useIsMobile';
 
 export default function GamePage() {
   const { roomCode } = useParams<{ roomCode: string }>();
@@ -52,9 +59,13 @@ export default function GamePage() {
 
   const isSpectator = useGameStore((s) => s.isSpectator);
   const setSpectator = useGameStore((s) => s.setSpectator);
+  const players = useGameStore((s) => s.players);
+  const userId = useEffectiveUserId();
+  const myAutopilot = players.find((p) => p.id === userId)?.autopilot ?? false;
   const isMyTurn = useIsMyTurn();
   const playableIds = usePlayableCardIds();
-  const needsColorPick = phase === 'choosing_color' && isMyTurn;
+  const noop = () => {};
+  const needsColorPick = phase === 'choosing_color' && isMyTurn && !myAutopilot;
   const showScoreBoard = phase === 'round_end' || phase === 'game_over';
 
   const connectionStatus = useGameSocket(roomCode);
@@ -70,8 +81,10 @@ export default function GamePage() {
 
   useGameLogTracker();
   const bgmSongName = useBgm('game');
+  const isMobile = useIsMobile();
   const [showStartRules, setShowStartRules] = useState(false);
   const [showHotkeys, setShowHotkeys] = useState(false);
+  const [showMobileMenu, setShowMobileMenu] = useState(false);
   const shownStartRulesRef = useRef<string | null>(null);
   const [antiCheatKey, setAntiCheatKey] = useState<string | null>(null);
   const shownAntiCheatRef = useRef<string | null>(null);
@@ -186,47 +199,97 @@ export default function GamePage() {
           </p>
         </div>
       )}
-      <TopBar roomCode={roomCode ?? ''} onOpenHotkeys={() => setShowHotkeys(true)} />
-      <PlayerListPanel />
-      <LayoutGroup>
-      <div className="relative flex flex-col flex-1 min-h-0">
-      <GameTable onDraw={drawCard} />
-      <DanmakuLayer />
-      </div>
-      <AnimatePresence>
-        {showTurnBanner && isMyTurn && phase === 'playing' && (
-          <motion.div
-            className="absolute left-1/2 top-turn-top -translate-x-1/2 -translate-y-1/2 z-actions pointer-events-none font-game text-title-responsive font-black text-white text-shadow-bold"
-            initial={{ opacity: 0, scale: 0.92, y: 12 }}
-            animate={{ opacity: 1, scale: 1, y: 0 }}
-            exit={{ opacity: 0, scale: 0.96, y: -8 }}
-            transition={{ duration: 0.22, ease: 'easeOut' }}
-          >
-            轮到你了
-          </motion.div>
-        )}
-      </AnimatePresence>
-      {!isSpectator && (
-        <GameActions
-          onCallUno={callUno}
-          onCatchUno={catchUno}
-          onChallenge={challenge}
-          onAccept={accept}
-          onPass={pass}
-          onSwapTarget={swapTarget}
-        />
-      )}
-      {!isSpectator && <PlayerHand onPlayCard={playCard} />}
-      </LayoutGroup>
-      {isSpectator && (
+      {isMobile ? (
         <>
-          <SpectatorActions onCatchUno={catchUno} />
-          {!showScoreBoard && (
-            <SpectatorBar
-              phase={phase}
-              onBackToLobby={backToLobby}
-              onJoined={() => { setSpectator(false); clearSpectators(); }}
+          <MobileStatusBar onOpenMenu={() => setShowMobileMenu(true)} />
+          <MobilePlayerStrip />
+          <div className="relative flex flex-col flex-1 min-h-0">
+            <MobileGameCenter onDraw={myAutopilot ? noop : drawCard} />
+            <DanmakuLayer />
+            <AnimatePresence>
+              {showTurnBanner && isMyTurn && phase === 'playing' && (
+                <motion.div
+                  className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-actions pointer-events-none font-game text-4xl font-black text-white text-shadow-bold"
+                  initial={{ opacity: 0, scale: 0.92 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  exit={{ opacity: 0, scale: 0.96 }}
+                  transition={{ duration: 0.22, ease: 'easeOut' }}
+                >
+                  轮到你了
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </div>
+          {!isSpectator && !myAutopilot && (
+            <GameActions
+              onCallUno={callUno}
+              onCatchUno={catchUno}
+              onChallenge={challenge}
+              onAccept={accept}
+              onPass={pass}
+              onSwapTarget={swapTarget}
             />
+          )}
+          {!isSpectator && <PlayerHand onPlayCard={myAutopilot ? noop : playCard} />}
+          {isSpectator && (
+            <>
+              <SpectatorActions onCatchUno={catchUno} />
+              {!showScoreBoard && (
+                <SpectatorBar
+                  phase={phase}
+                  onBackToLobby={backToLobby}
+                  onJoined={() => { setSpectator(false); clearSpectators(); }}
+                />
+              )}
+            </>
+          )}
+          <MobileMenuSheet open={showMobileMenu} onClose={() => setShowMobileMenu(false)} />
+        </>
+      ) : (
+        <>
+          <TopBar roomCode={roomCode ?? ''} onOpenHotkeys={() => setShowHotkeys(true)} />
+          <PlayerListPanel />
+          <LayoutGroup>
+          <div className="relative flex flex-col flex-1 min-h-0">
+          <GameTable onDraw={myAutopilot ? noop : drawCard} />
+          <DanmakuLayer />
+          </div>
+          <AnimatePresence>
+            {showTurnBanner && isMyTurn && phase === 'playing' && (
+              <motion.div
+                className="absolute left-1/2 top-turn-top -translate-x-1/2 -translate-y-1/2 z-actions pointer-events-none font-game text-title-responsive font-black text-white text-shadow-bold"
+                initial={{ opacity: 0, scale: 0.92, y: 12 }}
+                animate={{ opacity: 1, scale: 1, y: 0 }}
+                exit={{ opacity: 0, scale: 0.96, y: -8 }}
+                transition={{ duration: 0.22, ease: 'easeOut' }}
+              >
+                轮到你了
+              </motion.div>
+            )}
+          </AnimatePresence>
+          {!isSpectator && !myAutopilot && (
+            <GameActions
+              onCallUno={callUno}
+              onCatchUno={catchUno}
+              onChallenge={challenge}
+              onAccept={accept}
+              onPass={pass}
+              onSwapTarget={swapTarget}
+            />
+          )}
+          {!isSpectator && <PlayerHand onPlayCard={myAutopilot ? noop : playCard} />}
+          </LayoutGroup>
+          {isSpectator && (
+            <>
+              <SpectatorActions onCatchUno={catchUno} />
+              {!showScoreBoard && (
+                <SpectatorBar
+                  phase={phase}
+                  onBackToLobby={backToLobby}
+                  onJoined={() => { setSpectator(false); clearSpectators(); }}
+                />
+              )}
+            </>
           )}
         </>
       )}
@@ -242,6 +305,7 @@ export default function GamePage() {
       <ColorWave />
       {antiCheatKey && <AntiCheatToast key={antiCheatKey} />}
       <OwnerTransferBanner />
+      {!isSpectator && <AutopilotOverlay />}
       {(phase === 'round_end' || phase === 'game_over') && <Confetti />}
       {needsColorPick && <ColorPicker onPick={chooseColor} />}
       {showScoreBoard && (

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -135,6 +135,7 @@
   --z-index-topbar: 10;
   --z-index-actions: 20;
   --z-index-fab: 50;
+  --z-index-autopilot: 60;
   --z-index-confetti: 85;
   --z-index-effects: 90;
   --z-index-timer-overlay: 95;

--- a/packages/shared/src/rules/house-rules-engine.ts
+++ b/packages/shared/src/rules/house-rules-engine.ts
@@ -32,6 +32,15 @@ export function applyActionWithHouseRules(state: GameState, action: GameAction):
     }
   }
 
+  if (
+    action.type === 'DRAW_CARD' &&
+    (state.pendingPenaltyDraws ?? 0) === 0 &&
+    state.lastAction?.type === 'DRAW_CARD' &&
+    state.lastAction.playerId === action.playerId
+  ) {
+    return state;
+  }
+
   let next = applyAction(state, action);
   return runPostProcess(state, next, action, hr);
 }


### PR DESCRIPTION
## Summary
- 新增移动端专用游戏界面组件（MobileStatusBar / MobilePlayerStrip / MobileGameCenter / MobileMenuSheet），GamePage 根据屏幕宽度自动切换桌面/移动端布局
- 新增 AutopilotOverlay 托管遮罩，托管状态下屏蔽出牌、抽牌等交互操作
- 优化 PlayerHand 移动端卡牌尺寸（64×92）、最小步距与拖拽行为，桌面端关闭横向滚动
- 修复村规引擎中同一玩家连续重复抽牌的问题

## Test plan
- [ ] 桌面端游戏界面功能无回归
- [ ] 移动端（<768px）自动切换为移动布局
- [ ] 托管状态下出牌/抽牌交互被正确屏蔽
- [ ] 手牌区域在不同手牌数量下显示正常
- [ ] 村规开启时抽牌行为正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)