### PR TITLE
fix: 更新 bot-names 测试以匹配扩充后的名字库

### DIFF
--- a/packages/shared/tests/bot/bot-names.test.ts
+++ b/packages/shared/tests/bot/bot-names.test.ts
@@ -2,13 +2,19 @@ import { describe, it, expect } from 'vitest';
 import { BOT_NAMES, pickBotName } from '../../src/rules/bot/bot-names';
 
 describe('BOT_NAMES', () => {
-  it('has 26 names (A-Z)', () => {
-    expect(BOT_NAMES).toHaveLength(26);
+  it('covers all 26 letters (A-Z)', () => {
+    const firstLetters = new Set(BOT_NAMES.map(n => n[0]!.toUpperCase()));
+    expect(firstLetters.size).toBe(26);
   });
 
-  it('each name starts with a unique letter', () => {
-    const firstLetters = BOT_NAMES.map(n => n[0]!.toUpperCase());
-    expect(new Set(firstLetters).size).toBe(26);
+  it('has equal number of names per letter', () => {
+    const groups = new Map<string, number>();
+    for (const name of BOT_NAMES) {
+      const letter = name[0]!.toUpperCase();
+      groups.set(letter, (groups.get(letter) ?? 0) + 1);
+    }
+    const counts = [...groups.values()];
+    expect(new Set(counts).size).toBe(1);
   });
 });
 


### PR DESCRIPTION
## Summary

- #163 将 Bot 名字从每字母 1 个扩充到 6 个（26 → 156），测试未同步更新导致失败
- 移除硬编码的 `toHaveLength(26)`，改为验证覆盖 A-Z 全部 26 个字母且每字母名字数量一致

## Test plan

- [x] `pnpm --filter shared test` 全部通过（22 files, 287 tests）

🤖 Generated with [Claude Code](https://claude.com/claude-code)