### PR TITLE
fix: 头像裁切框显示空白，blob URL 被提前释放

### DIFF
--- a/packages/client/src/features/auth/components/AvatarUpload.tsx
+++ b/packages/client/src/features/auth/components/AvatarUpload.tsx
@@ -2,7 +2,7 @@ import { useRef, useState, useCallback } from 'react';
 import { Camera, Loader2 } from 'lucide-react';
 import Cropper from 'react-easy-crop';
 import type { Area } from 'react-easy-crop';
-import { loadImage, cropAndCompress } from '@/shared/utils/image-compress';
+import { loadImage, cropAndCompress, revokeImageSrc } from '@/shared/utils/image-compress';
 import { Button } from '@/shared/components/ui/Button';
 
 interface Props {
@@ -39,6 +39,12 @@ export default function AvatarUpload({ avatarUrl, size = 96, onUpload }: Props) 
     }
   };
 
+  const cleanup = () => {
+    if (imageEl) revokeImageSrc(imageEl);
+    setImageSrc(null);
+    setImageEl(null);
+  };
+
   const handleConfirm = () => {
     if (!imageEl || !croppedArea) return;
     setUploading(true);
@@ -47,14 +53,12 @@ export default function AvatarUpload({ avatarUrl, size = 96, onUpload }: Props) 
       onUpload(dataUrl);
     } finally {
       setUploading(false);
-      setImageSrc(null);
-      setImageEl(null);
+      cleanup();
     }
   };
 
   const handleCancel = () => {
-    setImageSrc(null);
-    setImageEl(null);
+    cleanup();
   };
 
   return (

--- a/packages/client/src/shared/utils/image-compress.ts
+++ b/packages/client/src/shared/utils/image-compress.ts
@@ -6,10 +6,14 @@ export function loadImage(file: File): Promise<HTMLImageElement> {
   return new Promise((resolve, reject) => {
     const img = new Image();
     const url = URL.createObjectURL(file);
-    img.onload = () => { URL.revokeObjectURL(url); resolve(img); };
+    img.onload = () => resolve(img);
     img.onerror = () => { URL.revokeObjectURL(url); reject(new Error('Failed to load image')); };
     img.src = url;
   });
+}
+
+export function revokeImageSrc(img: HTMLImageElement) {
+  if (img.src.startsWith('blob:')) URL.revokeObjectURL(img.src);
 }
 
 export function cropAndCompress(img: HTMLImageElement, croppedArea: Area): string {


### PR DESCRIPTION
## Summary
- `loadImage` 在 `onload` 中立即 `revokeObjectURL`，Cropper 组件加载已失效的 blob URL 导致裁切框空白
- 改为裁切确认或取消时才释放 blob URL

## Test plan
- [ ] 上传头像，确认裁切框正常显示图片
- [ ] 裁切确认后头像正常更新
- [ ] 取消裁切无内存泄漏（blob URL 被释放）

🤖 Generated with [Claude Code](https://claude.com/claude-code)