### PR TITLE
refactor: 提取菜单样式常量、移除冗余处理器、优化 fetchSockets 调用

### DIFF
--- a/packages/client/src/app/App.tsx
+++ b/packages/client/src/app/App.tsx
@@ -46,14 +46,9 @@ export default function App() {
     const onContextMenu = (e: Event) => {
       if (!isEditable(e.target)) e.preventDefault();
     };
-    const onMouseDown = (e: Event) => {
-      if (e instanceof MouseEvent && e.detail > 1 && !isEditable(e.target)) e.preventDefault();
-    };
     document.addEventListener('contextmenu', onContextMenu);
-    document.addEventListener('mousedown', onMouseDown);
     return () => {
       document.removeEventListener('contextmenu', onContextMenu);
-      document.removeEventListener('mousedown', onMouseDown);
     };
   }, []);
 

--- a/packages/client/src/features/game/components/PlayerActionMenu.tsx
+++ b/packages/client/src/features/game/components/PlayerActionMenu.tsx
@@ -7,6 +7,7 @@ import { showConfirm } from '@/shared/stores/confirm-store';
 import type { RoomPlayer } from '@/shared/stores/room-store';
 import { useBotManagement } from '../hooks/useBotManagement';
 import { DIFFICULTY_DISPLAY, DIFFICULTY_LIST } from '../constants/bot-difficulty';
