### PR TITLE
feat: 头像裁切支持旋转

### DIFF
--- a/packages/client/src/features/auth/components/AvatarUpload.tsx
+++ b/packages/client/src/features/auth/components/AvatarUpload.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState, useCallback } from 'react';
-import { Camera, Loader2 } from 'lucide-react';
+import { Camera, Loader2, RotateCw } from 'lucide-react';
 import Cropper from 'react-easy-crop';
 import type { Area } from 'react-easy-crop';
 import { loadImage, cropAndCompress, revokeImageSrc } from '@/shared/utils/image-compress';
@@ -18,6 +18,7 @@ export default function AvatarUpload({ avatarUrl, size = 96, onUpload }: Props) 
   const [imageEl, setImageEl] = useState<HTMLImageElement | null>(null);
   const [crop, setCrop] = useState({ x: 0, y: 0 });
   const [zoom, setZoom] = useState(1);
+  const [rotation, setRotation] = useState(0);
   const [croppedArea, setCroppedArea] = useState<Area | null>(null);
 
   const onCropComplete = useCallback((_: Area, croppedPixels: Area) => {
@@ -34,6 +35,7 @@ export default function AvatarUpload({ avatarUrl, size = 96, onUpload }: Props) 
       setImageSrc(img.src);
       setCrop({ x: 0, y: 0 });
       setZoom(1);
+      setRotation(0);
     } catch {
       // ignore
     }
@@ -49,7 +51,7 @@ export default function AvatarUpload({ avatarUrl, size = 96, onUpload }: Props) 
     if (!imageEl || !croppedArea) return;
     setUploading(true);
     try {
-      const dataUrl = cropAndCompress(imageEl, croppedArea);
+      const dataUrl = cropAndCompress(imageEl, croppedArea, rotation);
       onUpload(dataUrl);
     } finally {
       setUploading(false);
@@ -99,24 +101,36 @@ export default function AvatarUpload({ avatarUrl, size = 96, onUpload }: Props) 
                 image={imageSrc}
                 crop={crop}
                 zoom={zoom}
+                rotation={rotation}
                 aspect={1}
                 cropShape="round"
                 showGrid={false}
                 onCropChange={setCrop}
                 onZoomChange={setZoom}
+                onRotationChange={setRotation}
                 onCropComplete={onCropComplete}
               />
             </div>
             <div className="flex flex-col gap-3 p-4">
-              <input
-                type="range"
-                min={1}
-                max={3}
-                step={0.1}
-                value={zoom}
-                onChange={(e) => setZoom(Number(e.target.value))}
-                className="w-full accent-primary"
-              />
+              <div className="flex items-center gap-2">
+                <input
+                  type="range"
+                  min={1}
+                  max={3}
+                  step={0.1}
+                  value={zoom}
+                  onChange={(e) => setZoom(Number(e.target.value))}
+                  className="flex-1 accent-primary"
+                />
+                <button
+                  type="button"
+                  onClick={() => setRotation((r) => (r + 90) % 360)}
+                  className="shrink-0 p-1.5 rounded-lg text-muted-foreground hover:text-white hover:bg-white/10 transition-colors"
+                  title="旋转 90°"
+                >
+                  <RotateCw size={18} />
+                </button>
+              </div>
               <div className="flex gap-2">
                 <Button type="button" variant="ghost" className="flex-1" onClick={handleCancel} sound="click">
                   取消

--- a/packages/client/src/shared/utils/image-compress.ts
+++ b/packages/client/src/shared/utils/image-compress.ts
@@ -16,16 +16,40 @@ export function revokeImageSrc(img: HTMLImageElement) {
   if (img.src.startsWith('blob:')) URL.revokeObjectURL(img.src);
 }
 
-export function cropAndCompress(img: HTMLImageElement, croppedArea: Area): string {
+export function cropAndCompress(img: HTMLImageElement, croppedArea: Area, rotation = 0): string {
   const canvas = document.createElement('canvas');
   canvas.width = TARGET_SIZE;
   canvas.height = TARGET_SIZE;
   const ctx = canvas.getContext('2d')!;
-  ctx.drawImage(
-    img,
-    croppedArea.x, croppedArea.y, croppedArea.width, croppedArea.height,
-    0, 0, TARGET_SIZE, TARGET_SIZE,
-  );
+
+  if (rotation === 0) {
+    ctx.drawImage(
+      img,
+      croppedArea.x, croppedArea.y, croppedArea.width, croppedArea.height,
+      0, 0, TARGET_SIZE, TARGET_SIZE,
+    );
+  } else {
+    const rad = (rotation * Math.PI) / 180;
+    const sin = Math.abs(Math.sin(rad));
+    const cos = Math.abs(Math.cos(rad));
+    const rw = img.naturalWidth * cos + img.naturalHeight * sin;
+    const rh = img.naturalWidth * sin + img.naturalHeight * cos;
+
+    const tmp = document.createElement('canvas');
+    tmp.width = rw;
+    tmp.height = rh;
+    const tctx = tmp.getContext('2d')!;
+    tctx.translate(rw / 2, rh / 2);
+    tctx.rotate(rad);
+    tctx.drawImage(img, -img.naturalWidth / 2, -img.naturalHeight / 2);
+
+    ctx.drawImage(
+      tmp,
+      croppedArea.x, croppedArea.y, croppedArea.width, croppedArea.height,
+      0, 0, TARGET_SIZE, TARGET_SIZE,
+    );
+  }
+
   return canvas.toDataURL('image/png');
 }
 


### PR DESCRIPTION
## Summary
- Cropper 启用 `rotation` 支持拖拽旋转
- 缩放滑块旁添加旋转 90° 按钮
- `cropAndCompress` 支持旋转角度，先旋转原图到临时 canvas 再裁切

## Test plan
- [ ] 上传头像，点击旋转按钮确认图片每次旋转 90°
- [ ] 拖拽旋转功能正常
- [ ] 旋转后裁切确认，头像显示正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)