### PR TITLE
fix: Turnstile token 过期后清空，防止提交失效 token

### DIFF
--- a/packages/client/src/features/auth/pages/HomePage.tsx
+++ b/packages/client/src/features/auth/pages/HomePage.tsx
@@ -153,7 +153,7 @@ export default function HomePage() {
             />
           </div>
           {authConfig?.turnstileSiteKey && (
-            <Turnstile sitekey={authConfig.turnstileSiteKey} onVerify={setTurnstileToken} />
+            <Turnstile sitekey={authConfig.turnstileSiteKey} onVerify={setTurnstileToken} onExpire={() => setTurnstileToken(null)} />
           )}
           {fieldError && <p className="text-sm text-destructive m-0">{fieldError}</p>}
           <Button type="submit" variant="game" className="w-full" disabled={loggingIn} sound="click">

--- a/packages/client/src/features/auth/pages/RegisterPage.tsx
+++ b/packages/client/src/features/auth/pages/RegisterPage.tsx
@@ -104,7 +104,7 @@ export default function RegisterPage() {
         </div>
 
         {turnstileSiteKey && (
-          <Turnstile sitekey={turnstileSiteKey} onVerify={setTurnstileToken} />
+          <Turnstile sitekey={turnstileSiteKey} onVerify={setTurnstileToken} onExpire={() => setTurnstileToken(null)} />
         )}
 
         {fieldError && <p className="text-sm text-destructive m-0">{fieldError}</p>}


### PR DESCRIPTION
## Summary
- 登录页和注册页的 Turnstile 组件添加 `onExpire` 回调，token 过期后自动清空
- 防止用户长时间停留后提交已失效的 token

## Test plan
- [ ] 配置 Turnstile 后，登录页正常显示验证组件
- [ ] 注册页正常显示验证组件
- [ ] 验证通过后提交登录/注册请求正常
- [ ] token 过期后重新提交会触发服务端"人机验证失败"提示

🤖 Generated with [Claude Code](https://claude.com/claude-code)