### PR TITLE
feat: 头像裁切支持自定义旋转角度

### DIFF
--- a/packages/client/src/features/auth/components/AvatarUpload.tsx
+++ b/packages/client/src/features/auth/components/AvatarUpload.tsx
@@ -122,6 +122,18 @@ export default function AvatarUpload({ avatarUrl, size = 96, onUpload }: Props) 
                   onChange={(e) => setZoom(Number(e.target.value))}
                   className="flex-1 accent-primary"
                 />
+              </div>
+              <div className="flex items-center gap-2">
+                <input
+                  type="range"
+                  min={0}
+                  max={360}
+                  step={1}
+                  value={rotation}
+                  onChange={(e) => setRotation(Number(e.target.value))}
+                  className="flex-1 accent-primary"
+                />
+                <span className="shrink-0 w-9 text-right text-xs tabular-nums text-muted-foreground">{rotation}°</span>
                 <button
                   type="button"
                   onClick={() => setRotation((r) => (r + 90) % 360)}


### PR DESCRIPTION
## Summary

- 新增 0-360° 旋转滑块，支持任意角度微调
- 显示当前旋转角度数值
- 保留 90° 快捷旋转按钮

## Test plan

- [ ] 拖动旋转滑块，确认图片实时跟随旋转
- [ ] 角度数字实时更新
- [ ] 点击 90° 按钮，滑块位置同步跳转
- [ ] 确认裁切后输出的图片旋转角度正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)