### PR TITLE
feat: 支持检测客户端（Caddy）更新

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -22,6 +22,7 @@
 	header {
 		X-Content-Type-Options "nosniff"
 		Referrer-Policy "strict-origin-when-cross-origin"
+		X-Instance-Start "{$INSTANCE_START}"
 		-Server
 	}
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,3 +55,4 @@ COPY Caddyfile /etc/caddy/Caddyfile
 COPY --from=build-client /app/packages/client/dist/ /srv/
 COPY --from=build-admin /app/packages/admin/dist/ /srv/admin/
 EXPOSE 80 443
+CMD ["sh", "-c", "INSTANCE_START=$(date -u +%Y-%m-%dT%H:%M:%SZ) exec caddy run --config /etc/caddy/Caddyfile --adapter caddyfile"]

--- a/packages/client/src/shared/components/ServerUpdateDialog.tsx
+++ b/packages/client/src/shared/components/ServerUpdateDialog.tsx
@@ -27,12 +27,12 @@ export default function ServerUpdateDialog() {
             className="relative w-full max-w-[380px] glass-panel"
           >
             <div className="flex items-center gap-2 border-b border-white/5 px-6 py-4 text-lg font-bold">
-              <RefreshCw size={18} className="text-accent" /> 服务器已更新
+              <RefreshCw size={18} className="text-accent" /> 检测到新版本
             </div>
 
             <div className="px-6 py-5">
               <p className="text-sm text-foreground/90">
-                服务器刚刚完成了一次更新，请刷新页面以加载最新版本。
+                检测到版本更新，请刷新页面以加载最新版本。
               </p>
             </div>
 

--- a/packages/client/src/shared/socket.ts
+++ b/packages/client/src/shared/socket.ts
@@ -35,6 +35,18 @@ function clearAuthSession(): void {
   useAuthStore.setState({ user: null, token: null, loading: false, initialized: true });
 }
 
+async function checkCaddyVersion(): Promise<void> {
+  try {
+    const res = await fetch('/healthz', { method: 'HEAD', cache: 'no-store' });
+    const instanceStart = res.headers.get('X-Instance-Start');
+    if (instanceStart) {
+      useServerVersionStore.getState().setClientVersion(instanceStart);
+    }
+  } catch {
+    // Caddy header unavailable (e.g. dev mode) — skip
+  }
+}
+
 export function getSocket(): TypedSocket {
   if (!socket) {
     const token = currentToken();
@@ -220,7 +232,7 @@ export function getSocket(): TypedSocket {
     });
 
     socket.on('server:version', (data) => {
-      useServerVersionStore.getState().setVersion(data.version);
+      useServerVersionStore.getState().setServerVersion(data.version);
       if (data.serverTime) setServerTimeOffset(data.serverTime);
     });
 
@@ -240,6 +252,7 @@ export function getSocket(): TypedSocket {
       connectionStatusCallback?.('connected');
       measureLatency();
       latencyInterval = setInterval(measureLatency, 30_000);
+      checkCaddyVersion();
     });
 
     socket.on('disconnect', () => {

--- a/packages/client/src/shared/stores/server-version-store.ts
+++ b/packages/client/src/shared/stores/server-version-store.ts
@@ -1,20 +1,31 @@
 import { create } from 'zustand';
 
 interface ServerVersionState {
-  initialVersion: string | null;
+  initialServerVersion: string | null;
+  initialClientVersion: string | null;
   needsRefresh: boolean;
-  setVersion: (version: string) => void;
+  setServerVersion: (version: string) => void;
+  setClientVersion: (version: string) => void;
   dismiss: () => void;
 }
 
 export const useServerVersionStore = create<ServerVersionState>((set, get) => ({
-  initialVersion: null,
+  initialServerVersion: null,
+  initialClientVersion: null,
   needsRefresh: false,
-  setVersion: (version) => {
-    const { initialVersion } = get();
-    if (!initialVersion) {
-      set({ initialVersion: version });
-    } else if (version !== initialVersion) {
+  setServerVersion: (version) => {
+    const { initialServerVersion } = get();
+    if (!initialServerVersion) {
+      set({ initialServerVersion: version });
+    } else if (version !== initialServerVersion) {
+      set({ needsRefresh: true });
+    }
+  },
+  setClientVersion: (version) => {
+    const { initialClientVersion } = get();
+    if (!initialClientVersion) {
+      set({ initialClientVersion: version });
+    } else if (version !== initialClientVersion) {
       set({ needsRefresh: true });
     }
   },


### PR DESCRIPTION
## Summary

- Caddy 启动时生成 `INSTANCE_START` 时间戳，通过 `X-Instance-Start` 响应头暴露
- 客户端每次 Socket.IO 连接/重连时 HEAD `/healthz` 读取该头，检测 Caddy 是否重启
- 扩展 `server-version-store`，同时追踪服务端和客户端版本变化，任一变化触发刷新提示
- 更新弹窗文案为通用的「检测到新版本」，覆盖服务端和客户端两种更新场景

## Test plan

- [ ] 构建 Caddy 镜像，验证响应头 `X-Instance-Start` 存在且为 ISO 时间戳
- [ ] 重启 Caddy 容器，确认客户端弹出「检测到新版本」提示
- [ ] 仅重启 Server 容器，确认仍然能检测到服务端更新
- [ ] 本地 dev 模式（无 Caddy）下确认无报错、不弹窗

🤖 Generated with [Claude Code](https://claude.com/claude-code)