### PR TITLE
fix: 积分板中 AI 机器人显示为已准备状态

### DIFF
--- a/packages/server/src/ws/game-events.ts
+++ b/packages/server/src/ws/game-events.ts
@@ -225,11 +225,12 @@ function scheduleAutopilotJumpIn(
 function getNextRoundVoteState(roomCode: string, session: GameSession): NextRoundVoteState {
   const players = session.getFullState().players;
   const humanPlayerIds = new Set(players.filter((p) => !p.isBot).map((p) => p.id));
-  const voters = [...(nextRoundVotes.get(roomCode) ?? new Set<string>())].filter((id) => humanPlayerIds.has(id));
+  const allVoters = [...(nextRoundVotes.get(roomCode) ?? new Set<string>())];
+  const humanVoters = allVoters.filter((id) => humanPlayerIds.has(id));
   return {
-    votes: voters.length,
+    votes: humanVoters.length,
     required: humanPlayerIds.size,
-    voters,
+    voters: allVoters,
   };
 }
 


### PR DESCRIPTION
## Summary
- `getNextRoundVoteState` 之前将 `voters` 数组过滤为仅人类玩家 ID，导致自动投票的 AI 机器人在积分板 UI 中始终显示为"等待中"
- 现在 `voters` 返回所有已投票的 ID（AI、托管、断线玩家），客户端可正确判定准备状态
- `votes` / `required` 仍只计算人类玩家，"已有 X/Y 人同意继续下一轮" 进度逻辑不受影响

## Test plan
- [ ] 创建含 AI 机器人的房间，完成一轮后查看积分板，AI 应显示为 ✓ 已准备
- [ ] 确认"已有 X/Y 人同意"仅统计人类玩家
- [ ] 托管和断线玩家也应显示为已准备

🤖 Generated with [Claude Code](https://claude.com/claude-code)