### PR TITLE
fix: 统一浮动面板样式、修复拖拽约束与全局交互限制

### DIFF
--- a/packages/client/src/app/App.tsx
+++ b/packages/client/src/app/App.tsx
@@ -38,6 +38,25 @@ export default function App() {
     return () => window.removeEventListener('auth:unauthorized', handleUnauthorized);
   }, []);
 
+  useEffect(() => {
+    const isEditable = (el: EventTarget | null) =>
+      el instanceof HTMLElement &&
+      !!el.closest('input, textarea, select, [contenteditable="true"], [data-allow-selection]');
+
+    const onContextMenu = (e: Event) => {
+      if (!isEditable(e.target)) e.preventDefault();
+    };
+    const onMouseDown = (e: Event) => {
+      if (e instanceof MouseEvent && e.detail > 1 && !isEditable(e.target)) e.preventDefault();
+    };
+    document.addEventListener('contextmenu', onContextMenu);
+    document.addEventListener('mousedown', onMouseDown);
+    return () => {
+      document.removeEventListener('contextmenu', onContextMenu);
+      document.removeEventListener('mousedown', onMouseDown);
+    };
+  }, []);
+
   return (
     <div className="flex min-h-svh flex-col font-game bg-background text-foreground">
       <AppRouter />

--- a/packages/client/src/features/game/components/BotAddButton.tsx
+++ b/packages/client/src/features/game/components/BotAddButton.tsx
@@ -34,12 +34,12 @@ export function BotAddButton() {
         <span>添加人机</span>
       </button>
       {open && (
-        <div className="absolute left-0 top-full z-50 mt-1.5 w-full rounded-xl bg-card/95 backdrop-blur-sm border border-white/10 p-1.5 shadow-xl animate-in fade-in zoom-in-95 duration-100">
+        <div className="absolute left-0 top-full z-50 mt-1.5 w-full glass-panel !rounded-xl py-1 animate-in fade-in zoom-in-95 duration-100">
           {DIFFICULTY_LIST.map((d) => (
             <button
               key={d.value}
               onClick={() => handleAdd(d.value)}
-              className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left hover:bg-white/8 cursor-pointer transition-colors group"
+              className="flex w-full items-center gap-3 px-3 py-2.5 text-left hover:bg-white/10 cursor-pointer transition-colors group"
             >
               <div
                 className="w-7 h-7 rounded-full flex items-center justify-center shrink-0 transition-transform group-hover:scale-110"

--- a/packages/client/src/features/game/components/OwnerTransferBanner.tsx
+++ b/packages/client/src/features/game/components/OwnerTransferBanner.tsx
@@ -26,7 +26,7 @@ export default function OwnerTransferBanner() {
 
   return (
     <div className="fixed top-16 left-1/2 -translate-x-1/2 z-modal animate-in fade-in slide-in-from-top-2 duration-200">
-      <div className="flex items-center gap-2 rounded-xl bg-card/95 backdrop-blur-sm border border-primary/30 shadow-xl px-4 py-2.5">
+      <div className="glass-panel !rounded-xl !border-primary/30 flex items-center gap-2 px-4 py-2.5">
         <Crown size={16} className="text-primary shrink-0" />
         <span className="text-sm text-foreground">
           房主已离线，<span className="font-bold text-primary tabular-nums">{seconds}s</span> 后转移房主

--- a/packages/client/src/features/game/components/PlayerActionMenu.tsx
+++ b/packages/client/src/features/game/components/PlayerActionMenu.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
-import { Crown, UserX, MicOff, Mic, Volume2 } from 'lucide-react';
-import { cn } from '@/shared/lib/utils';
+import { ArrowLeftRight, Crown, UserX, MicOff, Mic, Volume2 } from 'lucide-react';
 import { getSocket } from '@/shared/socket';
 import { useGatewayStore } from '@/shared/voice/gateway-store';
 import { useToastStore } from '@/shared/stores/toast-store';
@@ -105,10 +104,10 @@ export default function PlayerActionMenu({ target, isOwner, roomStatus, position
       </div>
       {hasSwapRequest && (
         <button
-          className="w-full text-left px-3 py-2 text-sm hover:bg-white/5 rounded-lg flex items-center gap-2 text-foreground cursor-pointer"
+          className="w-full flex items-center gap-2 px-3 py-2 text-sm text-foreground hover:bg-white/10 cursor-pointer transition-colors"
           onClick={() => { onSwapRequest(target.userId); onClose(); }}
         >
-          🔄 请求换座
+          <ArrowLeftRight size={14} /> 请求换座
         </button>
       )}
       {hasOwnerItems && !target.isBot && (
@@ -117,7 +116,7 @@ export default function PlayerActionMenu({ target, isOwner, roomStatus, position
             <Crown size={14} />
             移交房主
           </button>
-          <button onClick={kickPlayer} className="w-full flex items-center gap-2 px-3 py-2 text-sm text-destructive hover:bg-destructive/10 cursor-pointer transition-colors">
+          <button onClick={kickPlayer} className="w-full flex items-center gap-2 px-3 py-2 text-sm text-red-400 hover:bg-white/10 cursor-pointer transition-colors">
             <UserX size={14} />
             踢出房间
           </button>
@@ -130,7 +129,7 @@ export default function PlayerActionMenu({ target, isOwner, roomStatus, position
             <button
               key={d.value}
               onClick={() => { setBotDifficulty(target.userId, d.value); onClose(); }}
-              className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm hover:bg-white/10 cursor-pointer transition-colors"
+              className="w-full flex items-center gap-2 px-3 py-2 text-sm hover:bg-white/10 cursor-pointer transition-colors"
             >
               <span className={DIFFICULTY_DISPLAY[d.value].color}>●</span>
               <span>{d.label}</span>
@@ -138,7 +137,7 @@ export default function PlayerActionMenu({ target, isOwner, roomStatus, position
           ))}
           <button
             onClick={() => { removeBot(target.userId); onClose(); }}
-            className="w-full px-3 py-1.5 text-left text-sm text-red-400 hover:bg-white/10 cursor-pointer transition-colors"
+            className="w-full flex items-center gap-2 px-3 py-2 text-sm text-red-400 hover:bg-white/10 cursor-pointer transition-colors"
           >
             移除人机
           </button>

--- a/packages/client/src/features/game/components/PlayerListPanel.tsx
+++ b/packages/client/src/features/game/components/PlayerListPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 import { motion, useDragControls, AnimatePresence } from 'framer-motion';
 import { ArrowRightLeft, Bot, ChevronDown, Crown, Eye, GripHorizontal, UserPlus } from 'lucide-react';
 import { getSocket } from '@/shared/socket';
@@ -24,17 +24,20 @@ export default function PlayerListPanel() {
   const userId = useEffectiveUserId();
   const [collapsed, setCollapsed] = useState(false);
   const dragControls = useDragControls();
+  const constraintsRef = useRef<HTMLDivElement>(null);
 
   if (players.length === 0) return null;
 
   return (
+    <div ref={constraintsRef} className="fixed inset-0 pointer-events-none z-fab hidden md:block">
     <motion.div
       drag
+      dragConstraints={constraintsRef}
       dragControls={dragControls}
       dragListener={false}
       dragMomentum={false}
       dragElastic={0}
-      className="absolute top-12 right-3 z-topbar hidden md:block"
+      className="absolute top-12 right-3 pointer-events-auto"
     >
       <div className="rounded-card-ui bg-card/80 backdrop-blur-sm shadow-card shadow-tech border border-white/10 w-48">
         <div
@@ -179,5 +182,6 @@ export default function PlayerListPanel() {
         </AnimatePresence>
       </div>
     </motion.div>
+    </div>
   );
 }

--- a/packages/client/src/features/game/components/PlayerNode.tsx
+++ b/packages/client/src/features/game/components/PlayerNode.tsx
@@ -159,7 +159,6 @@ function PlayerNode({
         className="relative pointer-events-auto"
         style={{ width: avatarSize, height: avatarSize }}
         onClick={handleClick}
-        onContextMenu={(e) => e.preventDefault()}
         onTouchEnd={handleTouchEnd}
         onTouchCancel={handleTouchEnd}
       >

--- a/packages/client/src/features/game/components/QuickReaction.tsx
+++ b/packages/client/src/features/game/components/QuickReaction.tsx
@@ -36,7 +36,7 @@ export default function QuickReaction({ onSelect, onClose, anchorX, anchorY }: Q
         exit={{ opacity: 0, scale: 0.7, y: 6 }}
         transition={{ duration: 0.18, ease: 'easeOut' }}
       >
-        <div className="bg-card/90 backdrop-blur-sm rounded-xl border border-white/10 p-2 flex gap-1 mb-2">
+        <div className="glass-panel !rounded-xl p-2 flex gap-1 mb-2">
           {EMOJIS.map((emoji) => (
             <button
               key={emoji}

--- a/packages/client/src/features/game/components/SeatContextMenu.tsx
+++ b/packages/client/src/features/game/components/SeatContextMenu.tsx
@@ -3,6 +3,9 @@ import { ArrowLeftRight, Bot, Trash2, UserRoundPlus } from 'lucide-react';
 import type { BotDifficulty, RoomSeatPlayer } from '@uno-online/shared';
 import { DIFFICULTY_LIST } from '../constants/bot-difficulty';
 
+const menuItemClass = 'w-full flex items-center gap-2 px-3 py-2 text-sm text-foreground hover:bg-white/10 cursor-pointer transition-colors';
+const dangerItemClass = 'w-full flex items-center gap-2 px-3 py-2 text-sm text-red-400 hover:bg-white/10 cursor-pointer transition-colors';
+
 interface SeatContextMenuProps {
   seatIndex: number;
   player: RoomSeatPlayer | null;
@@ -31,31 +34,26 @@ export function SeatContextMenu({
     return () => document.removeEventListener('mousedown', handler);
   }, [onClose]);
 
-  const menuStyle: React.CSSProperties = {
-    position: 'fixed',
-    left: Math.min(position.x, window.innerWidth - 200),
-    top: Math.min(position.y, window.innerHeight - 300),
-    zIndex: 100,
-  };
+  const clampedX = Math.min(position.x, window.innerWidth - 200);
+  const clampedY = Math.min(position.y, window.innerHeight - 300);
 
   if (!player) {
     return (
-      <div ref={ref} style={menuStyle} className="w-48 rounded-xl bg-card/95 backdrop-blur-sm border border-white/10 p-1.5 shadow-xl animate-in fade-in zoom-in-95 duration-100">
-        <div className="px-3 py-1.5 text-xs text-muted-foreground">{seatIndex + 1}号位</div>
+      <div ref={ref} style={{ position: 'fixed', left: clampedX, top: clampedY, zIndex: 50 }} className="glass-panel !rounded-xl py-1 min-w-[160px] animate-in fade-in zoom-in-95 duration-100">
+        <div className="px-3 py-1.5 text-xs text-muted-foreground border-b border-white/5">{seatIndex + 1}号位</div>
         <button
-          className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-foreground hover:bg-white/8 cursor-pointer"
+          className={menuItemClass}
           onClick={() => { onTakeSeat(); onClose(); }}
         >
           <UserRoundPlus size={14} /> 入座
         </button>
         {isOwner && (
           <>
-            <div className="border-t border-white/5 my-1" />
-            <div className="px-3 py-1 text-xs text-muted-foreground">添加人机</div>
+            <div className="px-3 py-1 text-xs text-white/40">添加人机</div>
             {DIFFICULTY_LIST.map((d) => (
               <button
                 key={d.value}
-                className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-sm hover:bg-white/8 cursor-pointer"
+                className="w-full flex items-center gap-2.5 px-3 py-2 text-sm hover:bg-white/10 cursor-pointer transition-colors"
                 onClick={() => { onAddBot(d.value, seatIndex); onClose(); }}
               >
                 <div className="w-5 h-5 rounded-full flex items-center justify-center shrink-0" style={{ background: d.avatarBg }}>
@@ -73,11 +71,11 @@ export function SeatContextMenu({
 
   if (player.isBot) {
     return (
-      <div ref={ref} style={menuStyle} className="w-48 rounded-xl bg-card/95 backdrop-blur-sm border border-white/10 p-1.5 shadow-xl animate-in fade-in zoom-in-95 duration-100">
-        <div className="px-3 py-1.5 text-xs text-muted-foreground">{seatIndex + 1}号位 · {player.nickname}</div>
+      <div ref={ref} style={{ position: 'fixed', left: clampedX, top: clampedY, zIndex: 50 }} className="glass-panel !rounded-xl py-1 min-w-[160px] animate-in fade-in zoom-in-95 duration-100">
+        <div className="px-3 py-1.5 text-xs text-muted-foreground border-b border-white/5">{seatIndex + 1}号位 · {player.nickname}</div>
         {isMeSeated && (
           <button
-            className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-foreground hover:bg-white/8 cursor-pointer"
+            className={menuItemClass}
             onClick={() => { onSwapRequest(player.userId); onClose(); }}
           >
             <ArrowLeftRight size={14} /> 交换座位
@@ -85,12 +83,11 @@ export function SeatContextMenu({
         )}
         {isOwner && (
           <>
-            <div className="border-t border-white/5 my-1" />
-            <div className="px-3 py-1 text-xs text-muted-foreground">调整难度</div>
+            <div className="px-3 py-1 text-xs text-white/40">调整难度</div>
             {DIFFICULTY_LIST.map((d) => (
               <button
                 key={d.value}
-                className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-sm hover:bg-white/8 cursor-pointer"
+                className="w-full flex items-center gap-2.5 px-3 py-2 text-sm hover:bg-white/10 cursor-pointer transition-colors"
                 onClick={() => { onSetBotDifficulty(player.userId, d.value); onClose(); }}
               >
                 <div className="w-5 h-5 rounded-full flex items-center justify-center shrink-0" style={{ background: d.avatarBg }}>
@@ -99,9 +96,8 @@ export function SeatContextMenu({
                 <span className="text-foreground">{d.label}</span>
               </button>
             ))}
-            <div className="border-t border-white/5 my-1" />
             <button
-              className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-red-400 hover:bg-white/8 cursor-pointer"
+              className={dangerItemClass}
               onClick={() => { onRemoveBot(player.userId); onClose(); }}
             >
               <Trash2 size={14} /> 移除人机

--- a/packages/client/src/features/game/components/SettingsDrawer.tsx
+++ b/packages/client/src/features/game/components/SettingsDrawer.tsx
@@ -131,18 +131,26 @@ export default function SettingsDrawer({
               {(room?.settings?.allowSpectators ?? true) && (
                 <div className="flex items-center justify-between">
                   <label className="text-sm">观战模式</label>
-                  <select
-                    value={room?.settings?.spectatorMode ?? 'hidden'}
-                    onChange={(e) => getSocket().emit('room:update_settings', { spectatorMode: e.target.value as 'full' | 'hidden' })}
-                    className={cn(
-                      'bg-white/[0.06] text-foreground border border-white/10 rounded-xl px-3 py-1.5 text-sm outline-none cursor-pointer',
-                      !isOwner && 'opacity-50 cursor-default',
-                    )}
-                    disabled={!isOwner}
-                  >
-                    <option value="hidden">只看出牌</option>
-                    <option value="full">全透视</option>
-                  </select>
+                  <div className={cn('flex rounded-xl bg-white/[0.06] border border-white/10 p-0.5', !isOwner && 'opacity-50')}>
+                    {([['hidden', '只看出牌'], ['full', '全透视']] as const).map(([value, label]) => {
+                      const active = (room?.settings?.spectatorMode ?? 'hidden') === value;
+                      return (
+                        <button
+                          key={value}
+                          type="button"
+                          onClick={() => isOwner && getSocket().emit('room:update_settings', { spectatorMode: value })}
+                          disabled={!isOwner}
+                          className={cn(
+                            'px-3 py-1 rounded-lg text-sm transition-colors',
+                            isOwner ? 'cursor-pointer' : 'cursor-default',
+                            active ? 'bg-accent text-white' : 'text-muted-foreground hover:text-foreground',
+                          )}
+                        >
+                          {label}
+                        </button>
+                      );
+                    })}
+                  </div>
                 </div>
               )}
             </div>

--- a/packages/client/src/features/game/components/SpectatorSeats.tsx
+++ b/packages/client/src/features/game/components/SpectatorSeats.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, useRef } from 'react';
 import { motion } from 'framer-motion';
 import { Eye } from 'lucide-react';
 import { useSpectatorStore } from '../stores/spectator-store';
@@ -11,20 +11,23 @@ interface SpectatorSeatsProps {
 function SpectatorSeats({ top }: SpectatorSeatsProps) {
   const spectators = useSpectatorStore((s) => s.spectators);
   const pendingJoinQueue = useSpectatorStore((s) => s.pendingJoinQueue);
+  const constraintsRef = useRef<HTMLDivElement>(null);
 
   if (spectators.length === 0) return null;
 
   return (
-    <div
-      className="absolute left-0 right-0 z-10 flex justify-center"
-      style={top != null ? { top } : { bottom: 8 }}
-    >
-      <motion.div
-        drag
-        dragMomentum={false}
-        dragElastic={0}
-        className="flex items-center gap-2 bg-card/60 backdrop-blur-sm rounded-full px-3 py-1.5 border border-white/5 cursor-grab active:cursor-grabbing select-none"
+    <div ref={constraintsRef} className="absolute inset-0 z-fab pointer-events-none">
+      <div
+        className="absolute left-0 right-0 flex justify-center"
+        style={top != null ? { top } : { bottom: 8 }}
       >
+        <motion.div
+          drag
+          dragConstraints={constraintsRef}
+          dragMomentum={false}
+          dragElastic={0}
+          className="flex items-center gap-2 bg-card/60 backdrop-blur-sm rounded-full px-3 py-1.5 border border-white/5 cursor-grab active:cursor-grabbing select-none pointer-events-auto"
+        >
         <Eye size={12} className="text-muted-foreground shrink-0" />
         <div className="flex items-center gap-1">
           {spectators.map((s) => {
@@ -49,6 +52,7 @@ function SpectatorSeats({ top }: SpectatorSeatsProps) {
           })}
         </div>
       </motion.div>
+      </div>
     </div>
   );
 }

--- a/packages/client/src/features/game/components/ThrowItemPicker.tsx
+++ b/packages/client/src/features/game/components/ThrowItemPicker.tsx
@@ -87,7 +87,7 @@ export default function ThrowItemPicker({ onSelect, onClose, anchorX, anchorY }:
         exit={{ opacity: 0, scale: 0.7, y: 6 }}
         transition={{ duration: 0.18, ease: 'easeOut' }}
       >
-        <div className="bg-card/90 backdrop-blur-sm rounded-xl border border-white/10 p-2.5 flex gap-2 mb-2">
+        <div className="glass-panel !rounded-xl p-2.5 flex gap-2 mb-2">
           {ITEMS.map(({ emoji, label }) => (
             <button
               key={emoji}

--- a/packages/client/src/features/game/pages/GamePage.tsx
+++ b/packages/client/src/features/game/pages/GamePage.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useRef, useState } from 'react';
-import type { MouseEvent } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { Loader2, Eye, LogOut, UserPlus, X } from 'lucide-react';
 import { motion, AnimatePresence, LayoutGroup } from 'framer-motion';
@@ -163,18 +162,6 @@ export default function GamePage() {
     open_chat: () => openInfoDrawer('chat'),
   });
 
-  const isSelectionAllowed = (target: EventTarget | null) => {
-    if (!(target instanceof HTMLElement)) return false;
-    return Boolean(target.closest('[data-allow-selection], input, textarea, select, [contenteditable="true"]'));
-  };
-
-  const suppressContextMenu = (event: MouseEvent<HTMLDivElement>) => {
-    if (!isSelectionAllowed(event.target)) {
-      event.preventDefault();
-    }
-  };
-
-
   if (!phase) {
     return <div className="flex flex-1 items-center justify-center">
       <p className="text-muted-foreground">加载游戏中...</p>
@@ -182,15 +169,8 @@ export default function GamePage() {
   }
 
   return (
-    <div
-      className="flex h-screen flex-col relative overflow-hidden select-none"
-      onContextMenu={suppressContextMenu}
-      onMouseDown={(event) => {
-        if (event.detail > 1 && !isSelectionAllowed(event.target)) {
-          event.preventDefault();
-        }
-      }}
-    >
+    <div className="flex h-screen flex-col relative overflow-hidden">
+
       {connectionStatus !== 'connected' && (
         <div className="fixed inset-0 z-connection flex flex-col items-center justify-center gap-3 bg-black/75">
           <Loader2 size={36} className="animate-spin text-white" />
@@ -365,7 +345,7 @@ function SpectatorBar({ phase, onBackToLobby, onJoined }: { phase: string | null
   };
 
   return (
-    <div className="fixed top-14 left-1/2 -translate-x-1/2 z-actions bg-card/90 backdrop-blur-sm rounded-full px-3 py-2 text-sm text-muted-foreground flex items-center gap-2">
+    <div className="fixed top-14 left-1/2 -translate-x-1/2 z-actions glass-panel !rounded-full px-3 py-2 text-sm text-muted-foreground flex items-center gap-2">
       <Eye size={16} /> 观战中
       {queued ? (
         <button

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -186,6 +186,12 @@
     box-sizing: border-box;
     margin: 0;
     padding: 0;
+    -webkit-user-select: none;
+    user-select: none;
+  }
+  input, textarea, [contenteditable="true"], [data-allow-selection] {
+    -webkit-user-select: text;
+    user-select: text;
   }
   body {
     @apply bg-background text-foreground font-[family-name:var(--font-ui)];
@@ -207,6 +213,10 @@
   input {
     font-family: var(--font-ui);
     outline: none;
+  }
+  img {
+    -webkit-user-drag: none;
+    user-select: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- 统一所有弹出菜单/浮动面板为 `glass-panel` 风格（SeatContextMenu、PlayerActionMenu、BotAddButton、QuickReaction、ThrowItemPicker、OwnerTransferBanner、观战条）
- 修复玩家列表和观战席可被拖出屏幕的问题，添加 `dragConstraints` 限制
- 提升悬浮窗 z-index 到 `z-fab`(50)，防止被手牌区域(`z-actions`=20)遮挡
- 全局禁用右键菜单和文本选择（`input`/`textarea`/`contenteditable` 除外）
- 全局禁止图片原生拖拽（`-webkit-user-drag: none`）
- 观战模式设置从 `<select>` 下拉改为分段切换按钮
- 统一菜单项 hover(`bg-white/10`)、间距(`py-2`)、图标（emoji→Lucide）

## Test plan
- [ ] 房间页点击空座位、点击玩家头像，确认两个菜单样式统一
- [ ] 拖拽玩家列表和观战席面板，确认无法拖出屏幕
- [ ] 将面板拖到手牌区域，确认面板不会被手牌遮挡
- [ ] 在大厅/房间/游戏各页面右键，确认菜单被禁用
- [ ] 确认输入框内仍可正常选择文本和右键
- [ ] 确认头像图片无法被浏览器原生拖拽
- [ ] 房间设置中观战模式切换正常工作

🤖 Generated with [Claude Code](https://claude.com/claude-code)