### PR TITLE
fix: 通知权限和更新日志弹窗仅登录后显示

### DIFF
--- a/packages/client/src/shared/components/ChangelogModal.tsx
+++ b/packages/client/src/shared/components/ChangelogModal.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { X, Sparkles, ChevronDown } from 'lucide-react';
 import { changelog } from '../data/changelog';
+import { useAuthStore } from '@/features/auth/stores/auth-store';
 
 const STORAGE_KEY = 'app-last-seen-version';
 const VISIBLE_COUNT = 3;
@@ -12,17 +13,19 @@ export function openChangelog() { externalOpen?.(); }
 export default function ChangelogModal() {
   const [open, setOpen] = useState(false);
   const [expanded, setExpanded] = useState(false);
+  const token = useAuthStore((s) => s.token);
 
   const show = useCallback(() => setOpen(true), []);
   useEffect(() => { externalOpen = show; return () => { externalOpen = null; }; }, [show]);
 
   useEffect(() => {
+    if (!token) return;
     const currentVersion = import.meta.env.BUILD_VERSION as string;
     const lastSeen = localStorage.getItem(STORAGE_KEY);
     if (lastSeen !== currentVersion) {
       setOpen(true);
     }
-  }, []);
+  }, [token]);
 
   const close = () => {
     setOpen(false);

--- a/packages/client/src/shared/components/NotificationPermissionDialog.tsx
+++ b/packages/client/src/shared/components/NotificationPermissionDialog.tsx
@@ -1,19 +1,22 @@
 import { useState, useEffect } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { Bell, X } from 'lucide-react';
+import { useAuthStore } from '@/features/auth/stores/auth-store';
 
 export default function NotificationPermissionDialog() {
   const [open, setOpen] = useState(false);
   const [permission, setPermission] = useState<NotificationPermission | 'unsupported'>('default');
+  const token = useAuthStore((s) => s.token);
 
   useEffect(() => {
+    if (!token) return;
     if (typeof Notification === 'undefined') return;
     const current = Notification.permission;
     setPermission(current);
     if (current !== 'granted') {
       setOpen(true);
     }
-  }, []);
+  }, [token]);
 
   const handleRequest = async () => {
     if (typeof Notification === 'undefined') return;


### PR DESCRIPTION
## Summary
- 通知权限弹窗和更新日志弹窗改为登录后才自动弹出
- 手动调用 `openChangelog()` 不受影响

## Test plan
- [ ] 未登录状态下访问首页，不应弹出通知和更新日志
- [ ] 登录后自动弹出通知权限 / 更新日志弹窗
- [ ] 大厅手动点击更新日志按钮仍可正常打开

🤖 Generated with [Claude Code](https://claude.com/claude-code)