### PR TITLE
修复最新游戏规则、语音和登录稳定性问题

### DIFF
--- a/packages/client/src/app/App.tsx
+++ b/packages/client/src/app/App.tsx
@@ -7,13 +7,35 @@ import ServerUpdateDialog from '@/shared/components/ServerUpdateDialog';
 import ProfileModal from '@/shared/components/ProfileModal';
 import ConfirmDialog from '@/shared/components/ConfirmDialog';
 import StartScreenOverlay from '@/shared/components/StartScreenOverlay';
-import { connectSocket } from '@/shared/socket';
+import { connectSocket, disconnectSocket } from '@/shared/socket';
+import { useAuthStore } from '@/features/auth/stores/auth-store';
 
 export default function App() {
+  const token = useAuthStore((s) => s.token);
+  const initialized = useAuthStore((s) => s.initialized);
+  const loadUser = useAuthStore((s) => s.loadUser);
+
   useEffect(() => {
-    if (localStorage.getItem('token')) {
-      connectSocket();
+    if (!initialized) {
+      void loadUser().catch(() => {});
     }
+  }, [initialized, loadUser]);
+
+  useEffect(() => {
+    if (token) {
+      connectSocket();
+    } else if (initialized) {
+      disconnectSocket();
+    }
+  }, [token, initialized]);
+
+  useEffect(() => {
+    const handleUnauthorized = () => {
+      useAuthStore.setState({ user: null, token: null, loading: false, initialized: true, authError: null });
+      disconnectSocket();
+    };
+    window.addEventListener('auth:unauthorized', handleUnauthorized);
+    return () => window.removeEventListener('auth:unauthorized', handleUnauthorized);
   }, []);
 
   return (

--- a/packages/client/src/app/RootSwitch.tsx
+++ b/packages/client/src/app/RootSwitch.tsx
@@ -4,23 +4,20 @@ import { useAuthStore } from '@/features/auth/stores/auth-store';
 const HomePage = lazy(() => import('@/features/auth/pages/HomePage'));
 const LobbyPage = lazy(() => import('@/features/lobby/pages/LobbyPage'));
 
-/**
- * `/` 路径的智能路由：根据 auth 状态决定渲染登录页或大厅。
- *
- * - 无 token：渲染 HomePage（登录表单）
- * - 有 token 但 user 还在 loading：渲染加载提示（沿用 ProtectedRoute 风格）
- * - 有 token + user：渲染 LobbyPage（原 /lobby 路径的大厅 UI）
- *
- * 已登录但 user 为 null 时主动调 loadUser()，与 ProtectedRoute 的语义对齐。
- */
 export default function RootSwitch() {
   const token = useAuthStore((s) => s.token);
   const user = useAuthStore((s) => s.user);
+  const initialized = useAuthStore((s) => s.initialized);
+  const loading = useAuthStore((s) => s.loading);
+  const authError = useAuthStore((s) => s.authError);
+  const logout = useAuthStore((s) => s.logout);
   const loadUser = useAuthStore((s) => s.loadUser);
 
   useEffect(() => {
-    if (token && !user) loadUser();
-  }, [token, user, loadUser]);
+    if (token && !user && !initialized) void loadUser().catch(() => {});
+  }, [token, user, initialized, loadUser]);
+
+  if (!initialized) return <LoadingScreen />;
 
   if (!token) {
     return (
@@ -30,7 +27,10 @@ export default function RootSwitch() {
     );
   }
 
-  if (!user) return <LoadingScreen />;
+  if (!user) {
+    if (loading) return <LoadingScreen />;
+    return <AuthRestoreFailed message={authError} onRetry={() => void loadUser().catch(() => {})} onLogout={logout} />;
+  }
 
   return (
     <Suspense fallback={<LoadingScreen />}>
@@ -43,6 +43,23 @@ function LoadingScreen() {
   return (
     <div className="flex-1 flex items-center justify-center">
       <p className="text-muted-foreground">加载中...</p>
+    </div>
+  );
+}
+
+function AuthRestoreFailed({ message, onRetry, onLogout }: { message: string | null; onRetry: () => void; onLogout: () => void }) {
+  return (
+    <div className="flex-1 flex items-center justify-center p-6">
+      <div className="glass-panel max-w-sm w-full p-5 text-center space-y-4">
+        <div>
+          <h2 className="text-base font-bold">无法恢复登录态</h2>
+          <p className="mt-2 text-sm text-muted-foreground">{message ?? '请检查网络后重试。'}</p>
+        </div>
+        <div className="flex justify-center gap-2">
+          <button type="button" className="btn-primary px-4 py-2 rounded-lg" onClick={onRetry}>重试</button>
+          <button type="button" className="btn-secondary px-4 py-2 rounded-lg" onClick={onLogout}>退出登录</button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/packages/client/src/features/auth/stores/auth-store.ts
+++ b/packages/client/src/features/auth/stores/auth-store.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { apiPost, apiGet } from '@/shared/api';
+import { apiPost, apiGet, UnauthorizedError } from '@/shared/api';
 
 interface User {
   id: string;
@@ -24,6 +24,8 @@ interface AuthState {
   user: User | null;
   token: string | null;
   loading: boolean;
+  initialized: boolean;
+  authError: string | null;
   login: (code: string) => Promise<CallbackResult>;
   bindGithub: (username: string, password: string, githubId: string, githubAvatarUrl?: string) => Promise<void>;
   devLogin: (username: string) => Promise<void>;
@@ -38,18 +40,20 @@ export const useAuthStore = create<AuthState>((set) => ({
   user: null,
   token: localStorage.getItem('token'),
   loading: false,
+  initialized: false,
+  authError: null,
 
   login: async (code: string) => {
     set({ loading: true });
     const data = await apiPost<{ token?: string; user?: User; isNewUser?: boolean; needsBind?: boolean; username?: string; githubId?: string; githubAvatarUrl?: string }>('/auth/callback', { code });
 
     if (data.needsBind && data.username && data.githubId) {
-      set({ loading: false });
+      set({ loading: false, initialized: true, authError: null });
       return { needsBind: { username: data.username, githubId: data.githubId, githubAvatarUrl: data.githubAvatarUrl } };
     }
 
     localStorage.setItem('token', data.token!);
-    set({ user: data.user!, token: data.token!, loading: false });
+    set({ user: data.user!, token: data.token!, loading: false, initialized: true, authError: null });
     return { isNewUser: data.isNewUser };
   },
 
@@ -58,9 +62,9 @@ export const useAuthStore = create<AuthState>((set) => ({
     try {
       const data = await apiPost<{ token: string; user: User }>('/auth/bind-github', { username, password, githubId, githubAvatarUrl });
       localStorage.setItem('token', data.token);
-      set({ user: data.user, token: data.token, loading: false });
+      set({ user: data.user, token: data.token, loading: false, initialized: true, authError: null });
     } catch (e) {
-      set({ loading: false });
+      set({ loading: false, initialized: true });
       throw e;
     }
   },
@@ -69,7 +73,7 @@ export const useAuthStore = create<AuthState>((set) => ({
     set({ loading: true });
     const data = await apiPost<{ token: string; user: User }>('/auth/dev-login', { username });
     localStorage.setItem('token', data.token);
-    set({ user: data.user, token: data.token, loading: false });
+    set({ user: data.user, token: data.token, loading: false, initialized: true, authError: null });
   },
 
   register: async (username: string, password: string, nickname: string, avatar?: string) => {
@@ -77,9 +81,9 @@ export const useAuthStore = create<AuthState>((set) => ({
     try {
       const data = await apiPost<{ token: string; user: User }>('/auth/register', { username, password, nickname, avatar });
       localStorage.setItem('token', data.token);
-      set({ user: data.user, token: data.token, loading: false });
+      set({ user: data.user, token: data.token, loading: false, initialized: true, authError: null });
     } catch (e) {
-      set({ loading: false });
+      set({ loading: false, initialized: true });
       throw e;
     }
   },
@@ -89,29 +93,43 @@ export const useAuthStore = create<AuthState>((set) => ({
     try {
       const data = await apiPost<{ token: string; user: User }>('/auth/login', { username, password });
       localStorage.setItem('token', data.token);
-      set({ user: data.user, token: data.token, loading: false });
+      set({ user: data.user, token: data.token, loading: false, initialized: true, authError: null });
     } catch (e) {
-      set({ loading: false });
+      set({ loading: false, initialized: true });
       throw e;
     }
   },
 
   loadUser: async () => {
     const token = localStorage.getItem('token');
-    if (!token) return;
-    set({ loading: true });
+    if (!token) {
+      set({ user: null, token: null, loading: false, initialized: true, authError: null });
+      return;
+    }
+    set({ loading: true, authError: null });
     try {
       const user = await apiGet<User>('/auth/me');
-      set({ user, token, loading: false });
-    } catch {
-      localStorage.removeItem('token');
-      set({ user: null, token: null, loading: false });
+      set({ user, token, loading: false, initialized: true, authError: null });
+    } catch (error) {
+      if (error instanceof UnauthorizedError) {
+        localStorage.removeItem('token');
+        set({ user: null, token: null, loading: false, initialized: true, authError: null });
+        return;
+      }
+      set({
+        user: null,
+        token,
+        loading: false,
+        initialized: true,
+        authError: error instanceof Error ? error.message : 'Failed to restore session',
+      });
+      throw error;
     }
   },
 
   logout: () => {
     localStorage.removeItem('token');
-    set({ user: null, token: null });
+    set({ user: null, token: null, loading: false, initialized: true, authError: null });
   },
 
   setUser: (user: User) => set({ user }),

--- a/packages/client/src/features/game/components/BlitzTimer.tsx
+++ b/packages/client/src/features/game/components/BlitzTimer.tsx
@@ -1,0 +1,39 @@
+import { Zap } from 'lucide-react';
+import { useCountdown } from '../hooks/useCountdown';
+import { useGameStore } from '../stores/game-store';
+import { cn } from '@/shared/lib/utils';
+
+function formatSeconds(total: number): string {
+  const minutes = Math.floor(total / 60);
+  const seconds = total % 60;
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+}
+
+export default function BlitzTimer() {
+  const phase = useGameStore((s) => s.phase);
+  const gameStartedAt = useGameStore((s) => s.gameStartedAt);
+  const blitzLimit = useGameStore((s) => s.settings?.houseRules?.blitzTimeLimit ?? null);
+  const endTime = gameStartedAt && blitzLimit && phase !== 'round_end' && phase !== 'game_over'
+    ? gameStartedAt + blitzLimit * 1000
+    : null;
+  const secondsLeft = useCountdown(endTime);
+
+  if (secondsLeft === null) return null;
+
+  const urgent = secondsLeft <= 30;
+
+  return (
+    <div
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-bold font-game',
+        urgent
+          ? 'border-destructive/50 bg-destructive/15 text-destructive animate-timer-flash'
+          : 'border-primary/30 bg-primary/10 text-primary',
+      )}
+      title="Blitz countdown"
+    >
+      <Zap size={12} />
+      <span>{formatSeconds(secondsLeft)}</span>
+    </div>
+  );
+}

--- a/packages/client/src/features/game/components/TopBar.tsx
+++ b/packages/client/src/features/game/components/TopBar.tsx
@@ -3,6 +3,7 @@ import { Eye, Volume2, VolumeX, Music, Spade, DoorOpen, LogOut, Bot, HelpCircle,
 import { AUTOPILOT_TOGGLE_COOLDOWN_MS } from '@uno-online/shared';
 import type { Card, Color } from '@uno-online/shared';
 import TurnTimer from './TurnTimer';
+import BlitzTimer from './BlitzTimer';
 import { useSettingsStore } from '@/shared/stores/settings-store';
 import { useRoomStore } from '@/shared/stores/room-store';
 import { useGameStore } from '../stores/game-store';
@@ -179,6 +180,7 @@ export default function TopBar({ roomCode, onOpenHotkeys }: TopBarProps) {
         <span className="text-muted-foreground">房间: {roomCode}</span>
         <span className="text-muted-foreground/50 text-xs hidden md:inline">v{BUILD_VERSION}</span>
         <LatencyIndicator />
+        <BlitzTimer />
         <ElapsedTimers />
       </div>
       <GameStatus />

--- a/packages/client/src/shared/api.ts
+++ b/packages/client/src/shared/api.ts
@@ -1,8 +1,19 @@
 import { getApiUrl } from './env';
 
-function handleUnauthorized() {
+export class UnauthorizedError extends Error {
+  constructor() {
+    super('Session expired, please sign in again');
+    this.name = 'UnauthorizedError';
+  }
+}
+
+export function clearStoredAuthToken(): void {
   localStorage.removeItem('token');
-  window.location.href = '/?session_expired=1';
+}
+
+function notifyUnauthorized(): void {
+  clearStoredAuthToken();
+  window.dispatchEvent(new Event('auth:unauthorized'));
 }
 
 function authHeaders(): Record<string, string> {
@@ -12,8 +23,8 @@ function authHeaders(): Record<string, string> {
 
 async function handleResponse<T>(res: Response): Promise<T> {
   if (res.status === 401) {
-    handleUnauthorized();
-    throw new Error('登录已过期，请重新登录');
+    notifyUnauthorized();
+    throw new UnauthorizedError();
   }
   if (!res.ok) {
     const data = await res.json().catch(() => ({})) as Record<string, string>;

--- a/packages/client/src/shared/components/ProtectedRoute.tsx
+++ b/packages/client/src/shared/components/ProtectedRoute.tsx
@@ -5,14 +5,47 @@ import { useAuthStore } from '@/features/auth/stores/auth-store';
 export default function ProtectedRoute() {
   const token = useAuthStore((s) => s.token);
   const user = useAuthStore((s) => s.user);
+  const initialized = useAuthStore((s) => s.initialized);
+  const loading = useAuthStore((s) => s.loading);
+  const authError = useAuthStore((s) => s.authError);
+  const logout = useAuthStore((s) => s.logout);
   const loadUser = useAuthStore((s) => s.loadUser);
   const location = useLocation();
 
   useEffect(() => {
-    if (token && !user) loadUser();
-  }, [token, user, loadUser]);
+    if (token && !user && !initialized) void loadUser().catch(() => {});
+  }, [token, user, initialized, loadUser]);
 
+  if (!initialized) return <LoadingScreen />;
   if (!token) return <Navigate to={`/?redirect=${encodeURIComponent(location.pathname)}`} replace />;
-  if (!user) return <div className="flex-1 flex items-center justify-center"><p className="text-muted-foreground">加载中...</p></div>;
+  if (!user) {
+    if (loading) return <LoadingScreen />;
+    return <AuthRestoreFailed message={authError} onRetry={() => void loadUser().catch(() => {})} onLogout={logout} />;
+  }
   return <Outlet />;
+}
+
+function LoadingScreen() {
+  return (
+    <div className="flex-1 flex items-center justify-center">
+      <p className="text-muted-foreground">加载中...</p>
+    </div>
+  );
+}
+
+function AuthRestoreFailed({ message, onRetry, onLogout }: { message: string | null; onRetry: () => void; onLogout: () => void }) {
+  return (
+    <div className="flex-1 flex items-center justify-center p-6">
+      <div className="glass-panel max-w-sm w-full p-5 text-center space-y-4">
+        <div>
+          <h2 className="text-base font-bold">无法恢复登录态</h2>
+          <p className="mt-2 text-sm text-muted-foreground">{message ?? '请检查网络后重试。'}</p>
+        </div>
+        <div className="flex justify-center gap-2">
+          <button type="button" className="btn-primary px-4 py-2 rounded-lg" onClick={onRetry}>重试</button>
+          <button type="button" className="btn-secondary px-4 py-2 rounded-lg" onClick={onLogout}>退出登录</button>
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/packages/client/src/shared/socket.ts
+++ b/packages/client/src/shared/socket.ts
@@ -14,6 +14,8 @@ import { useSpectatorStore } from '@/features/game/stores/spectator-store';
 import { useLobbyStore } from '@/features/lobby/stores/lobby-store';
 import { resetClientRoomState } from './stores/reset-room';
 import { globalNavigate } from './utils/global-navigate';
+import { useAuthStore } from '@/features/auth/stores/auth-store';
+import { clearStoredAuthToken } from './api';
 
 type TypedSocket = SocketType<ServerToClientEvents, ClientToServerEvents>;
 
@@ -24,9 +26,18 @@ export function onConnectionStatus(cb: (status: 'connected' | 'disconnected' | '
   connectionStatusCallback = cb;
 }
 
+function currentToken(): string | null {
+  return useAuthStore.getState().token ?? localStorage.getItem('token');
+}
+
+function clearAuthSession(): void {
+  clearStoredAuthToken();
+  useAuthStore.setState({ user: null, token: null, loading: false, initialized: true });
+}
+
 export function getSocket(): TypedSocket {
   if (!socket) {
-    const token = localStorage.getItem('token');
+    const token = currentToken();
     socket = io(getApiUrl(), {
       auth: { token },
       autoConnect: false,
@@ -47,6 +58,11 @@ export function getSocket(): TypedSocket {
 
     socket.on('seat:updated', (data: { seats: unknown[]; spectators: unknown[] }) => {
       useRoomStore.getState().updateSeats(data as any);
+    });
+
+    socket.on('room:ready_changed', (data) => {
+      const selfId = useAuthStore.getState().user?.id ?? useGameStore.getState().viewerId;
+      if (data.ready && data.playerId !== selfId) playSound('ready');
     });
 
     socket.on('voice:presence', (presence) => {
@@ -242,7 +258,7 @@ export function getSocket(): TypedSocket {
     socket.on('connect_error', (err) => {
       if (err.message === 'Authentication failed') {
         resetClientRoomState();
-        localStorage.removeItem('token');
+        clearAuthSession();
         socket?.disconnect();
         socket = null;
         window.location.href = '/?session_expired=1';
@@ -251,7 +267,7 @@ export function getSocket(): TypedSocket {
 
     socket.on('auth:kicked', (_data) => {
       resetClientRoomState();
-      localStorage.removeItem('token');
+      clearAuthSession();
       window.location.href = '/';
     });
 
@@ -290,6 +306,14 @@ export function refreshVoicePresence(): void {
 
 export function connectSocket(): void {
   const s = getSocket();
+  const token = currentToken();
+  const oldToken = (s.auth as { token?: string | null } | undefined)?.token ?? null;
+  s.auth = { token };
+  if (s.connected && oldToken !== token) {
+    s.disconnect();
+    s.connect();
+    return;
+  }
   if (!s.connected) {
     s.connect();
   }

--- a/packages/client/src/shared/voice/VoicePanel.tsx
+++ b/packages/client/src/shared/voice/VoicePanel.tsx
@@ -144,7 +144,26 @@ export default function VoicePanel() {
       next.set(userId, volume);
       return next;
     });
-  }, []);
+    getVoiceEngine(sendMicOpus, sendMicEnd).setUserVolume(userId, volume / 100);
+  }, [sendMicOpus, sendMicEnd]);
+
+  useEffect(() => {
+    const userIds = new Set(Object.keys(usersById).map(Number));
+    setPeerVolumes((prev) => {
+      let changed = false;
+      const next = new Map(prev);
+      for (const userId of next.keys()) {
+        if (!userIds.has(userId)) {
+          next.delete(userId);
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+    getVoiceEngine(sendMicOpus, sendMicEnd).resetUserVolumes(
+      [...peerVolumes.keys()].filter((userId) => !userIds.has(userId)),
+    );
+  }, [usersById, peerVolumes, sendMicOpus, sendMicEnd]);
 
   const otherUsers = Object.values(usersById).filter((u) => u.id !== selfUserId);
   const speakingCount = Object.values(speakingByUserId).filter(Boolean).length;

--- a/packages/client/src/shared/voice/voice-engine.ts
+++ b/packages/client/src/shared/voice/voice-engine.ts
@@ -21,6 +21,7 @@ export class VoiceEngine {
   private _captureNode: AudioWorkletNode | null = null
   private _captureGain: GainNode | null = null
   private _muted = false
+  private _userVolumes = new Map<number, number>()
 
   private _micStream: MediaStream | null = null
   private _micSource: MediaStreamAudioSourceNode | null = null
@@ -54,6 +55,23 @@ export class VoiceEngine {
     }
   }
 
+  setUserVolume(userId: number, volume: number) {
+    const clamped = Math.max(0, Math.min(1, Number.isFinite(volume) ? volume : 1))
+    this._userVolumes.set(userId, clamped)
+    this._playbackNode?.port.postMessage({ type: 'volume', userId, volume: clamped })
+  }
+
+  resetUserVolumes(userIds?: Iterable<number>) {
+    if (!userIds) {
+      this._userVolumes.clear()
+      return
+    }
+    for (const userId of userIds) {
+      this._userVolumes.delete(userId)
+      this._playbackNode?.port.postMessage({ type: 'volume', userId, volume: 1 })
+    }
+  }
+
   async enableAudio(): Promise<void> {
     if (this._audioContext && this._playbackNode) {
       await this._audioContext.resume()
@@ -68,10 +86,18 @@ class MumblePlaybackProcessor extends AudioWorkletProcessor {
   constructor() {
     super();
     this._streams = new Map();
+    this._volumes = new Map();
     this._lastStatsTime = 0;
     this.port.onmessage = (event) => {
       const msg = event.data;
-      if (!msg || msg.type !== 'pcm') return;
+      if (!msg) return;
+      if (msg.type === 'volume') {
+        const userId = Number(msg.userId) >>> 0;
+        const volume = Math.max(0, Math.min(1, Number(msg.volume)));
+        this._volumes.set(userId, Number.isFinite(volume) ? volume : 1);
+        return;
+      }
+      if (msg.type !== 'pcm') return;
       const userId = Number(msg.userId) >>> 0;
       const channels = Number(msg.channels) || 1;
       if (!(msg.pcm instanceof ArrayBuffer)) return;
@@ -93,6 +119,24 @@ class MumblePlaybackProcessor extends AudioWorkletProcessor {
     const frames = output[0].length;
     for (let ch = 0; ch < outChannels; ch++) output[ch].fill(0);
     for (const [userId, stream] of this._streams) {
+      const volume = this._volumes.get(userId) ?? 1;
+      if (volume <= 0) {
+        if (!stream.current && stream.queue.length > 0) stream.current = stream.queue.shift();
+        let item = stream.current;
+        let skipIndex = 0;
+        while (skipIndex < frames && item) {
+          const inChannels = item.channels || 1;
+          const totalFrames = Math.floor(item.pcm.length / inChannels);
+          const toSkip = Math.min(totalFrames - item.offsetFrames, frames - skipIndex);
+          item.offsetFrames += toSkip;
+          skipIndex += toSkip;
+          if (item.offsetFrames < totalFrames) break;
+          item = stream.queue.shift() || null;
+          stream.current = item;
+        }
+        if (!stream.current && currentTime - stream.lastActive > 10) this._streams.delete(userId);
+        continue;
+      }
       if (!stream.current && stream.queue.length > 0) stream.current = stream.queue.shift();
       let item = stream.current;
       if (!item) { if (currentTime - stream.lastActive > 10) this._streams.delete(userId); continue; }
@@ -106,8 +150,10 @@ class MumblePlaybackProcessor extends AudioWorkletProcessor {
         const toCopy = Math.min(remainingFrames, frames - writeIndex);
         for (let i = 0; i < toCopy; i++) {
           const srcBase = (item.offsetFrames + i) * inChannels;
-          const left = item.pcm[srcBase] ?? 0;
-          const right = inChannels >= 2 ? (item.pcm[srcBase + 1] ?? left) : left;
+          const srcLeft = item.pcm[srcBase] ?? 0;
+          const srcRight = inChannels >= 2 ? (item.pcm[srcBase + 1] ?? srcLeft) : srcLeft;
+          const left = srcLeft * volume;
+          const right = srcRight * volume;
           output[0][writeIndex + i] += left;
           if (outChannels >= 2) output[1][writeIndex + i] += right;
         }
@@ -224,6 +270,10 @@ registerProcessor('mumble-capture', MumbleCaptureProcessor);
     this._audioContext = ctx
     this._playbackNode = playback
     this._playbackGain = playbackGain
+
+    for (const [userId, volume] of this._userVolumes) {
+      playback.port.postMessage({ type: 'volume', userId, volume })
+    }
 
     if (ctx.sampleRate !== 48000) {
       // Keep working, but current implementation assumes 48kHz for both playback and uplink.

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "start": "tsx dist/index.js",
-    "build": "tsc && mkdir -p dist/voice/generated && cp src/voice/generated/MumbleServer.js dist/voice/generated/MumbleServer.js",
+    "build": "tsc && pnpm run build:copy-voice",
+    "build:copy-voice": "node -e \"require('fs').mkdirSync('dist/voice/generated',{recursive:true});require('fs').copyFileSync('src/voice/generated/MumbleServer.js','dist/voice/generated/MumbleServer.js')\"",
     "test": "vitest run",
     "test:watch": "vitest",
     "db:generate": "echo 'No codegen needed with Kysely'",

--- a/packages/server/src/ws/room-events.ts
+++ b/packages/server/src/ws/room-events.ts
@@ -229,10 +229,15 @@ export function registerRoomEvents(
   socket.on('room:ready', async (ready: boolean, callback) => {
     const roomCode = data.roomCode;
     if (!roomCode) return callback?.({ success: false });
+    const previousSeats = await getRoomSeats(redis, roomCode);
+    const previousReady = previousSeats.find(seat => seat?.userId === data.user.userId)?.ready ?? false;
     await roomManager.setReady(roomCode, data.user.userId, ready);
     await touchRoomActivity(redis, roomCode);
     const [seats, spectators] = await Promise.all([getRoomSeats(redis, roomCode), getRoomSpectators(redis, roomCode)]);
     io.to(roomCode).emit('seat:updated', { seats, spectators });
+    if (previousReady !== ready) {
+      io.to(roomCode).emit('room:ready_changed', { playerId: data.user.userId, ready });
+    }
     callback?.({ success: true });
   });
 

--- a/packages/shared/src/rules/rules/no-challenge-wild-four.ts
+++ b/packages/shared/src/rules/rules/no-challenge-wild-four.ts
@@ -1,6 +1,6 @@
 import type { HouseRulePlugin } from '../house-rule-types.js';
 import type { GameState, GameAction } from '../../types/game.js';
-import type { PreCheckResult } from '../house-rule-types.js';
+import type { PreCheckResult, RuleContext } from '../house-rule-types.js';
 
 export const noChallengeWildFour: HouseRulePlugin = {
   meta: {
@@ -10,7 +10,46 @@ export const noChallengeWildFour: HouseRulePlugin = {
     description: '关闭 +4 质疑机制',
   },
   isEnabled: (hr) => hr.noChallengeWildFour,
-  preCheck: (state: GameState, action: GameAction): PreCheckResult => {
+  preCheck: (state: GameState, action: GameAction, ctx: RuleContext): PreCheckResult => {
+    if (
+      action.type === 'CHOOSE_COLOR' &&
+      state.phase === 'choosing_color' &&
+      state.pendingDrawPlayerId !== null
+    ) {
+      const wd4Player = state.players[state.currentPlayerIndex];
+      if (wd4Player?.id !== action.playerId) return { handled: false };
+
+      const afterColor = ctx.applyAction(state, action);
+      if (afterColor.phase !== 'challenging' || afterColor.pendingDrawPlayerId === null) {
+        return { handled: true, state: afterColor };
+      }
+
+      const penaltyPlayerId = afterColor.pendingDrawPlayerId;
+      const penaltyPlayerIndex = afterColor.players.findIndex(p => p.id === penaltyPlayerId);
+      if (penaltyPlayerIndex === -1) return { handled: true, state: afterColor };
+
+      const nextPlayerIndex = ctx.getNextPlayerIndex(
+        penaltyPlayerIndex,
+        afterColor.players.length,
+        afterColor.direction,
+      );
+
+      return {
+        handled: true,
+        state: ctx.startPenaltyDraw(
+          {
+            ...afterColor,
+            phase: 'playing',
+            pendingDrawPlayerId: null,
+          },
+          penaltyPlayerId,
+          4,
+          nextPlayerIndex,
+          wd4Player.id,
+        ),
+      };
+    }
+
     if (action.type !== 'CHALLENGE') return { handled: false };
     return { handled: true, state };
   },

--- a/packages/shared/src/types/socket-events.ts
+++ b/packages/shared/src/types/socket-events.ts
@@ -55,6 +55,7 @@ export interface ServerToClientEvents {
   'chat:rate_limited': (data: { message: string }) => void;
   'throw:item': (data: { fromId: string; targetId: string; item: string }) => void;
   'room:updated': (data: Record<string, unknown>) => void;
+  'room:ready_changed': (data: { playerId: string; ready: boolean }) => void;
   'room:dissolved': (data?: { reason?: string }) => void;
   'room:rejoin_redirect': (data: { roomCode: string }) => void;
   'room:spectator_joined': (data: { nickname: string; spectators: { nickname: string; avatarUrl?: string | null; connected: boolean }[] }) => void;

--- a/packages/shared/tests/house-rules-latest-bugs.test.ts
+++ b/packages/shared/tests/house-rules-latest-bugs.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from 'vitest';
+import { applyActionWithHouseRules } from '../src/rules/house-rules-engine';
+import { DEFAULT_HOUSE_RULES } from '../src/types/house-rules';
+import { makeCard, makeState } from './helpers/test-utils';
+
+describe('latest house rule bug fixes', () => {
+  it('does not let draw-until-playable inherit a previous skip as a continuing draw turn', () => {
+    const skip = makeCard('skip', 'red', { id: 'skip' });
+    const state = makeState({
+      players: [
+        { id: 'p1', name: 'Alice', hand: [skip, makeCard('number', 'blue', { value: 8, id: 'p1_blue' })], score: 0, connected: true, autopilot: false, calledUno: false, isBot: false },
+        { id: 'p2', name: 'Bob', hand: [makeCard('number', 'yellow', { value: 1, id: 'p2_yellow' })], score: 0, connected: true, autopilot: false, calledUno: false, isBot: false },
+        { id: 'p3', name: 'Carol', hand: [makeCard('number', 'blue', { value: 2, id: 'p3_blue' })], score: 0, connected: true, autopilot: false, calledUno: false, isBot: false },
+      ],
+      deckLeft: [
+        makeCard('number', 'green', { value: 1, id: 'first_unplayable' }),
+        makeCard('number', 'yellow', { value: 2, id: 'second_unplayable' }),
+      ],
+      deckRight: [],
+      deckLeftInitialCount: 2,
+      deckRightInitialCount: 0,
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        allowSpectators: true,
+        spectatorMode: 'hidden',
+        houseRules: { ...DEFAULT_HOUSE_RULES, drawUntilPlayable: true },
+      },
+    });
+
+    const afterSkip = applyActionWithHouseRules(state, { type: 'PLAY_CARD', playerId: 'p1', cardId: 'skip' });
+    expect(afterSkip.currentPlayerIndex).toBe(2);
+    expect(afterSkip.lastAction).toMatchObject({ type: 'PLAY_CARD', playerId: 'p1', cardId: 'skip' });
+
+    const afterFirstDraw = applyActionWithHouseRules(afterSkip, { type: 'DRAW_CARD', playerId: 'p3', side: 'left' });
+    expect(afterFirstDraw.players[2]!.hand.map(c => c.id)).toEqual(['p3_blue', 'first_unplayable']);
+    expect(afterFirstDraw.deckLeft.map(c => c.id)).toEqual(['second_unplayable']);
+
+    const afterSecondDraw = applyActionWithHouseRules(afterFirstDraw, { type: 'DRAW_CARD', playerId: 'p3', side: 'left' });
+    expect(afterSecondDraw.players[2]!.hand.map(c => c.id)).toEqual(['p3_blue', 'first_unplayable', 'second_unplayable']);
+  });
+
+  it('does not auto-play the first drawn card when draw-until-playable is combined with forced draw play', () => {
+    const state = makeState({
+      players: [
+        { id: 'p1', name: 'Alice', hand: [makeCard('number', 'blue', { value: 8, id: 'p1_blue' })], score: 0, connected: true, autopilot: false, calledUno: false, isBot: false },
+        { id: 'p2', name: 'Bob', hand: [makeCard('number', 'yellow', { value: 1, id: 'p2_yellow' })], score: 0, connected: true, autopilot: false, calledUno: false, isBot: false },
+      ],
+      deckLeft: [makeCard('number', 'red', { value: 8, id: 'drawn_playable' })],
+      deckRight: [],
+      deckLeftInitialCount: 1,
+      deckRightInitialCount: 0,
+      lastAction: { type: 'PLAY_CARD', playerId: 'p2', cardId: 'p2_yellow' },
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        allowSpectators: true,
+        spectatorMode: 'hidden',
+        houseRules: { ...DEFAULT_HOUSE_RULES, drawUntilPlayable: true, forcedPlayAfterDraw: true },
+      },
+    });
+
+    const afterDraw = applyActionWithHouseRules(state, { type: 'DRAW_CARD', playerId: 'p1', side: 'left' });
+    expect(afterDraw.players[0]!.hand.map(c => c.id)).toEqual(['p1_blue', 'drawn_playable']);
+    expect(afterDraw.discardPile.map(c => c.id)).not.toContain('drawn_playable');
+  });
+
+  it('does not let death-draw inherit a previous skip as a continuing draw turn', () => {
+    const skip = makeCard('skip', 'red', { id: 'skip' });
+    const state = makeState({
+      players: [
+        { id: 'p1', name: 'Alice', hand: [skip, makeCard('number', 'blue', { value: 8, id: 'p1_blue' })], score: 0, connected: true, autopilot: false, calledUno: false, isBot: false },
+        { id: 'p2', name: 'Bob', hand: [makeCard('number', 'yellow', { value: 1, id: 'p2_yellow' })], score: 0, connected: true, autopilot: false, calledUno: false, isBot: false },
+        { id: 'p3', name: 'Carol', hand: [makeCard('number', 'blue', { value: 2, id: 'p3_blue' })], score: 0, connected: true, autopilot: false, calledUno: false, isBot: false },
+      ],
+      deckLeft: [
+        makeCard('number', 'green', { value: 1, id: 'first_unplayable' }),
+        makeCard('number', 'yellow', { value: 2, id: 'second_unplayable' }),
+      ],
+      deckRight: [],
+      deckLeftInitialCount: 2,
+      deckRightInitialCount: 0,
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        allowSpectators: true,
+        spectatorMode: 'hidden',
+        houseRules: { ...DEFAULT_HOUSE_RULES, deathDraw: true },
+      },
+    });
+
+    const afterSkip = applyActionWithHouseRules(state, { type: 'PLAY_CARD', playerId: 'p1', cardId: 'skip' });
+    const afterFirstDraw = applyActionWithHouseRules(afterSkip, { type: 'DRAW_CARD', playerId: 'p3', side: 'left' });
+    expect(afterFirstDraw.players[2]!.hand.map(c => c.id)).toEqual(['p3_blue', 'first_unplayable']);
+    expect(afterFirstDraw.deckLeft.map(c => c.id)).toEqual(['second_unplayable']);
+
+    const afterSecondDraw = applyActionWithHouseRules(afterFirstDraw, { type: 'DRAW_CARD', playerId: 'p3', side: 'left' });
+    expect(afterSecondDraw.players[2]!.hand.map(c => c.id)).toEqual(['p3_blue', 'first_unplayable', 'second_unplayable']);
+  });
+
+  it('does not auto-play the first drawn card when death-draw is combined with forced draw play', () => {
+    const state = makeState({
+      players: [
+        { id: 'p1', name: 'Alice', hand: [makeCard('number', 'blue', { value: 8, id: 'p1_blue' })], score: 0, connected: true, autopilot: false, calledUno: false, isBot: false },
+        { id: 'p2', name: 'Bob', hand: [makeCard('number', 'yellow', { value: 1, id: 'p2_yellow' })], score: 0, connected: true, autopilot: false, calledUno: false, isBot: false },
+      ],
+      deckLeft: [makeCard('number', 'red', { value: 8, id: 'drawn_playable' })],
+      deckRight: [],
+      deckLeftInitialCount: 1,
+      deckRightInitialCount: 0,
+      lastAction: { type: 'PLAY_CARD', playerId: 'p2', cardId: 'p2_yellow' },
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        allowSpectators: true,
+        spectatorMode: 'hidden',
+        houseRules: { ...DEFAULT_HOUSE_RULES, deathDraw: true, forcedPlayAfterDraw: true },
+      },
+    });
+
+    const afterDraw = applyActionWithHouseRules(state, { type: 'DRAW_CARD', playerId: 'p1', side: 'left' });
+    expect(afterDraw.players[0]!.hand.map(c => c.id)).toEqual(['p1_blue', 'drawn_playable']);
+    expect(afterDraw.discardPile.map(c => c.id)).not.toContain('drawn_playable');
+  });
+
+  it('starts +4 penalty draws immediately after choosing color when challenges are disabled', () => {
+    const wd4 = makeCard('wild_draw_four', null, { id: 'wd4' });
+    const state = makeState({
+      players: [
+        { id: 'p1', name: 'Alice', hand: [wd4, makeCard('number', 'blue', { value: 8, id: 'p1_blue' })], score: 0, connected: true, autopilot: false, calledUno: false, isBot: false },
+        { id: 'p2', name: 'Bob', hand: [makeCard('number', 'yellow', { value: 1, id: 'p2_yellow' })], score: 0, connected: true, autopilot: false, calledUno: false, isBot: false },
+        { id: 'p3', name: 'Carol', hand: [makeCard('number', 'green', { value: 2, id: 'p3_green' })], score: 0, connected: true, autopilot: false, calledUno: false, isBot: false },
+      ],
+      deckLeft: Array.from({ length: 5 }, (_, i) => makeCard('number', 'red', { value: i, id: `penalty_${i}` })),
+      deckRight: [],
+      deckLeftInitialCount: 5,
+      deckRightInitialCount: 0,
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        allowSpectators: true,
+        spectatorMode: 'hidden',
+        houseRules: { ...DEFAULT_HOUSE_RULES, noChallengeWildFour: true },
+      },
+    });
+
+    const afterPlay = applyActionWithHouseRules(state, { type: 'PLAY_CARD', playerId: 'p1', cardId: 'wd4' });
+    expect(afterPlay.phase).toBe('choosing_color');
+
+    const afterColor = applyActionWithHouseRules(afterPlay, { type: 'CHOOSE_COLOR', playerId: 'p1', color: 'green' });
+    expect(afterColor.phase).toBe('playing');
+    expect(afterColor.currentColor).toBe('green');
+    expect(afterColor.pendingDrawPlayerId).toBeNull();
+    expect(afterColor.currentPlayerIndex).toBe(1);
+    expect(afterColor.pendingPenaltyDraws).toBe(4);
+
+    const challengeAttempt = applyActionWithHouseRules(afterColor, { type: 'CHALLENGE', playerId: 'p2' });
+    expect(challengeAttempt).toBe(afterColor);
+
+    const afterFirstPenaltyDraw = applyActionWithHouseRules(afterColor, { type: 'DRAW_CARD', playerId: 'p2', side: 'left' });
+    expect(afterFirstPenaltyDraw.pendingPenaltyDraws).toBe(3);
+    expect(afterFirstPenaltyDraw.players[1]!.hand.map(c => c.id)).toEqual(['p2_yellow', 'penalty_0']);
+  });
+
+  it('still allows draw then pass when forced-play-after-draw draws an unplayable card', () => {
+    const state = makeState({
+      players: [
+        { id: 'p1', name: 'Alice', hand: [makeCard('number', 'blue', { value: 8, id: 'p1_blue' })], score: 0, connected: true, autopilot: false, calledUno: false, isBot: false },
+        { id: 'p2', name: 'Bob', hand: [makeCard('number', 'yellow', { value: 1, id: 'p2_yellow' })], score: 0, connected: true, autopilot: false, calledUno: false, isBot: false },
+        { id: 'p3', name: 'Carol', hand: [makeCard('number', 'green', { value: 2, id: 'p3_green' })], score: 0, connected: true, autopilot: false, calledUno: false, isBot: false },
+      ],
+      deckLeft: [makeCard('number', 'green', { value: 9, id: 'drawn_unplayable' })],
+      deckRight: [],
+      deckLeftInitialCount: 1,
+      deckRightInitialCount: 0,
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        allowSpectators: true,
+        spectatorMode: 'hidden',
+        houseRules: { ...DEFAULT_HOUSE_RULES, forcedPlay: true, forcedPlayAfterDraw: true },
+      },
+    });
+
+    const afterDraw = applyActionWithHouseRules(state, { type: 'DRAW_CARD', playerId: 'p1', side: 'left' });
+    expect(afterDraw.players[0]!.hand.map(c => c.id)).toEqual(['p1_blue', 'drawn_unplayable']);
+    expect(afterDraw.currentPlayerIndex).toBe(0);
+
+    const afterPass = applyActionWithHouseRules(afterDraw, { type: 'PASS', playerId: 'p1' });
+    expect(afterPass.currentPlayerIndex).toBe(1);
+  });
+});


### PR DESCRIPTION
## 概要

修复：游戏规则、语音、登录态、ready 声音、闪电战倒计时，以及 Windows 下 server build 的语音生成文件复制。

## 主要改动

- 修复 `无质疑 +4` 村规：打出 +4 并选色后直接进入罚摸流程，不再进入质疑阶段。
- 修复 `摸到能出为止` / `死亡摸牌` 与上一回合动作、`摸后强制出牌` 组合时的回归，避免第一次摸牌错误落回核心流程导致自动出牌。
- 增加最新村规回归测试，覆盖跳过后摸牌、+4 无质疑、罚摸和强制摸后出牌组合场景。
- 增加闪电战全局倒计时，在顶部栏展示剩余总时间。
- 修复登录态初始化：页面刷新时先恢复 `/auth/me`，避免还没初始化就跳转；普通失败保留 token 并提供重试/退出登录入口。
- 统一 API 401 处理，清理本地 token 并通知 app 断开 socket。
- 修复 socket token 变化后不会重连的问题，退出登录后会断开旧连接。
- 修复语音频道单人音量滑条无效的问题，播放 worklet 按用户音量混音，并清理离开的用户音量状态。
- ready 声音改为服务端广播实际 ready 状态变化，客户端只播放其他玩家准备的音效。
- server build 改用 Node 脚本复制 `MumbleServer.js`，避免 Windows 环境下 `mkdir -p` / `cp` 不可用。


## 验证

- `pnpm --filter shared test`：291 passed
- `pnpm --filter shared build`
- `pnpm --filter client build`
- `pnpm --filter server build`
- `git diff --check`

## 残余风险

- 语音音量、ready 音效、闪电战倒计时仍建议在浏览器里做一次手动 smoke，覆盖音频权限、刷新重连和后台标签页计时。
- `noChallengeWildFour` 已有单元测试覆盖核心流程，但更多复杂村规组合仍依赖现有插件顺序和后续端到端验证。