### PR TITLE
fix: 房间重连稳定性修复与连接速度优化

### DIFF
--- a/packages/client/src/features/game/pages/RoomPage.tsx
+++ b/packages/client/src/features/game/pages/RoomPage.tsx
@@ -30,12 +30,13 @@ import type { BotDifficulty } from '@uno-online/shared';
 export default function RoomPage() {
   const { roomCode } = useParams<{ roomCode: string }>();
   const user = useAuthStore((s) => s.user);
-  const { seats, spectators, room, setRoom } = useRoomStore();
+  const { roomCode: storeRoomCode, seats, spectators, room, setRoom } = useRoomStore();
   const setGameState = useGameStore((s) => s.setGameState);
   const navigate = useNavigate();
   const songName = useBgm('lobby');
   const leaveRoomHook = useLeaveRoom();
 
+  const [rejoinError, setRejoinError] = useState<string | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [swapRequest, setSwapRequest] = useState<{
     requesterId: string;
@@ -66,10 +67,13 @@ export default function RoomPage() {
   useEffect(() => {
     connectSocket();
     const socket = getSocket();
-    refreshVoicePresence();
+    let cancelled = false;
 
-    if (useRoomStore.getState().roomCode !== roomCode && roomCode) {
+    const tryRejoin = () => {
+      if (cancelled || !roomCode) return;
+      if (useRoomStore.getState().roomCode === roomCode) return;
       socket.emit('room:rejoin', roomCode, (res: any) => {
+        if (cancelled) return;
         if (res.success) {
           if (res.seats && res.spectators && res.room) {
             setRoom(roomCode, res.seats, res.spectators, res.room);
@@ -80,9 +84,16 @@ export default function RoomPage() {
             navigate(`/game/${roomCode}`);
           }
         } else {
-          navigate('/');
+          setRejoinError(res.error || '房间不存在');
         }
       });
+    };
+
+    if (useRoomStore.getState().roomCode !== roomCode) {
+      if (socket.connected) tryRejoin();
+      socket.on('connect', tryRejoin);
+    } else {
+      refreshVoicePresence();
     }
 
     const onState = (view: any) => {
@@ -92,6 +103,8 @@ export default function RoomPage() {
     };
     socket.on('game:state', onState);
     return () => {
+      cancelled = true;
+      socket.off('connect', tryRejoin);
       socket.off('game:state', onState);
     };
   }, [roomCode, navigate, setGameState]);
@@ -251,6 +264,29 @@ export default function RoomPage() {
     );
     setSwapRequest(null);
   };
+
+  if (rejoinError) {
+    return (
+      <GamePageShell>
+        <div className="flex-1 flex flex-col items-center justify-center gap-4">
+          <p className="text-muted-foreground">{rejoinError}</p>
+          <Button variant="game" onClick={() => navigate('/')} sound="click">
+            返回大厅
+          </Button>
+        </div>
+      </GamePageShell>
+    );
+  }
+
+  if (storeRoomCode !== roomCode) {
+    return (
+      <GamePageShell>
+        <div className="flex-1 flex items-center justify-center">
+          <p className="text-muted-foreground">正在加入房间…</p>
+        </div>
+      </GamePageShell>
+    );
+  }
 
   return (
     <GamePageShell>

--- a/packages/client/src/features/lobby/pages/LobbyPage.tsx
+++ b/packages/client/src/features/lobby/pages/LobbyPage.tsx
@@ -48,6 +48,7 @@ export default function LobbyPage() {
     const socket = getSocket();
     let cancelled = false;
     const checkRoom = () => {
+      if (cancelled) return;
       socket.emit('user:current_room', (res) => {
         if (cancelled || !res.roomCode) return;
         localStorage.setItem('lastRoomCode', res.roomCode);
@@ -55,7 +56,7 @@ export default function LobbyPage() {
       });
     };
     if (socket.connected) checkRoom();
-    else socket.once('connect', checkRoom);
+    socket.on('connect', checkRoom);
     return () => {
       cancelled = true;
       socket.off('connect', checkRoom);

--- a/packages/client/src/shared/socket.ts
+++ b/packages/client/src/shared/socket.ts
@@ -40,6 +40,7 @@ export function getSocket(): TypedSocket {
     const token = currentToken();
     socket = io(getApiUrl(), {
       auth: { token },
+      transports: ['websocket'],
       autoConnect: false,
       reconnection: true,
       reconnectionAttempts: 5,

--- a/packages/server/src/ws/socket-handler.ts
+++ b/packages/server/src/ws/socket-handler.ts
@@ -259,6 +259,13 @@ export function setupSocketHandlers(
 
     // Handle reconnection: restore room and game state
     socket.on('room:rejoin', async (roomCode: string, callback) => {
+      const pendingDisconnect = disconnectTimers.get(userId);
+      if (pendingDisconnect) {
+        clearTimeout(pendingDisconnect);
+        disconnectTimers.delete(userId);
+        stopAutoPlay(userId);
+      }
+
       const room = await getRoom(redis, roomCode);
       if (!room) {
         await clearUserRoom(redis, userId);


### PR DESCRIPTION
## Summary
- 修复刷新页面时新旧 socket disconnect/connect 竞态导致 30 秒后被踢出房间的问题
- RoomPage/LobbyPage 的 socket 重连后自动重试 rejoin/current_room 检查，不再因回调丢失卡死
- RoomPage 增加加载态（"正在加入房间…"）和错误提示（"房间不存在" + 返回按钮），替代空桌闪烁和静默跳转
- Socket.IO 改用 WebSocket 直连（`transports: ['websocket']`），跳过 polling 阶段，连接速度显著提升

## Test plan
- [ ] 在房间内刷新页面，应显示"正在加入房间…"后快速恢复
- [ ] 访问不存在的房间 URL，应显示错误提示和返回按钮
- [ ] 从 URL 栏删除房间号回到首页，应自动重定向回房间
- [ ] 反复快速刷新，不应出现空桌或卡住
- [ ] 检查连接延迟指示灯，刷新后应快速亮绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)