### PR TITLE
fix: 房主迁移完善：主动离开即时迁移、移交不限阶段、观战者房主提示

### DIFF
--- a/packages/client/src/features/game/components/PlayerListPanel.tsx
+++ b/packages/client/src/features/game/components/PlayerListPanel.tsx
@@ -1,6 +1,9 @@
 import { useState } from 'react';
 import { motion, useDragControls, AnimatePresence } from 'framer-motion';
-import { Bot, ChevronDown, Crown, Eye, GripHorizontal, UserPlus } from 'lucide-react';
+import { ArrowRightLeft, Bot, ChevronDown, Crown, Eye, GripHorizontal, UserPlus } from 'lucide-react';
+import { getSocket } from '@/shared/socket';
+import { showConfirm } from '@/shared/stores/confirm-store';
+import { useToastStore } from '@/shared/stores/toast-store';
 import { useGameStore } from '../stores/game-store';
 import { useSpectatorStore } from '../stores/spectator-store';
 import { useRoomStore } from '@/shared/stores/room-store';
@@ -128,6 +131,20 @@ export default function PlayerListPanel() {
                         </div>
                         <div className="flex items-center gap-1 shrink-0">
                           <PlayerVoiceStatus playerId={p.id} playerName={p.name} isSelf={isMe} />
+                          {ownerId === userId && !isMe && !p.isBot && (
+                            <button
+                              onClick={async () => {
+                                if (!(await showConfirm({ title: '移交房主', message: `确定要将房主移交给 ${p.name} 吗？`, confirmText: '移交' }))) return;
+                                getSocket().emit('room:transfer_owner', { targetId: p.id }, (res: { success?: boolean; error?: string }) => {
+                                  if (!res?.success) useToastStore.getState().addToast(res?.error ?? '移交失败', 'error');
+                                });
+                              }}
+                              className="text-yellow-500/40 hover:text-yellow-500 cursor-pointer transition-colors"
+                              title="移交房主"
+                            >
+                              <ArrowRightLeft size={10} />
+                            </button>
+                          )}
                           <span className="text-2xs text-muted-foreground">{p.handCount}</span>
                           {!p.connected && <span className="w-1.5 h-1.5 rounded-full bg-destructive" />}
                           {isActive && <span className="text-2xs">◀</span>}

--- a/packages/client/src/features/game/components/ScoreBoard.tsx
+++ b/packages/client/src/features/game/components/ScoreBoard.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
-import { Trophy, BarChart3, Crown, Check, UserX, UserPlus, WifiOff, Eye, X } from 'lucide-react';
+import { Trophy, BarChart3, Crown, Check, UserX, UserPlus, WifiOff, Eye, X, ArrowRightLeft } from 'lucide-react';
+import { showConfirm } from '@/shared/stores/confirm-store';
 import { useGameStore } from '../stores/game-store';
 import { useEffectiveUserId } from '../hooks/useEffectiveUserId';
 import { useRoomStore } from '@/shared/stores/room-store';
@@ -100,9 +101,12 @@ export default function ScoreBoard({ isSpectator = false, onPlayAgain, onBackToR
 
   const ownerId = useRoomStore((s) => s.room?.ownerId);
   const userId = useEffectiveUserId();
+  const authUserId = useAuthStore((s) => s.user?.id);
   const sorted = [...players].sort((a, b) => b.score - a.score);
   const isGameOver = phase === 'game_over';
   const isHost = ownerId === userId;
+  const isSpectatorOwner = isSpectator && ownerId === authUserId;
+  const canTransfer = isHost || isSpectatorOwner;
   const hasVoted = !!userId && !!vote?.voters.includes(userId);
   const fallbackRequired = players.length;
   const votes = vote?.votes ?? 0;
@@ -156,6 +160,20 @@ export default function ScoreBoard({ isSpectator = false, onPlayAgain, onBackToR
                     {p.id === ownerId && <span title="房主"><Crown size={12} className="inline align-middle ml-1 text-yellow-500" /></span>}
                     {p.isBot && <AiBadge className="ml-1" />}
                     {disconnected && <WifiOff size={12} className="inline align-middle ml-1 text-destructive" />}
+                    {canTransfer && !isSelf && !p.isBot && (
+                      <button
+                        onClick={async () => {
+                          if (!(await showConfirm({ title: '移交房主', message: `确定要将房主移交给 ${p.name} 吗？`, confirmText: '移交' }))) return;
+                          getSocket().emit('room:transfer_owner', { targetId: p.id }, (res: { success?: boolean; error?: string }) => {
+                            if (!res?.success) useToastStore.getState().addToast(res?.error ?? '移交失败', 'error');
+                          });
+                        }}
+                        className="ml-1 text-yellow-500/50 hover:text-yellow-500 cursor-pointer bg-transparent border-none transition-colors"
+                        title="移交房主"
+                      >
+                        <ArrowRightLeft size={12} className="inline align-middle" />
+                      </button>
+                    )}
                   </td>
                   {!isGameOver && (
                     <td className="px-2 py-1.5 text-center whitespace-nowrap">
@@ -173,6 +191,12 @@ export default function ScoreBoard({ isSpectator = false, onPlayAgain, onBackToR
             })}
           </tbody>
         </table>
+        {isSpectatorOwner && (
+          <div className="mb-3 flex items-center gap-2 rounded-lg bg-yellow-500/10 border border-yellow-500/30 px-3 py-2 text-xs text-yellow-300">
+            <Crown size={14} className="shrink-0" />
+            <span>你是房主但处于观战状态，请入座或将房主移交给在座的玩家</span>
+          </div>
+        )}
         {!isGameOver && pendingJoinQueue.length > 0 && (
           <p className="mb-2 text-xs text-accent flex items-center justify-center gap-1">
             <UserPlus size={12} /> {pendingJoinQueue.join('、')} 将在下一轮加入

--- a/packages/server/src/plugins/core/room/store.ts
+++ b/packages/server/src/plugins/core/room/store.ts
@@ -325,6 +325,22 @@ export async function clearRoomSpectators(kv: KvStore, roomCode: string): Promis
   await kv.del(`room:${roomCode}:spectators`);
 }
 
+export async function removeDisconnectedSpectators(
+  kv: KvStore, roomCode: string, thresholdMs: number,
+): Promise<RoomSpectator[]> {
+  return withRoomSeatLock(roomCode, async () => {
+    const spectators = await getRoomSpectators(kv, roomCode);
+    const now = Date.now();
+    const stale = spectators.filter(
+      s => !s.connected && s.disconnectedAt && now - s.disconnectedAt >= thresholdMs,
+    );
+    if (stale.length === 0) return [];
+    const remaining = spectators.filter(s => !stale.includes(s));
+    await setRoomSpectators(kv, roomCode, remaining);
+    return stale;
+  });
+}
+
 export function pickNextOwner(
   seats: RoomSeats, spectators: RoomSpectator[], excludeUserId?: string,
 ): string | null {

--- a/packages/server/src/ws/game-events.ts
+++ b/packages/server/src/ws/game-events.ts
@@ -810,6 +810,11 @@ export function registerGameEvents(
     const player = state.players.find((p) => p.id === data.user.userId);
     if (!player) return callback?.({ success: false, error: '玩家不在游戏中' });
 
+    const room = await getRoom(redis, roomCode);
+    if (room?.ownerId === data.user.userId) {
+      return callback?.({ success: false, error: '房主需要先移交房主权才能进入观战席' });
+    }
+
     if (state.players.length <= MIN_PLAYERS) {
       return callback?.({ success: false, error: '玩家数量不足，无法切换观战' });
     }
@@ -825,14 +830,6 @@ export function registerGameEvents(
       role: data.user.role,
       connected: true,
     });
-
-    const room = await getRoom(redis, roomCode);
-    if (room?.ownerId === data.user.userId) {
-      const nextOwnerId = await findNextOwner(redis, roomCode, data.user.userId);
-      if (nextOwnerId) {
-        await setRoomOwner(redis, roomCode, nextOwnerId);
-      }
-    }
 
     const voters = nextRoundVotes.get(roomCode) ?? new Set<string>();
     voters.delete(data.user.userId);

--- a/packages/server/src/ws/room-events.ts
+++ b/packages/server/src/ws/room-events.ts
@@ -3,7 +3,7 @@ import type { KvStore } from '../kv/types.js';
 import type { GameAction, GameState, RoomSettings, BotDifficulty } from '@uno-online/shared';
 import { MIN_PLAYERS, DEFAULT_HOUSE_RULES, chooseAutopilotAction, chooseJumpInAction, chooseBotAction, getPlayableCards, DIFFICULTY_PARAMS, BOT_DIFFICULTIES } from '@uno-online/shared';
 import { RoomManager } from '../plugins/core/room/manager.js';
-import { getRoom, getRoomSeats, getRoomSpectators, setRoomSettings, setRoomStatus, setRoomOwner, touchRoomActivity, ensureNotInRoom, removeSpectatorFromRoom, clearRoomSpectators, getSeatedPlayers, findNextOwner } from '../plugins/core/room/store.js';
+import { getRoom, getRoomSeats, getRoomSpectators, setRoomSettings, setRoomStatus, setRoomOwner, touchRoomActivity, ensureNotInRoom, removeSpectatorFromRoom, clearRoomSpectators, getSeatedPlayers, pickNextOwner, findNextOwner } from '../plugins/core/room/store.js';
 import { joinRoomSocket, leaveRoomSocket } from './socket-room.js';
 import { GameSession } from '../plugins/core/game/session.js';
 import type { GameStatePersister } from '../plugins/core/game/state-store.js';
@@ -160,17 +160,17 @@ export function registerRoomEvents(
       const seats = await getRoomSeats(redis, roomCode);
       const seatedPlayers = getSeatedPlayers(seats);
       const hasHumanPlayers = seatedPlayers.some(p => !p.isBot);
+      const hasOtherHumanSpectators = spectators.some(s => s.connected && s.userId !== userId);
 
-      if (seatedPlayers.length === 0 || !hasHumanPlayers) {
+      if ((seatedPlayers.length === 0 || !hasHumanPlayers) && !hasOtherHumanSpectators) {
         await leaveRoomSocket(redis, socket, roomCode);
         await dissolveRoom(io, redis, roomCode, sessions, turnTimer, persister, 'empty', voiceChannels);
         return callback?.({ success: true, dissolved: true });
       }
 
-      // Transfer ownership if the leaving spectator was the owner
       const room = await getRoom(redis, roomCode);
       if (room?.ownerId === userId) {
-        const nextOwnerId = await findNextOwner(redis, roomCode, userId);
+        const nextOwnerId = pickNextOwner(seats, spectators, userId);
         if (nextOwnerId) {
           await setRoomOwner(redis, roomCode, nextOwnerId);
         }
@@ -200,6 +200,22 @@ export function registerRoomEvents(
       io.to(roomCode).emit('player:autopilot', { playerId: data.user.userId, enabled: true });
       removeVoicePresence(io, roomCode, data.user.userId);
       await leaveRoomSocket(redis, socket, roomCode);
+
+      if (!session.getFullState().players.some(p => p.connected && !p.isBot)) {
+        await dissolveRoom(io, redis, roomCode, sessions, turnTimer, persister, 'empty', voiceChannels);
+        return callback?.({ success: true, dissolved: true });
+      }
+
+      const room = await getRoom(redis, roomCode);
+      if (room && room.ownerId === data.user.userId) {
+        const nextOwnerId = await findNextOwner(redis, roomCode, data.user.userId);
+        if (nextOwnerId) {
+          await setRoomOwner(redis, roomCode, nextOwnerId);
+          const updatedRoom = await getRoom(redis, roomCode);
+          io.to(roomCode).emit('room:updated', { room: updatedRoom });
+        }
+      }
+
       addAutopilotVote(roomCode, data.user.userId, session, io);
       startTurnTimer(io, redis, roomCode, session, turnTimer, sessions, persister);
       return callback?.({ success: true });
@@ -290,14 +306,12 @@ export function registerRoomEvents(
     const room = await getRoom(redis, roomCode);
     if (!room) return callback?.({ success: false, error: '房间不存在' });
     if (room.ownerId !== data.user.userId) return callback?.({ success: false, error: '只有房主可以移交' });
-    if (room.status !== 'waiting') return callback?.({ success: false, error: '游戏进行中无法移交房主' });
     if (payload.targetId === data.user.userId) return callback?.({ success: false, error: '不能移交给自己' });
-    const [seats, spectators] = await Promise.all([getRoomSeats(redis, roomCode), getRoomSpectators(redis, roomCode)]);
-    const allUsers = [...getSeatedPlayers(seats), ...spectators];
-    if (!allUsers.some(p => p.userId === payload.targetId)) return callback?.({ success: false, error: '目标玩家不在房间中' });
+    const seats = await getRoomSeats(redis, roomCode);
+    if (!getSeatedPlayers(seats).some(p => p.userId === payload.targetId && !p.isBot)) return callback?.({ success: false, error: '只能移交给在座的玩家' });
     await setRoomOwner(redis, roomCode, payload.targetId);
     await touchRoomActivity(redis, roomCode);
-    const updatedRoom = await getRoom(redis, roomCode);
+    const [updatedRoom, spectators] = await Promise.all([getRoom(redis, roomCode), getRoomSpectators(redis, roomCode)]);
     io.to(roomCode).emit('room:updated', { room: updatedRoom });
     io.to(roomCode).emit('seat:updated', { seats, spectators });
     callback?.({ success: true });

--- a/packages/server/src/ws/seat-events.ts
+++ b/packages/server/src/ws/seat-events.ts
@@ -189,6 +189,7 @@ export function registerSeatEvents(
 
       const currentSeat = seats[seatIndex]!;
       if (currentSeat.ready) return callback({ success: false, error: '请先取消准备再离座' });
+      if (room.ownerId === userId) return callback({ success: false, error: '房主需要先移交房主权才能离座' });
 
       await leaveSeat(redis, roomCode, userId);
 

--- a/packages/server/src/ws/socket-handler.ts
+++ b/packages/server/src/ws/socket-handler.ts
@@ -7,7 +7,7 @@ import { GameSession } from '../plugins/core/game/session.js';
 import { registerRoomEvents, emitGameUpdate, startTurnTimer, executeAutopilot, notifyAutopilotAction, resetPlayerTimeout } from './room-events.js';
 import { getAutopilotActionPlayerId, canPlayerAutopilotOnce } from './autopilot-action-player.js';
 import { registerGameEvents, emitTerminalStateIfNeeded, addAutopilotVote, clearChatTimestamps, getRoundEndVoteState, getPendingSpectatorQueue, getRoundEndAt } from './game-events.js';
-import { getRoom, setRoomOwner, clearUserRoom, getUserRoom, setSeatPlayerConnected, getRoomSeats, getRoomSpectators, addSpectatorToRoom, removeSpectatorFromRoom, setSpectatorConnected, getSeatedPlayers, findNextOwner, pickNextOwner } from '../plugins/core/room/store.js';
+import { getRoom, setRoomOwner, clearUserRoom, getUserRoom, setSeatPlayerConnected, getRoomSeats, getRoomSpectators, addSpectatorToRoom, removeDisconnectedSpectators, setSpectatorConnected, getSeatedPlayers, findNextOwner, pickNextOwner } from '../plugins/core/room/store.js';
 import { registerSeatEvents, clearPendingSwapRequests, clearUserSwapRequests } from './seat-events.js';
 import { joinRoomSocket, leaveRoomSocket } from './socket-room.js';
 import { loadGameState, GameStatePersister } from '../plugins/core/game/state-store.js';
@@ -168,14 +168,11 @@ export function setupSocketHandlers(
 
   async function sweepDisconnectedSpectators() {
     const roomCodes = await getRoomCodes();
-    const now = Date.now();
     for (const roomCode of roomCodes) {
-      const spectators = await getRoomSpectators(redis, roomCode);
-      const stale = spectators.filter(s => !s.connected && s.disconnectedAt && now - s.disconnectedAt >= RECONNECT_TIMEOUT_MS);
-      if (stale.length === 0) continue;
+      const removed = await removeDisconnectedSpectators(redis, roomCode, RECONNECT_TIMEOUT_MS);
+      if (removed.length === 0) continue;
 
-      for (const s of stale) {
-        await removeSpectatorFromRoom(redis, roomCode, s.userId);
+      for (const s of removed) {
         await clearUserRoom(redis, s.userId);
       }
       await broadcastSpectatorList(io, redis, roomCode);
@@ -196,7 +193,7 @@ export function setupSocketHandlers(
         continue;
       }
 
-      if (stale.some(s => s.userId === room.ownerId)) {
+      if (removed.some(s => s.userId === room.ownerId)) {
         const nextOwnerId = pickNextOwner(seats, remaining, room.ownerId);
         if (nextOwnerId) {
           await setRoomOwner(redis, roomCode, nextOwnerId);
@@ -365,7 +362,7 @@ export function setupSocketHandlers(
           await setSpectatorConnected(redis, roomCode, userId, true);
         }
 
-        await joinRoomSocket(redis, socket, roomCode);
+        await joinRoomSocket(redis, socket, roomCode, { asSpectator: !isSeated });
         if (hasOwnerTransferPending(roomCode) && room.ownerId === userId) {
           cancelOwnerTransfer(roomCode);
           io.to(roomCode).emit('room:owner_transfer_cancelled');
@@ -548,7 +545,6 @@ export function setupSocketHandlers(
               getRoomSpectators(redis, roomCode),
             ]);
             io.to(roomCode).emit('seat:updated', { seats, spectators });
-            // If leaver was owner, room:updated already emitted by leaveRoom's transfer
             if (room) {
               io.to(roomCode).emit('room:updated', { room });
             }


### PR DESCRIPTION
## Summary
- 游戏中房主主动离开时立即迁移房主权（之前不触发迁移导致游戏卡死）
- `room:transfer_owner` 移除等待阶段限制，任何阶段均可移交
- 移交目标收紧为仅在座非机器人玩家（不再允许移交给观战者）
- 房主退至观战（`seat:leave` / `game:leave_to_spectate`）需先移交房主权
- ScoreBoard 和 PlayerListPanel 增加移交房主按钮
- 观战者房主在积分板显示提示横幅，引导入座或移交

## Test plan
- [ ] 游戏中房主主动离开，验证房主权立即迁移给其他在座玩家
- [ ] 回合结束阶段通过 ScoreBoard 移交房主按钮移交
- [ ] 游戏进行中通过 PlayerListPanel 移交房主按钮移交
- [ ] 等待阶段通过 PlayerActionMenu 移交房主
- [ ] 房主点击"进入观战席"或"离座"时提示需先移交
- [ ] 观战者成为房主后 ScoreBoard 显示黄色提示横幅
- [ ] 移交目标只能是在座非机器人玩家，无法移交给观战者或机器人

🤖 Generated with [Claude Code](https://claude.com/claude-code)