### PR TITLE
fix: 末牌限制/空手赢不算触发时自动补摸 1 张，避免对局卡死

### DIFF
--- a/packages/shared/src/rules/rules/finish-restrictions.ts
+++ b/packages/shared/src/rules/rules/finish-restrictions.ts
@@ -16,11 +16,19 @@ export const finishRestrictions: HouseRulePlugin = {
     const card = player?.hand.find(c => c.id === action.cardId);
     if (!card) return { handled: false };
     const hr = state.settings.houseRules;
-    if (hr.noWildFinish && ctx.isLastCard(state, action.playerId, action.cardId) && ctx.isWildCard(card)) {
-      return { handled: true, state };
-    }
-    if (hr.noFunctionCardFinish && ctx.isLastCard(state, action.playerId, action.cardId) && ctx.isFunctionCard(card)) {
-      return { handled: true, state };
+    const isLast = ctx.isLastCard(state, action.playerId, action.cardId);
+    if (isLast && (
+      (hr.noWildFinish && ctx.isWildCard(card)) ||
+      (hr.noFunctionCardFinish && ctx.isFunctionCard(card))
+    )) {
+      const isCurrentPlayer = state.players[state.currentPlayerIndex]?.id === action.playerId;
+      if (!isCurrentPlayer || state.drawStack > 0) {
+        return { handled: true, state };
+      }
+      return {
+        handled: true,
+        state: ctx.drawCardsFromDeck(state, action.playerId, 1),
+      };
     }
     return { handled: false };
   },

--- a/packages/shared/tests/house-rules-engine.test.ts
+++ b/packages/shared/tests/house-rules-engine.test.ts
@@ -48,7 +48,7 @@ describe('default house rules — behaves like standard engine', () => {
 // ──────────────────────────────────────────────────────────────────────────────
 
 describe('noWildFinish', () => {
-  it('rejects wild as last card', () => {
+  it('rejects wild as last card and draws 1 card', () => {
     const wild = makeCard('wild', null, { id: 'wild1' });
     const state = makeState({
       players: [
@@ -63,12 +63,11 @@ describe('noWildFinish', () => {
       },
     });
     const next = applyActionWithHouseRules(state, { type: 'PLAY_CARD', playerId: 'p1', cardId: 'wild1' });
-    // State should be returned unchanged (play rejected)
-    expect(next.players[0]!.hand).toHaveLength(1);
+    expect(next.players[0]!.hand).toHaveLength(2);
     expect(next.discardPile[next.discardPile.length - 1]!.id).toBe('discard_top');
   });
 
-  it('rejects wild_draw_four as last card', () => {
+  it('rejects wild_draw_four as last card and draws 1 card', () => {
     const wd4 = makeCard('wild_draw_four', null, { id: 'wd4' });
     const state = makeState({
       players: [
@@ -83,7 +82,7 @@ describe('noWildFinish', () => {
       },
     });
     const next = applyActionWithHouseRules(state, { type: 'PLAY_CARD', playerId: 'p1', cardId: 'wd4' });
-    expect(next.players[0]!.hand).toHaveLength(1);
+    expect(next.players[0]!.hand).toHaveLength(2);
   });
 
   it('allows wild when NOT last card', () => {
@@ -104,6 +103,44 @@ describe('noWildFinish', () => {
     const next = applyActionWithHouseRules(state, { type: 'PLAY_CARD', playerId: 'p1', cardId: 'wild1' });
     expect(next.phase).toBe('choosing_color');
   });
+
+  it('blocks without drawing when drawStack > 0', () => {
+    const wd4 = makeCard('wild_draw_four', null, { id: 'wd4' });
+    const state = makeState({
+      players: [
+        { id: 'p1', name: 'Alice', hand: [wd4], score: 0, connected: true, calledUno: false },
+        { id: 'p2', name: 'Bob', hand: [makeCard('number', 'blue', { value: 1, id: 'p2c' })], score: 0, connected: true, calledUno: false },
+        { id: 'p3', name: 'Carol', hand: [], score: 0, connected: true, calledUno: false },
+      ],
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        houseRules: { ...DEFAULT_HOUSE_RULES, noWildFinish: true },
+      },
+      drawStack: 2,
+    });
+    const next = applyActionWithHouseRules(state, { type: 'PLAY_CARD', playerId: 'p1', cardId: 'wd4' });
+    expect(next).toBe(state);
+  });
+
+  it('blocks jump-in without drawing', () => {
+    const wd4 = makeCard('wild_draw_four', null, { id: 'wd4' });
+    const state = makeState({
+      currentPlayerIndex: 1,
+      players: [
+        { id: 'p1', name: 'Alice', hand: [wd4], score: 0, connected: true, calledUno: false },
+        { id: 'p2', name: 'Bob', hand: [makeCard('number', 'blue', { value: 1, id: 'p2c' })], score: 0, connected: true, calledUno: false },
+        { id: 'p3', name: 'Carol', hand: [], score: 0, connected: true, calledUno: false },
+      ],
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        houseRules: { ...DEFAULT_HOUSE_RULES, noWildFinish: true },
+      },
+    });
+    const next = applyActionWithHouseRules(state, { type: 'PLAY_CARD', playerId: 'p1', cardId: 'wd4' });
+    expect(next).toBe(state);
+  });
 });
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -111,7 +148,7 @@ describe('noWildFinish', () => {
 // ──────────────────────────────────────────────────────────────────────────────
 
 describe('noFunctionCardFinish', () => {
-  it('rejects draw_two as last card', () => {
+  it('rejects draw_two as last card and draws 1 card', () => {
     const d2 = makeCard('draw_two', 'red', { id: 'd2' });
     const state = makeState({
       players: [
@@ -126,10 +163,10 @@ describe('noFunctionCardFinish', () => {
       },
     });
     const next = applyActionWithHouseRules(state, { type: 'PLAY_CARD', playerId: 'p1', cardId: 'd2' });
-    expect(next.players[0]!.hand).toHaveLength(1);
+    expect(next.players[0]!.hand).toHaveLength(2);
   });
 
-  it('rejects wild_draw_four as last card', () => {
+  it('rejects wild_draw_four as last card and draws 1 card', () => {
     const wd4 = makeCard('wild_draw_four', null, { id: 'wd4' });
     const state = makeState({
       players: [
@@ -144,7 +181,7 @@ describe('noFunctionCardFinish', () => {
       },
     });
     const next = applyActionWithHouseRules(state, { type: 'PLAY_CARD', playerId: 'p1', cardId: 'wd4' });
-    expect(next.players[0]!.hand).toHaveLength(1);
+    expect(next.players[0]!.hand).toHaveLength(2);
   });
 
   it('allows draw_two when NOT last card', () => {


### PR DESCRIPTION
## Summary
- 修复 `finishRestrictions` 规则阻止受限最后一张牌打出后无后续动作，导致对局卡死的问题
- 触发限制时自动从牌堆补摸 1 张，玩家手牌变为 2 张后可正常继续出牌
- 处理 drawStack > 0（叠加场景）和 jump-in（插牌场景）两个边界情况：只阻止出牌，不额外摸牌

## Test plan
- [x] 末牌限制：wild 作为最后一张牌被阻止并补摸 1 张（手牌 1→2）
- [x] 末牌限制：wild_draw_four 作为最后一张牌被阻止并补摸 1 张
- [x] 空手赢不算：draw_two 作为最后一张牌被阻止并补摸 1 张
- [x] 空手赢不算：wild_draw_four 作为最后一张牌被阻止并补摸 1 张
- [x] drawStack > 0 时只阻止出牌，state 不变
- [x] 非当前玩家 jump-in 时只阻止插牌，state 不变
- [x] 非最后一张牌时不受影响，正常出牌
- [x] 全部 293 个测试通过，类型检查通过

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)