+import { menuItemClass, dangerItemClass } from '../constants/menu-styles';
 
 interface PlayerActionMenuProps {
   target: RoomPlayer;
@@ -104,7 +105,7 @@ export default function PlayerActionMenu({ target, isOwner, roomStatus, position
       </div>
       {hasSwapRequest && (
         <button
-          className="w-full flex items-center gap-2 px-3 py-2 text-sm text-foreground hover:bg-white/10 cursor-pointer transition-colors"
+          className={menuItemClass}
           onClick={() => { onSwapRequest(target.userId); onClose(); }}
         >
           <ArrowLeftRight size={14} /> 请求换座
@@ -112,11 +113,11 @@ export default function PlayerActionMenu({ target, isOwner, roomStatus, position
       )}
       {hasOwnerItems && !target.isBot && (
         <>
-          <button onClick={transferOwner} className="w-full flex items-center gap-2 px-3 py-2 text-sm hover:bg-white/10 cursor-pointer transition-colors">
+          <button onClick={transferOwner} className={menuItemClass}>
             <Crown size={14} />
             移交房主
           </button>
-          <button onClick={kickPlayer} className="w-full flex items-center gap-2 px-3 py-2 text-sm text-red-400 hover:bg-white/10 cursor-pointer transition-colors">
+          <button onClick={kickPlayer} className={dangerItemClass}>
             <UserX size={14} />
             踢出房间
           </button>
@@ -129,7 +130,7 @@ export default function PlayerActionMenu({ target, isOwner, roomStatus, position
             <button
               key={d.value}
               onClick={() => { setBotDifficulty(target.userId, d.value); onClose(); }}
-              className="w-full flex items-center gap-2 px-3 py-2 text-sm hover:bg-white/10 cursor-pointer transition-colors"
+              className={menuItemClass}
             >
               <span className={DIFFICULTY_DISPLAY[d.value].color}>●</span>
               <span>{d.label}</span>
@@ -137,14 +138,14 @@ export default function PlayerActionMenu({ target, isOwner, roomStatus, position
           ))}
           <button
             onClick={() => { removeBot(target.userId); onClose(); }}
-            className="w-full flex items-center gap-2 px-3 py-2 text-sm text-red-400 hover:bg-white/10 cursor-pointer transition-colors"
+            className={dangerItemClass}
           >
             移除人机
           </button>
         </>
       )}
       {hasForceMute && (
-        <button onClick={toggleForceMute} className="w-full flex items-center gap-2 px-3 py-2 text-sm hover:bg-white/10 cursor-pointer transition-colors">
+        <button onClick={toggleForceMute} className={menuItemClass}>
           {isForceMuted ? <Mic size={14} /> : <MicOff size={14} />}
           {isForceMuted ? '解除静音' : '强制静音'}
         </button>

--- a/packages/client/src/features/game/components/SeatContextMenu.tsx
+++ b/packages/client/src/features/game/components/SeatContextMenu.tsx
@@ -2,9 +2,7 @@ import { useEffect, useRef } from 'react';
 import { ArrowLeftRight, Bot, Trash2, UserRoundPlus } from 'lucide-react';
 import type { BotDifficulty, RoomSeatPlayer } from '@uno-online/shared';
 import { DIFFICULTY_LIST } from '../constants/bot-difficulty';
-
-const menuItemClass = 'w-full flex items-center gap-2 px-3 py-2 text-sm text-foreground hover:bg-white/10 cursor-pointer transition-colors';
-const dangerItemClass = 'w-full flex items-center gap-2 px-3 py-2 text-sm text-red-400 hover:bg-white/10 cursor-pointer transition-colors';
+import { menuItemClass, dangerItemClass } from '../constants/menu-styles';
 
 interface SeatContextMenuProps {
   seatIndex: number;
@@ -53,7 +51,7 @@ export function SeatContextMenu({
             {DIFFICULTY_LIST.map((d) => (
               <button
                 key={d.value}
-                className="w-full flex items-center gap-2.5 px-3 py-2 text-sm hover:bg-white/10 cursor-pointer transition-colors"
+                className="w-full flex items-center gap-2 px-3 py-2 text-sm hover:bg-white/10 cursor-pointer transition-colors"
                 onClick={() => { onAddBot(d.value, seatIndex); onClose(); }}
               >
                 <div className="w-5 h-5 rounded-full flex items-center justify-center shrink-0" style={{ background: d.avatarBg }}>
@@ -87,7 +85,7 @@ export function SeatContextMenu({
             {DIFFICULTY_LIST.map((d) => (
               <button
                 key={d.value}
-                className="w-full flex items-center gap-2.5 px-3 py-2 text-sm hover:bg-white/10 cursor-pointer transition-colors"
+                className="w-full flex items-center gap-2 px-3 py-2 text-sm hover:bg-white/10 cursor-pointer transition-colors"
                 onClick={() => { onSetBotDifficulty(player.userId, d.value); onClose(); }}
               >
                 <div className="w-5 h-5 rounded-full flex items-center justify-center shrink-0" style={{ background: d.avatarBg }}>

--- a/packages/client/src/features/game/components/SpectatorSeats.tsx
+++ b/packages/client/src/features/game/components/SpectatorSeats.tsx
@@ -28,30 +28,30 @@ function SpectatorSeats({ top }: SpectatorSeatsProps) {
           dragElastic={0}
           className="flex items-center gap-2 bg-card/60 backdrop-blur-sm rounded-full px-3 py-1.5 border border-white/5 cursor-grab active:cursor-grabbing select-none pointer-events-auto"
         >
-        <Eye size={12} className="text-muted-foreground shrink-0" />
-        <div className="flex items-center gap-1">
-          {spectators.map((s) => {
-            const queued = pendingJoinQueue.includes(s.nickname);
-            return (
-              <div
-                key={s.nickname}
-                className={cn(
-                  'w-7 h-7 rounded-full flex items-center justify-center text-xs border-2 shrink-0 overflow-hidden',
-                  queued
-                    ? 'bg-accent/20 border-accent/40 text-accent'
-                    : 'bg-white/10 border-white/10 text-muted-foreground',
-                  !s.connected && 'opacity-40',
-                )}
-                title={s.nickname + (queued ? ' (下局加入)' : '') + (!s.connected ? ' (已断线)' : '')}
-              >
-                {s.avatarUrl
-                  ? <img src={s.avatarUrl} alt={s.nickname} className="w-full h-full object-cover" referrerPolicy="no-referrer" onError={(e) => { e.currentTarget.style.display = 'none'; }} />
-                  : s.nickname.charAt(0).toUpperCase()}
-              </div>
-            );
-          })}
-        </div>
-      </motion.div>
+          <Eye size={12} className="text-muted-foreground shrink-0" />
+          <div className="flex items-center gap-1">
+            {spectators.map((s) => {
+              const queued = pendingJoinQueue.includes(s.nickname);
+              return (
+                <div
+                  key={s.nickname}
+                  className={cn(
+                    'w-7 h-7 rounded-full flex items-center justify-center text-xs border-2 shrink-0 overflow-hidden',
+                    queued
+                      ? 'bg-accent/20 border-accent/40 text-accent'
+                      : 'bg-white/10 border-white/10 text-muted-foreground',
+                    !s.connected && 'opacity-40',
+                  )}
+                  title={s.nickname + (queued ? ' (下局加入)' : '') + (!s.connected ? ' (已断线)' : '')}
+                >
+                  {s.avatarUrl
+                    ? <img src={s.avatarUrl} alt={s.nickname} className="w-full h-full object-cover" referrerPolicy="no-referrer" onError={(e) => { e.currentTarget.style.display = 'none'; }} />
+                    : s.nickname.charAt(0).toUpperCase()}
+                </div>
+              );
+            })}
+          </div>
+        </motion.div>
       </div>
     </div>
   );

--- a/packages/client/src/features/game/constants/menu-styles.ts
+++ b/packages/client/src/features/game/constants/menu-styles.ts
@@ -1,0 +1,2 @@
+export const menuItemClass = 'w-full flex items-center gap-2 px-3 py-2 text-sm text-foreground hover:bg-white/10 cursor-pointer transition-colors';
+export const dangerItemClass = 'w-full flex items-center gap-2 px-3 py-2 text-sm text-red-400 hover:bg-white/10 cursor-pointer transition-colors';

--- a/packages/server/src/ws/game-events.ts
+++ b/packages/server/src/ws/game-events.ts
@@ -254,6 +254,7 @@ async function processPendingSpectatorJoins(
 
   const joined: string[] = [];
   const userRoomWrites: Promise<void>[] = [];
+  const allSockets = await io.in(roomCode).fetchSockets();
   for (const [userId, info] of pending) {
     if (session.getPlayerCount() >= MAX_PLAYERS) break;
     if (session.getFullState().players.some((p) => p.id === userId)) {
@@ -261,7 +262,6 @@ async function processPendingSpectatorJoins(
       continue;
     }
 
-    const allSockets = await io.in(roomCode).fetchSockets();
     const sock = allSockets.find(s => (s.data as SocketData).user?.userId === userId);
     if (!sock) {
       joined.push(userId);


### PR DESCRIPTION
## Summary
- 将 `menuItemClass` / `dangerItemClass` 提取到 `constants/menu-styles.ts`，`PlayerActionMenu` 和 `SeatContextMenu` 共享引用，消除 7 处重复内联类名
- 统一 `SeatContextMenu` 机器人难度按钮 `gap-2.5` → `gap-2`
- 移除 `App.tsx` 中多余的 `onMouseDown` 双击防选中处理器（全局 CSS `user-select: none` 已覆盖）
- 将 `processPendingSpectatorJoins` 中 `fetchSockets()` 提到循环外，避免 N+1 调用
- 修复 `SpectatorSeats.tsx` 缩进

## Test plan
- [ ] 右键菜单在游戏页面仍被正确拦截，输入框等可编辑区域不受影响
- [ ] 座位右键菜单、玩家操作菜单样式与之前一致
- [ ] 观战者加入队列功能正常
- [ ] 拖拽浮动面板（玩家列表、观战席）行为不变

🤖 Generated with [Claude Code](https://claude.com/claude-code)