### PR TITLE
fix: 修复房间加入座位不显示、玩家误入观战视角及掉线状态同步问题

### DIFF
--- a/packages/client/src/features/lobby/pages/LobbyPage.tsx
+++ b/packages/client/src/features/lobby/pages/LobbyPage.tsx
@@ -101,7 +101,7 @@ export default function LobbyPage() {
     getSocket().emit('room:join', code, (res: any) => {
       setLoading(false);
       if (res.success) {
-        setRoom(code, Array.from({ length: SEAT_COUNT }, () => null), [], res.room as any ?? { ownerId: '', status: 'waiting', settings: {} });
+        setRoom(code, res.seats ?? Array.from({ length: SEAT_COUNT }, () => null), res.spectators ?? [], res.room as any ?? { ownerId: '', status: 'waiting', settings: {} });
         navigate(res.rejoin ? `/game/${code}` : `/room/${code}`);
       } else {
         setError(res.error || '加入失败');

--- a/packages/server/src/ws/game-events.ts
+++ b/packages/server/src/ws/game-events.ts
@@ -775,8 +775,10 @@ export function registerGameEvents(
       await clearUserRoom(redis, targetId);
     } else {
       const targetSockets = await io.in(roomCode).fetchSockets();
+      let hasConnectedSocket = false;
       for (const s of targetSockets) {
         if ((s.data as SocketData).user.userId === targetId) {
+          hasConnectedSocket = true;
           (s.data as SocketData).isSpectator = true;
           s.emit('game:kicked', { reason: '你已被房主移至观战席', toSpectator: true });
         }
@@ -786,7 +788,8 @@ export function registerGameEvents(
         nickname: targetPlayer.name,
         avatarUrl: targetPlayer.avatarUrl,
         role: targetPlayer.role,
-        connected: true,
+        connected: hasConnectedSocket,
+        disconnectedAt: hasConnectedSocket ? undefined : Date.now(),
       });
     }
 

--- a/packages/server/src/ws/room-events.ts
+++ b/packages/server/src/ws/room-events.ts
@@ -125,8 +125,12 @@ export function registerRoomEvents(
         if (room.status !== 'waiting') {
           socket.emit('room:rejoin_redirect', { roomCode });
         }
-        const voiceChannelId = await voiceChannels?.getRoomChannel(roomCode) ?? null;
-        return callback({ success: true, players: seatedPlayers, room, rejoin: room.status !== 'waiting', voiceChannelId });
+        const [voiceChannelId, latestSeats, latestSpectators] = await Promise.all([
+          voiceChannels?.getRoomChannel(roomCode) ?? null,
+          getRoomSeats(redis, roomCode),
+          getRoomSpectators(redis, roomCode),
+        ]);
+        return callback({ success: true, players: seatedPlayers, seats: latestSeats, spectators: latestSpectators, room, rejoin: room.status !== 'waiting', voiceChannelId });
       }
 
       const conflict = await ensureNotInRoom(redis, data.user.userId, roomCode);
@@ -140,8 +144,8 @@ export function registerRoomEvents(
         getRoomSeats(redis, roomCode),
         getRoomSpectators(redis, roomCode),
       ]);
+      callback({ success: true, players: getSeatedPlayers(updatedSeats), seats: updatedSeats, spectators: updatedSpectators, room, voiceChannelId });
       io.to(roomCode).emit('seat:updated', { seats: updatedSeats, spectators: updatedSpectators });
-      callback({ success: true, players: getSeatedPlayers(updatedSeats), room, voiceChannelId });
     } catch (err) {
       callback({ success: false, error: (err as Error).message });
     }
@@ -469,6 +473,7 @@ export function registerRoomEvents(
         sData.isSpectator = true;
         s.emit('game:state', session.getSpectatorView(spectatorMode));
       } else {
+        sData.isSpectator = false;
         s.emit('game:state', session.getPlayerView(sData.user.userId));
       }
     }

--- a/packages/server/src/ws/seat-events.ts
+++ b/packages/server/src/ws/seat-events.ts
@@ -148,6 +148,7 @@ export function registerSeatEvents(
           role: data.user.role,
           isBot: data.user.isBot ?? false,
         };
+        data.isSpectator = false;
         await removeSpectatorFromRoom(redis, roomCode, userId);
       } else {
         // Reuse existing player data, reset ready
@@ -192,6 +193,7 @@ export function registerSeatEvents(
       if (room.ownerId === userId) return callback({ success: false, error: '房主需要先移交房主权才能离座' });
 
       await leaveSeat(redis, roomCode, userId);
+      data.isSpectator = true;
 
       await addSpectatorToRoom(redis, roomCode, {
         userId: data.user.userId,

--- a/packages/server/src/ws/socket-handler.ts
+++ b/packages/server/src/ws/socket-handler.ts
@@ -475,6 +475,10 @@ export function setupSocketHandlers(
         await emitGameUpdate(io, roomCode, session, redis);
         io.to(roomCode).emit('player:disconnected', { playerId: userId });
 
+        if (session.isRoundEnd()) {
+          addAutopilotVote(roomCode, userId, session, io);
+        }
+
         const state = session.getFullState();
         const connectedCount = state.players.filter((p) => p.connected).length;
         const connectedHumanCount = state.players.filter((p) => p.connected && !p.isBot).length;


### PR DESCRIPTION
## Summary

- **进房看不到座位**：`room:join` 回调现在返回 `seats`/`spectators` 数据，并将 callback 移到 broadcast 之前，防止客户端收到真实座位后被空数组覆盖
- **玩家误入观战视角**：`seat:take`/`seat:leave` 同步 `socket.data.isSpectator` flag；`game:start` 显式设 `isSpectator=false`，确保后续 `emitGameUpdate` 发送正确视角
- **踢掉线玩家变幽灵观战者**：踢人到观战席时检查目标是否有在线 socket，无连接则设 `connected: false` + `disconnectedAt`，交由 sweep 清理
- **回合结束掉线不自动投票**：掉线时若处于 `round_end` 阶段立即补投下一轮票

## Test plan

- [ ] 从大厅加入房间，确认立即显示正确座位和操作按钮
- [ ] 观众入座后开始游戏，确认收到玩家视角而非观战视角
- [ ] 游戏中踢掉线玩家，确认观战席显示为掉线状态并在 30s 后被清理
- [ ] 回合结束时关闭浏览器，确认该玩家立即自动投票下一轮

🤖 Generated with [Claude Code](https://claude.com/claude-code)