### PR TITLE
fix: 观战房主自动排队入座与下局加入流程优化

### DIFF
--- a/packages/client/src/features/game/components/ScoreBoard.tsx
+++ b/packages/client/src/features/game/components/ScoreBoard.tsx
@@ -194,7 +194,7 @@ export default function ScoreBoard({ isSpectator = false, onPlayAgain, onBackToR
         {isSpectatorOwner && (
           <div className="mb-3 flex items-center gap-2 rounded-lg bg-yellow-500/10 border border-yellow-500/30 px-3 py-2 text-xs text-yellow-300">
             <Crown size={14} className="shrink-0" />
-            <span>你是房主但处于观战状态，请入座或将房主移交给在座的玩家</span>
+            <span>{spectatorQueued ? '你将在下一轮入座，或将房主移交给在座的玩家' : '你是房主但处于观战状态，请入座或将房主移交给在座的玩家'}</span>
           </div>
         )}
         {!isGameOver && pendingJoinQueue.length > 0 && (
@@ -226,7 +226,16 @@ export default function ScoreBoard({ isSpectator = false, onPlayAgain, onBackToR
         {isSpectator ? (
           <div className="flex gap-3 justify-center flex-wrap">
             {!isGameOver && isHost && <Button variant="primary" onClick={onPlayAgain} disabled={isNextRoundDisabled} sound="ready">{nextRoundButtonText}</Button>}
-            {!isGameOver && <Button variant={isHost ? 'secondary' : 'primary'} onClick={toggleSpectatorQueue} sound="ready"><UserPlus size={14} className="inline align-middle mr-1" />加入游戏</Button>}
+            {!isGameOver && (() => {
+              const locked = spectatorQueued && isSpectatorOwner;
+              const Icon = spectatorQueued ? (locked ? Check : X) : UserPlus;
+              const label = spectatorQueued ? (locked ? '已加入下局' : '取消加入') : '下局加入';
+              return (
+                <Button variant="secondary" onClick={locked ? undefined : toggleSpectatorQueue} disabled={locked} sound={spectatorQueued ? 'click' : 'ready'}>
+                  <Icon size={14} className="inline align-middle mr-1" />{label}
+                </Button>
+              );
+            })()}
             {isGameOver && isHost && <Button variant="primary" onClick={onBackToRoom} disabled={cooldownActive} sound="ready">返回房间</Button>}
             {isGameOver && !isHost && <Button variant="primary" disabled>等待房主返回房间…</Button>}
             <Button variant="secondary" onClick={onBackToLobby} sound="click" disabled={leaveCountdown > 0}>{leaveCountdown > 0 ? `返回大厅 (${leaveCountdown}s)` : '返回大厅'}</Button>

--- a/packages/client/src/features/game/pages/GamePage.tsx
+++ b/packages/client/src/features/game/pages/GamePage.tsx
@@ -304,7 +304,6 @@ export default function GamePage() {
       <GameEffects />
       <ColorWave />
       {antiCheatKey && <AntiCheatToast key={antiCheatKey} />}
-      <OwnerTransferBanner />
       {!isSpectator && <AutopilotOverlay />}
       {(phase === 'round_end' || phase === 'game_over') && <Confetti />}
       {needsColorPick && <ColorPicker onPick={chooseColor} />}
@@ -319,6 +318,7 @@ export default function GamePage() {
           onJoinedFromSpectator={() => { setSpectator(false); clearSpectators(); }}
         />
       )}
+      <OwnerTransferBanner />
       <BgmToast song={bgmSongName} />
       <HotkeySettingsModal open={showHotkeys} onClose={() => setShowHotkeys(false)} />
     </div>

--- a/packages/server/src/ws/game-events.ts
+++ b/packages/server/src/ws/game-events.ts
@@ -79,6 +79,42 @@ export function clearPendingSpectatorJoins(roomCode: string): void {
   pendingSpectatorJoins.delete(roomCode);
 }
 
+async function autoQueueSpectatorOwner(
+  io: SocketIOServer, redis: KvStore, roomCode: string, session: GameSession,
+): Promise<void> {
+  const room = await getRoom(redis, roomCode);
+  if (!room) return;
+  const ownerId = room.ownerId;
+  if (session.getFullState().players.some(p => p.id === ownerId)) return;
+
+  if (!pendingSpectatorJoins.has(roomCode)) pendingSpectatorJoins.set(roomCode, new Map());
+  const pending = pendingSpectatorJoins.get(roomCode)!;
+  if (pending.has(ownerId)) return;
+  if (session.getPlayerCount() + pending.size >= MAX_PLAYERS) return;
+
+  const sockets = await io.in(roomCode).fetchSockets();
+  const ownerSocket = sockets.find(s =>
+    (s.data as SocketData).user?.userId === ownerId && (s.data as SocketData).isSpectator,
+  );
+  if (!ownerSocket) return;
+
+  const ownerData = ownerSocket.data as SocketData;
+  pending.set(ownerId, {
+    userId: ownerId,
+    nickname: ownerData.user.nickname,
+    avatarUrl: ownerData.user.avatarUrl,
+    role: ownerData.user.role,
+    isBot: ownerData.user.isBot,
+    socketId: ownerSocket.id,
+  });
+
+  io.to(roomCode).emit('game:spectator_queue', {
+    queue: [...pending.values()].map((p) => p.nickname),
+    nickname: ownerData.user.nickname,
+    joined: true,
+  });
+}
+
 interface NextRoundVoteState {
   votes: number;
   required: number;
@@ -359,6 +395,8 @@ export async function emitTerminalStateIfNeeded(
 
     const voteState = getNextRoundVoteState(roomCode, session);
     io.to(roomCode).emit('game:next_round_vote', voteState);
+
+    await autoQueueSpectatorOwner(io, redis, roomCode, session);
   }
 
   if (state.phase === 'game_over') {
@@ -634,6 +672,13 @@ export function registerGameEvents(
     const voteState = getNextRoundVoteState(roomCode, session);
     io.to(roomCode).emit('game:next_round_vote', voteState);
 
+    if (isOwner && data.isSpectator) {
+      const pending = pendingSpectatorJoins.get(roomCode);
+      if (!pending?.has(data.user.userId)) {
+        return callback?.({ success: false, error: '房主必须先加入下一轮才能开始' });
+      }
+    }
+
     if (isOwner && (hadAlreadyVoted || voteState.required === 0) && voteState.votes >= voteState.required) {
       const endedAt = roundEndTimestamps.get(roomCode);
       if (endedAt && Date.now() - endedAt < NEXT_ROUND_COOLDOWN_MS) {
@@ -655,51 +700,14 @@ export function registerGameEvents(
       return callback?.({ success: false, error: '已在游戏中' });
     }
 
-    const state = session.getFullState();
-    if (state.phase === 'round_end') {
-      if (session.getPlayerCount() >= MAX_PLAYERS) {
-        return callback?.({ success: false, error: `房间人数已达上限 (${MAX_PLAYERS})` });
-      }
-
-      const seats = await getRoomSeats(redis, roomCode);
-      const seatIdx = getFirstEmptySeatIndex(seats);
-      if (seatIdx === -1) {
-        return callback?.({ success: false, error: '没有空余座位' });
-      }
-
-      (socket.data as SocketData).isSpectator = false;
-      await removeSpectatorFromRoom(redis, roomCode, data.user.userId);
-      session.addPlayer({
-        id: data.user.userId,
-        name: data.user.nickname,
-        avatarUrl: data.user.avatarUrl,
-        role: data.user.role as any,
-        isBot: data.user.isBot,
-      });
-      await takeSeat(redis, roomCode, seatIdx, {
-        userId: data.user.userId,
-        nickname: data.user.nickname,
-        avatarUrl: data.user.avatarUrl,
-        role: data.user.role,
-        isBot: data.user.isBot ?? false,
-        ready: false,
-        connected: true,
-      });
-      await setUserRoom(redis, data.user.userId, roomCode);
-
-      persister.markDirty(roomCode, session.getFullState());
-      await persister.flushNow(roomCode);
-      await emitGameUpdate(io, roomCode, session, redis);
-      await broadcastSpectatorList(io, redis, roomCode);
-      const voteState = getNextRoundVoteState(roomCode, session);
-      io.to(roomCode).emit('game:next_round_vote', voteState);
-      return callback?.({ success: true, joined: true });
-    }
-
     if (!pendingSpectatorJoins.has(roomCode)) pendingSpectatorJoins.set(roomCode, new Map());
     const pending = pendingSpectatorJoins.get(roomCode)!;
 
     if (pending.has(data.user.userId)) {
+      const room = await getRoom(redis, roomCode);
+      if (room?.ownerId === data.user.userId) {
+        return callback?.({ success: false, error: '房主必须参加下一轮，如需取消请先移交房主' });
+      }
       pending.delete(data.user.userId);
       callback?.({ success: true, queued: false });
     } else {


### PR DESCRIPTION
## Summary
- 回合结束时自动将观战中的房主加入下局排队，避免房主忘记入座
- 房主观战状态下必须先加入下局才能开始新回合，防止无人开局
- 房主取消加入需先移交房主，确保始终有人能操作
- 移除 round_end 即时入座旧逻辑，统一走排队流程
- 加入按钮改为三态（下局加入 / 取消加入 / 已加入下局），房主已排队时锁定
- OwnerTransferBanner 移至计分板下方避免遮挡

## Test plan
- [ ] 房主观战时，回合结束后自动进入下局排队
- [ ] 房主观战未排队时，点击"开始下一轮"被拒绝并提示
- [ ] 房主已排队时，加入按钮显示"已加入下局"且不可取消
- [ ] 非房主观战者可正常加入/取消排队
- [ ] OwnerTransferBanner 不遮挡计分板内容
- [x] 服务端和客户端类型检查通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)