### PR TITLE
fix: 返回房间流程修复、踢人简化、房主迁移统一及超时优化

### DIFF
--- a/packages/client/src/features/game/components/AutopilotOverlay.tsx
+++ b/packages/client/src/features/game/components/AutopilotOverlay.tsx
@@ -1,11 +1,10 @@
 import { useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Hand, Bot } from 'lucide-react';
+import { AUTOPILOT_TOGGLE_COOLDOWN_MS } from '@uno-online/shared';
 import { useGameStore } from '../stores/game-store';
 import { useEffectiveUserId } from '../hooks/useEffectiveUserId';
 import { getSocket } from '@/shared/socket';
-
-const COOLDOWN_MS = 3000;
 
 export default function AutopilotOverlay() {
   const players = useGameStore((s) => s.players);
@@ -18,7 +17,7 @@ export default function AutopilotOverlay() {
     if (cooldown) return;
     setCooldown(true);
     getSocket().emit('player:toggle-autopilot', () => {});
-    setTimeout(() => setCooldown(false), COOLDOWN_MS);
+    setTimeout(() => setCooldown(false), AUTOPILOT_TOGGLE_COOLDOWN_MS);
   };
 
   const visible = myAutopilot

--- a/packages/client/src/features/game/components/ColorPicker.tsx
+++ b/packages/client/src/features/game/components/ColorPicker.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import type { Color } from '@uno-online/shared';
 import { UNO_COLOR_HEX } from '../constants/colors';
@@ -14,10 +14,13 @@ interface ColorPickerProps { onPick: (color: Color) => void; }
 
 export default function ColorPicker({ onPick }: ColorPickerProps) {
   const [picked, setPicked] = useState<Color | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  useEffect(() => () => clearTimeout(timerRef.current), []);
 
   const handlePick = (color: Color) => {
     setPicked(color);
-    setTimeout(() => onPick(color), 400);
+    timerRef.current = setTimeout(() => onPick(color), 400);
   };
 
   return (

--- a/packages/client/src/features/game/components/ScoreBoard.tsx
+++ b/packages/client/src/features/game/components/ScoreBoard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import { Trophy, BarChart3, Crown, Check, UserX, UserPlus, WifiOff, Eye, X } from 'lucide-react';
 import { useGameStore } from '../stores/game-store';
 import { useEffectiveUserId } from '../hooks/useEffectiveUserId';
@@ -12,30 +12,7 @@ import { getSocket } from '@/shared/socket';
 import { useToastStore } from '@/shared/stores/toast-store';
 import { serverNow } from '@/shared/server-time';
 
-const KICK_DELAY_S = 30;
 const START_COOLDOWN_S = 10;
-
-function KickCountdownRing({ remaining, total }: { remaining: number; total: number }) {
-  const r = 7;
-  const circumference = 2 * Math.PI * r;
-  const progress = Math.max(0, remaining / total);
-
-  return (
-    <svg width="18" height="18" viewBox="0 0 18 18" className="inline align-middle">
-      <circle cx="9" cy="9" r={r} fill="none" stroke="currentColor" strokeWidth="2" className="text-muted-foreground/20" />
-      <circle
-        cx="9" cy="9" r={r} fill="none" stroke="currentColor" strokeWidth="2"
-        className="text-destructive"
-        strokeDasharray={circumference}
-        strokeDashoffset={circumference * (1 - progress)}
-        strokeLinecap="round"
-        transform="rotate(-90 9 9)"
-        style={{ transition: 'stroke-dashoffset 1s linear' }}
-      />
-      <text x="9" y="9" textAnchor="middle" dominantBaseline="central" className="fill-muted-foreground" fontSize="7">{remaining}</text>
-    </svg>
-  );
-}
 
 interface ScoreBoardProps {
   isSpectator?: boolean;
@@ -55,10 +32,6 @@ export default function ScoreBoard({ isSpectator = false, onPlayAgain, onBackToR
   const roundEndAt = useGameStore((s) => s.roundEndAt);
   const gameOverAt = useGameStore((s) => s.gameOverAt);
   const pendingJoinQueue = useSpectatorStore((s) => s.pendingJoinQueue);
-  const [kickCountdown, setKickCountdown] = useState(() => {
-    if (!roundEndAt) return KICK_DELAY_S;
-    return Math.max(0, KICK_DELAY_S - Math.floor((serverNow() - roundEndAt) / 1000));
-  });
   const [leaveCountdown, setLeaveCountdown] = useState(5);
   const [startCooldown, setStartCooldown] = useState(() => {
     const endAt = roundEndAt ?? gameOverAt;
@@ -69,20 +42,6 @@ export default function ScoreBoard({ isSpectator = false, onPlayAgain, onBackToR
     const nickname = useAuthStore.getState().user?.nickname;
     return !!nickname && pendingJoinQueue.includes(nickname);
   });
-  const kickTimerRef = useRef<ReturnType<typeof setInterval> | undefined>(undefined);
-
-  useEffect(() => {
-    if (phase !== 'round_end' || !roundEndAt) { setKickCountdown(KICK_DELAY_S); return; }
-    const calc = () => Math.max(0, KICK_DELAY_S - Math.floor((serverNow() - roundEndAt) / 1000));
-    setKickCountdown(calc());
-    kickTimerRef.current = setInterval(() => {
-      const v = calc();
-      setKickCountdown(v);
-      if (v <= 0) clearInterval(kickTimerRef.current);
-    }, 1000);
-    return () => clearInterval(kickTimerRef.current);
-  }, [phase, roundEndAt]);
-
   useEffect(() => {
     setLeaveCountdown(5);
     const interval = setInterval(() => {
@@ -149,7 +108,6 @@ export default function ScoreBoard({ isSpectator = false, onPlayAgain, onBackToR
   const votes = vote?.votes ?? 0;
   const required = vote?.required ?? fallbackRequired;
   const allAgreed = votes >= required;
-  const canKick = kickCountdown === 0;
   const cooldownActive = startCooldown > 0;
   const noHumanPlayers = required === 0;
   const nextRoundButtonText = isHost
@@ -201,24 +159,12 @@ export default function ScoreBoard({ isSpectator = false, onPlayAgain, onBackToR
                   </td>
                   {!isGameOver && (
                     <td className="px-2 py-1.5 text-center whitespace-nowrap">
-                      {p.isBot ? (
-                        <span className="inline-flex items-center gap-1">
-                          <Check size={14} className="inline text-green-400" />
-                          {isHost && <button onClick={() => onKickPlayer(p.id)} className="text-destructive hover:text-destructive/80 cursor-pointer bg-transparent border-none" title="移除机器人"><UserX size={14} className="inline" /></button>}
-                        </span>
-                      ) : ready
-                        ? <Check size={14} className="inline text-green-400" />
-                        : isSpectator
-                          ? <span className="text-xs text-muted-foreground">等待中</span>
-                          : isSelf
-                            ? <span className="text-xs text-muted-foreground">等待中</span>
-                            : isHost && canKick
-                              ? <button onClick={() => onKickPlayer(p.id)} className="text-xs text-destructive hover:text-destructive/80 cursor-pointer bg-transparent border-none" title="移至观战席"><UserX size={14} className="inline" /></button>
-                              : disconnected
-                                ? canKick
-                                  ? <span className="text-xs text-destructive">已超时</span>
-                                  : <KickCountdownRing remaining={kickCountdown} total={KICK_DELAY_S} />
-                                : <span className="text-xs text-muted-foreground">等待中</span>}
+                      <span className="inline-flex items-center gap-1">
+                        {ready ? <Check size={14} className="inline text-green-400" /> : <span className="text-xs text-muted-foreground">等待中</span>}
+                        {isHost && !isSelf && !isSpectator && (
+                          <button onClick={() => onKickPlayer(p.id)} className="text-destructive hover:text-destructive/80 cursor-pointer bg-transparent border-none" title={p.isBot ? '移除机器人' : '移至观战席'}><UserX size={14} className="inline" /></button>
+                        )}
+                      </span>
                     </td>
                   )}
                   <td className="px-2 py-1.5 text-right font-bold">{p.score}</td>

--- a/packages/client/src/features/game/components/TopBar.tsx
+++ b/packages/client/src/features/game/components/TopBar.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Eye, Volume2, VolumeX, Music, Spade, DoorOpen, LogOut, Bot, HelpCircle, Keyboard, Trash2, Wifi, Clock, RotateCw } from 'lucide-react';
+import { AUTOPILOT_TOGGLE_COOLDOWN_MS } from '@uno-online/shared';
 import type { Card, Color } from '@uno-online/shared';
 import TurnTimer from './TurnTimer';
 import { useSettingsStore } from '@/shared/stores/settings-store';
@@ -13,8 +14,6 @@ import { useServerStore } from '@/shared/stores/server-store';
 import { showConfirm } from '@/shared/stores/confirm-store';
 import { cn } from '@/shared/lib/utils';
 import { BUILD_VERSION } from '@/shared/build-info';
-
-const AUTOPILOT_COOLDOWN_MS = 3000;
 
 const PHASE_LABEL: Record<string, string> = {
   choosing_color: '选色中…',
@@ -144,7 +143,7 @@ export default function TopBar({ roomCode, onOpenHotkeys }: TopBarProps) {
     if (autopilotCooldown) return;
     setAutopilotCooldown(true);
     getSocket().emit('player:toggle-autopilot', () => {});
-    setTimeout(() => setAutopilotCooldown(false), AUTOPILOT_COOLDOWN_MS);
+    setTimeout(() => setAutopilotCooldown(false), AUTOPILOT_TOGGLE_COOLDOWN_MS);
   };
 
   const handleLeave = async () => {

--- a/packages/client/src/features/game/pages/RoomPage.tsx
+++ b/packages/client/src/features/game/pages/RoomPage.tsx
@@ -68,7 +68,7 @@ export default function RoomPage() {
     const socket = getSocket();
     refreshVoicePresence();
 
-    if (useRoomStore.getState().seats.every((s) => s === null) && roomCode) {
+    if (useRoomStore.getState().roomCode !== roomCode && roomCode) {
       socket.emit('room:rejoin', roomCode, (res: any) => {
         if (res.success) {
           if (res.seats && res.spectators && res.room) {

--- a/packages/server/src/plugins/core/game/state-store.ts
+++ b/packages/server/src/plugins/core/game/state-store.ts
@@ -14,6 +14,10 @@ export async function loadGameState(redis: KvStore, roomCode: string): Promise<G
   return JSON.parse(raw) as GameState;
 }
 
+export async function deleteGameState(redis: KvStore, roomCode: string): Promise<void> {
+  await redis.del(GAME_STATE_KEY(roomCode));
+}
+
 export class GameStatePersister {
   private dirty = new Map<string, GameState>();
   private flushTimers = new Map<string, ReturnType<typeof setTimeout>>();

--- a/packages/server/src/plugins/core/room/manager.ts
+++ b/packages/server/src/plugins/core/room/manager.ts
@@ -6,6 +6,7 @@ import {
   getRoomSeats, takeSeat, clearSeatByUserId, setSeatPlayerReady,
   resetAllSeatsReady, setRoomOwner, getSeatedPlayers, getFirstEmptySeatIndex,
   getRoomSpectators, addSpectatorToRoom, removeSpectatorFromRoom,
+  pickNextOwner,
 } from './store.js';
 import type { RoomSeatPlayer } from './store.js';
 
@@ -62,18 +63,19 @@ export class RoomManager {
     await clearSeatByUserId(this.redis, roomCode, userId);
     await removeSpectatorFromRoom(this.redis, roomCode, userId);
     const seats = await getRoomSeats(this.redis, roomCode);
+    const spectators = await getRoomSpectators(this.redis, roomCode);
     const seatedPlayers = getSeatedPlayers(seats);
     const hasHumanPlayers = seatedPlayers.some(p => !p.isBot);
-    if (seatedPlayers.length === 0 || !hasHumanPlayers) {
+    const hasHumanSpectators = spectators.some(sp => sp.connected);
+    if ((seatedPlayers.length === 0 || !hasHumanPlayers) && !hasHumanSpectators) {
       await deleteRoom(this.redis, roomCode);
       return { deleted: true };
     }
     const room = await getRoom(this.redis, roomCode);
     if (room && room.ownerId === userId) {
-      const spectators = await getRoomSpectators(this.redis, roomCode);
-      const nextOwner = seatedPlayers.find(p => !p.isBot) ?? spectators[0];
-      if (nextOwner) {
-        await setRoomOwner(this.redis, roomCode, nextOwner.userId);
+      const nextOwnerId = pickNextOwner(seats, spectators);
+      if (nextOwnerId) {
+        await setRoomOwner(this.redis, roomCode, nextOwnerId);
       }
     }
     return { deleted: false };

--- a/packages/server/src/plugins/core/room/store.ts
+++ b/packages/server/src/plugins/core/room/store.ts
@@ -324,3 +324,23 @@ export async function setSpectatorConnected(kv: KvStore, roomCode: string, userI
 export async function clearRoomSpectators(kv: KvStore, roomCode: string): Promise<void> {
   await kv.del(`room:${roomCode}:spectators`);
 }
+
+export function pickNextOwner(
+  seats: RoomSeats, spectators: RoomSpectator[], excludeUserId?: string,
+): string | null {
+  const seated = getSeatedPlayers(seats);
+  const next =
+    seated.find(p => !p.isBot && p.connected && p.userId !== excludeUserId) ??
+    spectators.find(s => s.connected && s.userId !== excludeUserId);
+  return next?.userId ?? null;
+}
+
+export async function findNextOwner(
+  kv: KvStore, roomCode: string, excludeUserId?: string,
+): Promise<string | null> {
+  const [seats, spectators] = await Promise.all([
+    getRoomSeats(kv, roomCode),
+    getRoomSpectators(kv, roomCode),
+  ]);
+  return pickNextOwner(seats, spectators, excludeUserId);
+}

--- a/packages/server/src/ws/game-events.ts
+++ b/packages/server/src/ws/game-events.ts
@@ -3,10 +3,10 @@ import type { KvStore } from '../kv/types.js';
 import type { ChatMessage, Color, GameAction } from '@uno-online/shared';
 import { chooseAutopilotJumpInAction } from '@uno-online/shared';
 import { GameSession } from '../plugins/core/game/session.js';
-import type { GameStatePersister } from '../plugins/core/game/state-store.js';
+import { deleteGameState, type GameStatePersister } from '../plugins/core/game/state-store.js';
 import { emitGameUpdate, setAutopilotActionHandler, startTurnTimer, resetPlayerTimeout, clearRoomTimeouts } from './room-events.js';
 import type { TurnTimer } from '../plugins/core/game/turn-timer.js';
-import { getRoom, setRoomStatus, setRoomOwner, touchRoomActivity, clearSeatByUserId, setUserRoom, getRoomSeats, setRoomSeats, getRoomSpectators, getSeatedPlayers, addSpectatorToRoom, removeSpectatorFromRoom, clearRoomSpectators, takeSeat, getFirstEmptySeatIndex, clearUserRoom } from '../plugins/core/room/store.js';
+import { getRoom, setRoomStatus, setRoomOwner, touchRoomActivity, clearSeatByUserId, setUserRoom, getRoomSeats, setRoomSeats, getRoomSpectators, getSeatedPlayers, addSpectatorToRoom, removeSpectatorFromRoom, clearRoomSpectators, takeSeat, getFirstEmptySeatIndex, clearUserRoom, findNextOwner } from '../plugins/core/room/store.js';
 import { MAX_PLAYERS, MIN_PLAYERS, SEAT_COUNT } from '@uno-online/shared';
 import type { RoomSeats } from '../plugins/core/room/store.js';
 import { broadcastSpectatorList } from '../plugins/core/spectate/ws.js';
@@ -735,8 +735,8 @@ export function registerGameEvents(
     if (!ctx) return callback?.({ success: false, error: 'No active game' });
     const { session, roomCode } = ctx;
 
-    if (!session.isRoundEnd()) {
-      return callback?.({ success: false, error: '只能在回合结束阶段踢人' });
+    if (!session.isRoundEnd() && !session.isGameOver()) {
+      return callback?.({ success: false, error: '只能在回合/游戏结束阶段踢人' });
     }
 
     const room = await getRoom(redis, roomCode);
@@ -755,12 +755,7 @@ export function registerGameEvents(
     }
 
     if (state.players.length <= MIN_PLAYERS) {
-      return callback?.({ success: false, error: '玩家数量不足，无法踢出' });
-    }
-
-    const voters = nextRoundVotes.get(roomCode) ?? new Set<string>();
-    if (!targetPlayer.isBot && voters.has(targetId)) {
-      return callback?.({ success: false, error: '该玩家已准备，无法踢出' });
+      return callback?.({ success: false, error: '至少需要两名玩家' });
     }
 
     session.removePlayer(targetId);
@@ -786,7 +781,8 @@ export function registerGameEvents(
       });
     }
 
-    voters.delete(targetId);
+    const voters = nextRoundVotes.get(roomCode);
+    if (voters) voters.delete(targetId);
     const voteState = getNextRoundVoteState(roomCode, session);
     io.to(roomCode).emit('game:next_round_vote', voteState);
 
@@ -832,10 +828,9 @@ export function registerGameEvents(
 
     const room = await getRoom(redis, roomCode);
     if (room?.ownerId === data.user.userId) {
-      const remaining = session.getFullState().players;
-      const nextOwner = remaining.find(p => p.connected && !p.isBot) ?? remaining.find(p => !p.isBot);
-      if (nextOwner) {
-        await setRoomOwner(redis, roomCode, nextOwner.id);
+      const nextOwnerId = await findNextOwner(redis, roomCode, data.user.userId);
+      if (nextOwnerId) {
+        await setRoomOwner(redis, roomCode, nextOwnerId);
       }
     }
 
@@ -882,14 +877,14 @@ export function registerGameEvents(
     persister.cleanup(roomCode);
     turnTimer.stop(roomCode);
     clearRoomTimeouts(roomCode);
-    // Leftover opt-ins from the previous game would otherwise be re-applied
-    // with stale socket ids → ghost players.
     clearPendingSpectatorJoins(roomCode);
 
-    await setRoomStatus(redis, roomCode, 'waiting');
-
     const emptySeats: RoomSeats = Array.from({ length: SEAT_COUNT }, () => null);
-    await setRoomSeats(redis, roomCode, emptySeats);
+    await Promise.all([
+      deleteGameState(redis, roomCode),
+      setRoomStatus(redis, roomCode, 'waiting'),
+      setRoomSeats(redis, roomCode, emptySeats),
+    ]);
 
     await clearRoomSpectators(redis, roomCode);
     const sockets = await io.in(roomCode).fetchSockets();
@@ -902,7 +897,7 @@ export function registerGameEvents(
         role: sData.user.role,
         connected: true,
       });
-      sData.isSpectator = false;
+      sData.isSpectator = true;
     }
 
     await touchRoomActivity(redis, roomCode);

--- a/packages/server/src/ws/owner-transfer.ts
+++ b/packages/server/src/ws/owner-transfer.ts
@@ -1,6 +1,6 @@
 import type { Server as SocketIOServer } from 'socket.io';
 import type { KvStore } from '../kv/types.js';
-import { getRoom, setRoomOwner, getRoomSeats, getRoomSpectators } from '../plugins/core/room/store.js';
+import { getRoom, setRoomOwner, findNextOwner } from '../plugins/core/room/store.js';
 import type { GameSession } from '../plugins/core/game/session.js';
 import type { GameStatePersister } from '../plugins/core/game/state-store.js';
 import type { TurnTimer } from '../plugins/core/game/turn-timer.js';
@@ -57,20 +57,7 @@ export function scheduleOwnerTransfer(roomCode: string, ownerId: string): void {
     const sockets = await _io.in(roomCode).fetchSockets();
     if (sockets.some(s => s.data.user?.userId === ownerId)) return;
 
-    // Find next owner: prefer game-session connected players, fall back to
-    // any connected non-bot socket (covers the waiting-room case).
-    let nextOwnerId: string | undefined;
-    const session = _sessions.get(roomCode);
-    if (session) {
-      nextOwnerId = session.getFullState().players
-        .find(p => p.id !== ownerId && p.connected && !p.isBot)?.id;
-    }
-    if (!nextOwnerId) {
-      nextOwnerId = sockets
-        .find(s => s.data.user?.userId !== ownerId && !s.data.user?.isBot)
-        ?.data.user?.userId;
-    }
-
+    const nextOwnerId = await findNextOwner(_redis, roomCode, ownerId);
     if (!nextOwnerId) {
       _stopAutoPlayForRoom(roomCode);
       await dissolveRoom(_io, _redis, roomCode, _sessions, _turnTimer, _persister, 'empty', _voiceChannels);
@@ -78,9 +65,6 @@ export function scheduleOwnerTransfer(roomCode: string, ownerId: string): void {
     }
     await setRoomOwner(_redis, roomCode, nextOwnerId);
     const updatedRoom = await getRoom(_redis, roomCode);
-    const seats = await getRoomSeats(_redis, roomCode);
-    const spectators = await getRoomSpectators(_redis, roomCode);
-    _io.to(roomCode).emit('seat:updated', { seats, spectators });
     _io.to(roomCode).emit('room:updated', { room: updatedRoom });
   }, OWNER_TRANSFER_DELAY_S * 1000);
   timer.unref?.();

--- a/packages/server/src/ws/room-events.ts
+++ b/packages/server/src/ws/room-events.ts
@@ -3,7 +3,7 @@ import type { KvStore } from '../kv/types.js';
 import type { GameAction, GameState, RoomSettings, BotDifficulty } from '@uno-online/shared';
 import { MIN_PLAYERS, DEFAULT_HOUSE_RULES, chooseAutopilotAction, chooseJumpInAction, chooseBotAction, getPlayableCards, DIFFICULTY_PARAMS, BOT_DIFFICULTIES } from '@uno-online/shared';
 import { RoomManager } from '../plugins/core/room/manager.js';
-import { getRoom, getRoomSeats, getRoomSpectators, setRoomSettings, setRoomStatus, setRoomOwner, touchRoomActivity, ensureNotInRoom, removeSpectatorFromRoom, clearRoomSpectators, getSeatedPlayers } from '../plugins/core/room/store.js';
+import { getRoom, getRoomSeats, getRoomSpectators, setRoomSettings, setRoomStatus, setRoomOwner, touchRoomActivity, ensureNotInRoom, removeSpectatorFromRoom, clearRoomSpectators, getSeatedPlayers, findNextOwner } from '../plugins/core/room/store.js';
 import { joinRoomSocket, leaveRoomSocket } from './socket-room.js';
 import { GameSession } from '../plugins/core/game/session.js';
 import type { GameStatePersister } from '../plugins/core/game/state-store.js';
@@ -170,9 +170,9 @@ export function registerRoomEvents(
       // Transfer ownership if the leaving spectator was the owner
       const room = await getRoom(redis, roomCode);
       if (room?.ownerId === userId) {
-        const nextOwner = seatedPlayers.find(p => !p.isBot) ?? spectators.find(s => s.userId !== userId);
-        if (nextOwner) {
-          await setRoomOwner(redis, roomCode, nextOwner.userId);
+        const nextOwnerId = await findNextOwner(redis, roomCode, userId);
+        if (nextOwnerId) {
+          await setRoomOwner(redis, roomCode, nextOwnerId);
         }
         const updatedRoom = await getRoom(redis, roomCode);
         io.to(roomCode).emit('room:updated', { room: updatedRoom });

--- a/packages/server/src/ws/socket-handler.ts
+++ b/packages/server/src/ws/socket-handler.ts
@@ -7,7 +7,7 @@ import { GameSession } from '../plugins/core/game/session.js';
 import { registerRoomEvents, emitGameUpdate, startTurnTimer, executeAutopilot, notifyAutopilotAction, resetPlayerTimeout } from './room-events.js';
 import { getAutopilotActionPlayerId, canPlayerAutopilotOnce } from './autopilot-action-player.js';
 import { registerGameEvents, emitTerminalStateIfNeeded, addAutopilotVote, clearChatTimestamps, getRoundEndVoteState, getPendingSpectatorQueue, getRoundEndAt } from './game-events.js';
-import { getRoom, setRoomOwner, clearUserRoom, getUserRoom, setSeatPlayerConnected, getRoomSeats, getRoomSpectators, addSpectatorToRoom, removeSpectatorFromRoom, setSpectatorConnected, getSeatedPlayers } from '../plugins/core/room/store.js';
+import { getRoom, setRoomOwner, clearUserRoom, getUserRoom, setSeatPlayerConnected, getRoomSeats, getRoomSpectators, addSpectatorToRoom, removeSpectatorFromRoom, setSpectatorConnected, getSeatedPlayers, findNextOwner, pickNextOwner } from '../plugins/core/room/store.js';
 import { registerSeatEvents, clearPendingSwapRequests, clearUserSwapRequests } from './seat-events.js';
 import { joinRoomSocket, leaveRoomSocket } from './socket-room.js';
 import { loadGameState, GameStatePersister } from '../plugins/core/game/state-store.js';
@@ -20,11 +20,11 @@ import { cancelOwnerTransfer, hasOwnerTransferPending, scheduleOwnerTransfer, co
 import { registerVoicePresenceEvents, removeVoicePresence } from './voice-presence.js';
 import { VoiceChannelManager } from '../voice/channel-manager.js';
 import type { MumbleIceConfig } from '../config.js';
+import { AUTOPILOT_TOGGLE_COOLDOWN_MS } from '@uno-online/shared';
 
-const RECONNECT_TIMEOUT_MS = 60_000;
+const RECONNECT_TIMEOUT_MS = 30_000;
 const AUTOPILOT_THINK_MS = 2_000;
 const ROOM_IDLE_SWEEP_MS = 60_000;
-const AUTOPILOT_TOGGLE_COOLDOWN_MS = 3_000;
 const ALL_DISCONNECT_TIMEOUT_MS = 5 * 60_000;
 
 const autopilotToggleTimestamps = new Map<string, number>();
@@ -197,9 +197,9 @@ export function setupSocketHandlers(
       }
 
       if (stale.some(s => s.userId === room.ownerId)) {
-        const nextOwner = seatedPlayers.find(p => !p.isBot && p.connected) ?? remaining.find(sp => sp.connected);
-        if (nextOwner) {
-          await setRoomOwner(redis, roomCode, nextOwner.userId);
+        const nextOwnerId = pickNextOwner(seats, remaining, room.ownerId);
+        if (nextOwnerId) {
+          await setRoomOwner(redis, roomCode, nextOwnerId);
           const updatedRoom = await getRoom(redis, roomCode);
           io.to(roomCode).emit('room:updated', { room: updatedRoom });
         }
@@ -335,7 +335,7 @@ export function setupSocketHandlers(
         ]);
         callback?.({ success: true, gameState: session.getPlayerView(userId), seats, spectators, room });
         socket.emit('chat:history', session.getChatHistory());
-        socket.emit('room:spectator_list', { spectators: toSpectatorView(await getRoomSpectators(redis, roomCode)) });
+        socket.emit('room:spectator_list', { spectators: toSpectatorView(spectators) });
         const voteState = getRoundEndVoteState(roomCode, session);
         if (voteState) socket.emit('game:next_round_vote', voteState);
         replayTerminalEvent(socket, roomCode, session);
@@ -522,6 +522,7 @@ export function setupSocketHandlers(
             }
           }
         }, RECONNECT_TIMEOUT_MS);
+        timer.unref?.();
         disconnectTimers.set(userId, timer);
       } else {
         // Mark player as disconnected in seat (also cancels ready)
@@ -558,6 +559,7 @@ export function setupSocketHandlers(
             await dissolveRoom(io, redis, roomCode, sessions, turnTimer, persister, 'empty', voiceChannels);
           }
         }, RECONNECT_TIMEOUT_MS);
+        timer.unref?.();
         disconnectTimers.set(userId, timer);
       }
     });

--- a/packages/shared/src/constants/deck.ts
+++ b/packages/shared/src/constants/deck.ts
@@ -10,6 +10,7 @@ export const MAX_PLAYERS = 10;
 export const SEAT_COUNT = 10;
 export const SWAP_COOLDOWN_MS = 5000;
 export const SWAP_REQUEST_TIMEOUT_MS = 15000;
+export const AUTOPILOT_TOGGLE_COOLDOWN_MS = 3000;
 
 export const ROOM_CODE_LENGTH = 6;
 export const ROOM_CODE_CHARS = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';


### PR DESCRIPTION
## Summary

- **返回房间 bug 修复**：game:back_to_room 后删除 KV 游戏状态，防止 room:rejoin 加载僵尸 session 导致循环跳转；修正 isSpectator 标记和 RoomPage rejoin 条件；leaveRoom 检查观众防止误删房间
- **踢人简化**：game_over 阶段也可踢人，移除投票限制和 30 秒倒计时，房主对非自己的玩家直接显示踢人按钮
- **房主迁移统一**：提取 `findNextOwner`/`pickNextOwner` 替换 5 处重复实现，统一选人策略（在线非机器人座位玩家优先，在线观众兜底）
- **超时优化**：断线重连窗口 60s→30s，disconnectTimers 补 .unref()，AUTOPILOT_TOGGLE_COOLDOWN_MS 提取到 shared
- **性能改进**：back_to_room 清理操作并行化，消除 manager/sweepSpectators/rejoin 中的重复 KV 读取

## Test plan

- [ ] 游戏结束后房主点"返回房间"，所有人回到房间页（观战席），可重新入座开局
- [ ] 回合结束/游戏结束积分板中房主可直接踢人（无需等待 30 秒）
- [ ] 踢到只剩 2 人时踢人按钮不可用
- [ ] 房主断线后 30 秒内重连可取消迁移，超时后自动迁移给在线玩家
- [ ] 所有人断线后房间在 5 分钟后解散
- [ ] 返回房间后房主可修改设置、所有人可选座位

🤖 Generated with [Claude Code](https://claude.com/claude-code)