### PR TITLE
feat: 可拖拽悬浮面板、玩家列表折叠及观战流程优化

### DIFF
--- a/packages/client/src/features/game/components/PlayerListPanel.tsx
+++ b/packages/client/src/features/game/components/PlayerListPanel.tsx
@@ -1,4 +1,6 @@
-import { Bot, Crown, Eye, UserPlus } from 'lucide-react';
+import { useState } from 'react';
+import { motion, useDragControls, AnimatePresence } from 'framer-motion';
+import { Bot, ChevronDown, Crown, Eye, GripHorizontal, UserPlus } from 'lucide-react';
 import { useGameStore } from '../stores/game-store';
 import { useSpectatorStore } from '../stores/spectator-store';
 import { useRoomStore } from '@/shared/stores/room-store';
@@ -17,113 +19,148 @@ export default function PlayerListPanel() {
   const pendingJoinQueue = useSpectatorStore((s) => s.pendingJoinQueue);
   const ownerId = useRoomStore((s) => s.room?.ownerId);
   const userId = useEffectiveUserId();
+  const [collapsed, setCollapsed] = useState(false);
+  const dragControls = useDragControls();
 
   if (players.length === 0) return null;
 
   return (
-    <div className="absolute top-12 right-3 z-topbar hidden md:block">
-      <div className="rounded-card-ui bg-card/80 backdrop-blur-sm shadow-card shadow-tech border border-white/10 w-48 max-h-64 overflow-y-auto scrollbar-thin">
-        <div className="px-3 py-2 border-b border-white/10 text-xs text-muted-foreground font-bold">
-          玩家 ({players.length})
+    <motion.div
+      drag
+      dragControls={dragControls}
+      dragListener={false}
+      dragMomentum={false}
+      dragElastic={0}
+      className="absolute top-12 right-3 z-topbar hidden md:block"
+    >
+      <div className="rounded-card-ui bg-card/80 backdrop-blur-sm shadow-card shadow-tech border border-white/10 w-48">
+        <div
+          className="px-3 py-2 border-b border-white/10 text-xs text-muted-foreground font-bold flex items-center gap-1 cursor-grab active:cursor-grabbing select-none"
+          onPointerDown={(e) => dragControls.start(e)}
+        >
+          <GripHorizontal size={12} className="shrink-0 opacity-40" />
+          <span className="flex-1">玩家 ({players.length})</span>
+          <button
+            type="button"
+            className="p-0.5 rounded hover:bg-white/10 transition-colors cursor-pointer"
+            onClick={() => setCollapsed((c) => !c)}
+            onPointerDown={(e) => e.stopPropagation()}
+          >
+            <ChevronDown size={12} className={cn('transition-transform', !collapsed && 'rotate-180')} />
+          </button>
         </div>
-        <div className="py-1">
-          {players.map((p, i: number) => {
-            const isActive = i === currentPlayerIndex;
-            const isMe = p.id === userId;
-            const roleColor = getRoleColor(p.role);
-            return (
-              <div
-                key={p.id}
-                className={cn(
-                  'flex items-center gap-2 px-3 py-1.5 transition-colors',
-                  isActive && 'bg-primary/10',
-                  p.eliminated && 'opacity-40',
-                )}
-              >
-                {(() => {
-                  const isConfiguredBot = p.isBot && !!p.botConfig;
-                  const botDisplay = isConfiguredBot ? DIFFICULTY_DISPLAY[p.botConfig!.difficulty] : undefined;
-                  return (
-                    <div
-                      className="relative w-6 h-6 rounded-full flex items-center justify-center text-xs shrink-0 overflow-hidden"
-                      style={{
-                        background: botDisplay
-                          ? botDisplay.avatarBg
-                          : AVATAR_COLORS[i % AVATAR_COLORS.length],
-                      }}
-                    >
-                      {isConfiguredBot ? (
-                        <Bot size={13} className="text-white drop-shadow-sm" />
-                      ) : (
-                        <>
-                          <span>{AVATAR_EMOJIS[i % AVATAR_EMOJIS.length]}</span>
-                          {p.avatarUrl && (
-                            <img
-                              src={p.avatarUrl}
-                              alt={p.name}
-                              className="absolute inset-0 w-full h-full object-cover"
-                              referrerPolicy="no-referrer"
-                              onError={(e) => {
-                                e.currentTarget.style.display = 'none';
+        <AnimatePresence initial={false}>
+          {!collapsed && (
+            <motion.div
+              initial={{ height: 0 }}
+              animate={{ height: 'auto' }}
+              exit={{ height: 0 }}
+              transition={{ duration: 0.15, ease: 'easeInOut' }}
+              className="overflow-hidden"
+            >
+              <div className="max-h-64 overflow-y-auto scrollbar-thin">
+                <div className="py-1">
+                  {players.map((p, i: number) => {
+                    const isActive = i === currentPlayerIndex;
+                    const isMe = p.id === userId;
+                    const roleColor = getRoleColor(p.role);
+                    return (
+                      <div
+                        key={p.id}
+                        className={cn(
+                          'flex items-center gap-2 px-3 py-1.5 transition-colors',
+                          isActive && 'bg-primary/10',
+                          p.eliminated && 'opacity-40',
+                        )}
+                      >
+                        {(() => {
+                          const isConfiguredBot = p.isBot && !!p.botConfig;
+                          const botDisplay = isConfiguredBot ? DIFFICULTY_DISPLAY[p.botConfig!.difficulty] : undefined;
+                          return (
+                            <div
+                              className="relative w-6 h-6 rounded-full flex items-center justify-center text-xs shrink-0 overflow-hidden"
+                              style={{
+                                background: botDisplay
+                                  ? botDisplay.avatarBg
+                                  : AVATAR_COLORS[i % AVATAR_COLORS.length],
                               }}
-                            />
-                          )}
-                        </>
-                      )}
-                      {botDisplay ? (
-                        <div
-                          className="absolute inset-0 rounded-full pointer-events-none"
-                          style={{
-                            border: `1.5px solid ${botDisplay.ringColor}`,
-                          }}
-                        />
-                      ) : (
-                        <GoogleRing size={0} className="w-full h-full" />
-                      )}
+                            >
+                              {isConfiguredBot ? (
+                                <Bot size={13} className="text-white drop-shadow-sm" />
+                              ) : (
+                                <>
+                                  <span>{AVATAR_EMOJIS[i % AVATAR_EMOJIS.length]}</span>
+                                  {p.avatarUrl && (
+                                    <img
+                                      src={p.avatarUrl}
+                                      alt={p.name}
+                                      className="absolute inset-0 w-full h-full object-cover"
+                                      referrerPolicy="no-referrer"
+                                      onError={(e) => {
+                                        e.currentTarget.style.display = 'none';
+                                      }}
+                                    />
+                                  )}
+                                </>
+                              )}
+                              {botDisplay ? (
+                                <div
+                                  className="absolute inset-0 rounded-full pointer-events-none"
+                                  style={{
+                                    border: `1.5px solid ${botDisplay.ringColor}`,
+                                  }}
+                                />
+                              ) : (
+                                <GoogleRing size={0} className="w-full h-full" />
+                              )}
+                            </div>
+                          );
+                        })()}
+                        <div className="flex-1 min-w-0">
+                          <div className={cn(
+                            'text-xs truncate',
+                            isActive && 'text-primary font-bold',
+                            isMe && !isActive && 'text-primary',
+                            !isActive && !isMe && 'text-foreground',
+                          )} style={(!isActive && !isMe && roleColor) ? { color: roleColor } : undefined}>
+                            {p.name}{isMe ? ' (你)' : ''}{p.id === ownerId && <Crown size={10} className="inline align-middle ml-1 text-yellow-500" />}{p.isBot && <AiBadge className="ml-1" />}
+                          </div>
+                        </div>
+                        <div className="flex items-center gap-1 shrink-0">
+                          <PlayerVoiceStatus playerId={p.id} playerName={p.name} isSelf={isMe} />
+                          <span className="text-2xs text-muted-foreground">{p.handCount}</span>
+                          {!p.connected && <span className="w-1.5 h-1.5 rounded-full bg-destructive" />}
+                          {isActive && <span className="text-2xs">◀</span>}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+                {spectators.length > 0 && (
+                  <>
+                    <div className="px-3 py-2 border-t border-white/10 text-xs text-muted-foreground font-bold">
+                      观众 ({spectators.length})
                     </div>
-                  );
-                })()}
-                <div className="flex-1 min-w-0">
-                  <div className={cn(
-                    'text-xs truncate',
-                    isActive && 'text-primary font-bold',
-                    isMe && !isActive && 'text-primary',
-                    !isActive && !isMe && 'text-foreground',
-                  )} style={(!isActive && !isMe && roleColor) ? { color: roleColor } : undefined}>
-                    {p.name}{isMe ? ' (你)' : ''}{p.id === ownerId && <Crown size={10} className="inline align-middle ml-1 text-yellow-500" />}{p.isBot && <AiBadge className="ml-1" />}
-                  </div>
-                </div>
-                <div className="flex items-center gap-1 shrink-0">
-                  <PlayerVoiceStatus playerId={p.id} playerName={p.name} isSelf={isMe} />
-                  <span className="text-2xs text-muted-foreground">{p.handCount}</span>
-                  {!p.connected && <span className="w-1.5 h-1.5 rounded-full bg-destructive" />}
-                  {isActive && <span className="text-2xs">◀</span>}
-                </div>
+                    <div className="py-1">
+                      {spectators.map((s) => {
+                        const queued = pendingJoinQueue.includes(s.nickname);
+                        return (
+                          <div key={s.nickname} className={cn('flex items-center gap-2 px-3 py-1 text-xs text-muted-foreground', !s.connected && 'opacity-50')}>
+                            {queued ? <UserPlus size={12} className="shrink-0 text-accent" /> : <Eye size={12} className="shrink-0" />}
+                            <span className={cn('truncate', queued && 'text-accent')}>{s.nickname}</span>
+                            {!s.connected && <span className="w-1.5 h-1.5 rounded-full bg-destructive shrink-0 ml-auto" />}
+                            {queued && <span className="text-2xs text-accent ml-auto shrink-0">加入中</span>}
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </>
+                )}
               </div>
-            );
-          })}
-        </div>
-        {spectators.length > 0 && (
-          <>
-            <div className="px-3 py-2 border-t border-white/10 text-xs text-muted-foreground font-bold">
-              观众 ({spectators.length})
-            </div>
-            <div className="py-1">
-              {spectators.map((s) => {
-                const queued = pendingJoinQueue.includes(s.nickname);
-                return (
-                  <div key={s.nickname} className={cn('flex items-center gap-2 px-3 py-1 text-xs text-muted-foreground', !s.connected && 'opacity-50')}>
-                    {queued ? <UserPlus size={12} className="shrink-0 text-accent" /> : <Eye size={12} className="shrink-0" />}
-                    <span className={cn('truncate', queued && 'text-accent')}>{s.nickname}</span>
-                    {!s.connected && <span className="w-1.5 h-1.5 rounded-full bg-destructive shrink-0 ml-auto" />}
-                    {queued && <span className="text-2xs text-accent ml-auto shrink-0">加入中</span>}
-                  </div>
-                );
-              })}
-            </div>
-          </>
-        )}
+            </motion.div>
+          )}
+        </AnimatePresence>
       </div>
-    </div>
+    </motion.div>
   );
 }

--- a/packages/client/src/features/game/components/SpectatorSeats.tsx
+++ b/packages/client/src/features/game/components/SpectatorSeats.tsx
@@ -1,4 +1,5 @@
 import { memo } from 'react';
+import { motion } from 'framer-motion';
 import { Eye } from 'lucide-react';
 import { useSpectatorStore } from '../stores/spectator-store';
 import { cn } from '@/shared/lib/utils';
@@ -15,32 +16,39 @@ function SpectatorSeats({ top }: SpectatorSeatsProps) {
 
   return (
     <div
-      className="absolute left-1/2 -translate-x-1/2 z-10 flex items-center gap-2 bg-card/60 backdrop-blur-sm rounded-full px-3 py-1.5 border border-white/5"
+      className="absolute left-0 right-0 z-10 flex justify-center"
       style={top != null ? { top } : { bottom: 8 }}
     >
-      <Eye size={12} className="text-muted-foreground shrink-0" />
-      <div className="flex items-center gap-1">
-        {spectators.map((s) => {
-          const queued = pendingJoinQueue.includes(s.nickname);
-          return (
-            <div
-              key={s.nickname}
-              className={cn(
-                'w-7 h-7 rounded-full flex items-center justify-center text-xs border-2 shrink-0 overflow-hidden',
-                queued
-                  ? 'bg-accent/20 border-accent/40 text-accent'
-                  : 'bg-white/10 border-white/10 text-muted-foreground',
-                !s.connected && 'opacity-40',
-              )}
-              title={s.nickname + (queued ? ' (下局加入)' : '') + (!s.connected ? ' (已断线)' : '')}
-            >
-              {s.avatarUrl
-                ? <img src={s.avatarUrl} alt={s.nickname} className="w-full h-full object-cover" referrerPolicy="no-referrer" onError={(e) => { e.currentTarget.style.display = 'none'; }} />
-                : s.nickname.charAt(0).toUpperCase()}
-            </div>
-          );
-        })}
-      </div>
+      <motion.div
+        drag
+        dragMomentum={false}
+        dragElastic={0}
+        className="flex items-center gap-2 bg-card/60 backdrop-blur-sm rounded-full px-3 py-1.5 border border-white/5 cursor-grab active:cursor-grabbing select-none"
+      >
+        <Eye size={12} className="text-muted-foreground shrink-0" />
+        <div className="flex items-center gap-1">
+          {spectators.map((s) => {
+            const queued = pendingJoinQueue.includes(s.nickname);
+            return (
+              <div
+                key={s.nickname}
+                className={cn(
+                  'w-7 h-7 rounded-full flex items-center justify-center text-xs border-2 shrink-0 overflow-hidden',
+                  queued
+                    ? 'bg-accent/20 border-accent/40 text-accent'
+                    : 'bg-white/10 border-white/10 text-muted-foreground',
+                  !s.connected && 'opacity-40',
+                )}
+                title={s.nickname + (queued ? ' (下局加入)' : '') + (!s.connected ? ' (已断线)' : '')}
+              >
+                {s.avatarUrl
+                  ? <img src={s.avatarUrl} alt={s.nickname} className="w-full h-full object-cover" referrerPolicy="no-referrer" onError={(e) => { e.currentTarget.style.display = 'none'; }} />
+                  : s.nickname.charAt(0).toUpperCase()}
+              </div>
+            );
+          })}
+        </div>
+      </motion.div>
     </div>
   );
 }

--- a/packages/client/src/features/game/pages/RoomPage.tsx
+++ b/packages/client/src/features/game/pages/RoomPage.tsx
@@ -406,6 +406,7 @@ export default function RoomPage() {
           roomStatus={room?.status ?? ''}
           position={menuTarget.position}
           onClose={() => setMenuTarget(null)}
+          onSwapRequest={handleSwapWithBot}
         />
       )}
       <VoicePanel />

--- a/packages/client/src/features/lobby/pages/LobbyPage.tsx
+++ b/packages/client/src/features/lobby/pages/LobbyPage.tsx
@@ -275,12 +275,7 @@ export default function LobbyPage() {
                 className="group bg-white/[0.03] rounded-[14px] p-3.5 cursor-pointer transition-all border border-transparent hover:bg-white/[0.06] hover:border-[rgba(251,191,36,0.1)]"
                 onClick={() => {
                   connectSocket();
-                  getSocket().emit('room:spectate', room.roomCode, (res: any) => {
-                    if (res.success) navigate(`/game/${room.roomCode}?spectate=true`);
-                    else {
-                      setError(res.error || '无法观战');
-                    }
-                  });
+                  navigate(`/game/${room.roomCode}`);
                 }}
               >
                 <div className="text-sm font-semibold text-[#cbd5e1]">

--- a/packages/server/src/plugins/core/spectate/ws.ts
+++ b/packages/server/src/plugins/core/spectate/ws.ts
@@ -1,11 +1,7 @@
 import type { Server as SocketIOServer } from 'socket.io';
 import type { KvStore } from '../../../kv/types.js';
-import type { SocketData } from '../../../ws/types.js';
-import { deleteRoom, getRoom, clearUserRoom, ensureNotInRoom, getRoomSpectators, addSpectatorToRoom } from '../room/store.js';
-import { GameSession } from '../game/session.js';
-import { loadGameState } from '../game/state-store.js';
+import { getRoomSpectators } from '../room/store.js';
 import { removePendingSpectatorJoin, getPendingSpectatorQueue } from '../../../ws/game-events.js';
-import { joinRoomSocket } from '../../../ws/socket-room.js';
 
 export function toSpectatorView(spectators: import('../room/store.js').RoomSpectator[]) {
   return spectators.map(s => ({ nickname: s.nickname, avatarUrl: s.avatarUrl, connected: s.connected }));
@@ -35,76 +31,3 @@ export async function broadcastSpectatorLeft(
   io.to(roomCode).emit('room:spectator_left', { nickname, spectators });
 }
 
-export function setupSpectateHandlers(
-  io: SocketIOServer,
-  kv: KvStore,
-  sessions: Map<string, GameSession>,
-): void {
-  io.on('connection', (socket) => {
-    socket.on('room:spectate', async (roomCode: string, callback?: (res: Record<string, unknown>) => void) => {
-      const data = socket.data as SocketData;
-      if (!data.user) {
-        callback?.({ success: false, error: '未登录' });
-        return;
-      }
-
-      const room = await getRoom(kv, roomCode);
-      if (!room) {
-        callback?.({ success: false, error: '房间不存在' });
-        return;
-      }
-      if (room.status !== 'playing') {
-        callback?.({ success: false, error: '游戏未开始' });
-        return;
-      }
-      if (!room.settings.allowSpectators) {
-        callback?.({ success: false, error: '该房间不允许观战' });
-        return;
-      }
-
-      const conflict = await ensureNotInRoom(kv, data.user.userId, roomCode);
-      if (conflict) {
-        callback?.({ success: false, error: conflict });
-        return;
-      }
-
-      let session = sessions.get(roomCode);
-      if (!session) {
-        const savedState = await loadGameState(kv, roomCode);
-        if (!savedState) {
-          await deleteRoom(kv, roomCode);
-          callback?.({ success: false, error: '游戏会话不存在' });
-          return;
-        }
-        session = GameSession.fromState(savedState);
-        sessions.set(roomCode, session);
-      }
-
-      await joinRoomSocket(kv, socket, roomCode, { asSpectator: true });
-
-      await addSpectatorToRoom(kv, roomCode, {
-        userId: data.user.userId,
-        nickname: data.user.nickname,
-        avatarUrl: data.user.avatarUrl,
-        role: data.user.role,
-        connected: true,
-      });
-
-      const view = session.getSpectatorView(room.settings.spectatorMode);
-      socket.emit('game:state', view);
-      socket.emit('chat:history', session.getChatHistory());
-
-      const spectators = toSpectatorView(await getRoomSpectators(kv, roomCode));
-      io.to(roomCode).emit('room:spectator_list', { spectators });
-      socket.to(roomCode).emit('room:spectator_joined', {
-        nickname: data.user.nickname,
-        spectators,
-      });
-
-      callback?.({ success: true });
-    });
-
-    // Spectator disconnect is handled by the unified disconnect handler in
-    // socket-handler.ts — same timeout/reconnect flow as seated players.
-  });
-}

--- a/packages/server/src/ws/socket-handler.ts
+++ b/packages/server/src/ws/socket-handler.ts
@@ -14,7 +14,7 @@ import { loadGameState, GameStatePersister } from '../plugins/core/game/state-st
 import { getActiveRooms } from '../plugins/core/spectate/routes.js';
 import { checkRateLimit, clearRateLimit } from './rate-limiter.js';
 import { registerInteractionEvents, clearThrowTimestamp } from '../plugins/core/interaction/ws.js';
-import { setupSpectateHandlers, broadcastSpectatorList, broadcastSpectatorLeft, toSpectatorView } from '../plugins/core/spectate/ws.js';
+import { broadcastSpectatorList, broadcastSpectatorLeft, toSpectatorView } from '../plugins/core/spectate/ws.js';
 import { dissolveRoom } from './room-lifecycle.js';
 import { cancelOwnerTransfer, hasOwnerTransferPending, scheduleOwnerTransfer, configureOwnerTransfer } from './owner-transfer.js';
 import { registerVoicePresenceEvents, removeVoicePresence } from './voice-presence.js';
@@ -297,7 +297,12 @@ export function setupSocketHandlers(
           const view = session.getSpectatorView(spectatorMode);
           callback?.({ success: true, gameState: view, isSpectator: true });
           socket.emit('chat:history', session.getChatHistory());
-          await broadcastSpectatorList(io, redis, roomCode);
+          const updatedSpectators = toSpectatorView(await getRoomSpectators(redis, roomCode));
+          io.to(roomCode).emit('room:spectator_list', { spectators: updatedSpectators });
+          socket.to(roomCode).emit('room:spectator_joined', {
+            nickname: socket.data.user.nickname,
+            spectators: updatedSpectators,
+          });
           const queue = getPendingSpectatorQueue(roomCode);
           if (queue.length > 0) {
             socket.emit('game:spectator_queue', { queue, nickname: '', joined: true });
@@ -557,8 +562,6 @@ export function setupSocketHandlers(
       }
     });
   });
-
-  setupSpectateHandlers(io, redis, sessions);
 
   return { roomManager, turnTimer, sessions, persister, voiceChannels };
 }

--- a/packages/shared/src/types/socket-events.ts
+++ b/packages/shared/src/types/socket-events.ts
@@ -93,7 +93,6 @@ export interface ClientToServerEvents {
   'seat:swap_request': (targetUserId: string, callback: (res: SocketCallbackResult) => void) => void;
   'seat:swap_respond': (payload: { requesterId: string; accept: boolean }, callback: (res: SocketCallbackResult) => void) => void;
   'voice:force_mute': (payload: { targetId: string; muted: boolean }, callback?: (res: SocketCallbackResult) => void) => void;
-  'room:spectate': (roomCode: string, callback?: (res: SocketCallbackResult) => void) => void;
   'game:start': (callback: (res: SocketCallbackResult & { gameState?: PlayerView }) => void) => void;
   'game:play_card': (payload: { cardId: string; chosenColor?: Color }, callback?: (res: SocketCallbackResult) => void) => void;
   'game:draw_card': (payload: { side?: string }, callback?: (res: SocketCallbackResult) => void) => void;


### PR DESCRIPTION
## Summary
- 玩家列表面板支持拖拽移动（标题栏作为拖拽手柄）和折叠收起
- 观战席支持拖拽移动，使用 flex 居中避免与 framer-motion transform 冲突
- 修复 PlayerActionMenu 未传递 onSwapRequest 回调导致无法对人类玩家请求换座
- 观战入口统一到 room:join 流程，移除独立的 room:spectate 事件和 setupSpectateHandlers

## Test plan
- [ ] 游戏中拖拽玩家列表面板到不同位置
- [ ] 点击折叠/展开按钮验证动画效果
- [ ] 拖拽观战席到不同位置
- [ ] 在房间中对人类玩家右键菜单请求换座
- [ ] 从大厅点击观战进入游戏房间

🤖 Generated with [Claude Code](https://claude.com/claude-code)