### PR TITLE
refactor(client): 全局视觉重构 — 暗色主题、金色色系、FitScaler

### DIFF
--- a/packages/client/src/features/auth/components/AuthLayout.tsx
+++ b/packages/client/src/features/auth/components/AuthLayout.tsx
@@ -1,6 +1,7 @@
 import { motion } from 'framer-motion';
 import GamePageShell from '@/shared/components/GamePageShell';
 import ServerStatusBar from '@/shared/components/ServerStatusBar';
+import FitScaler from '@/shared/components/FitScaler';
 
 interface Props {
   title?: string;
@@ -19,34 +20,40 @@ interface Props {
 export default function AuthLayout({ title, subtitle, showLogo = true, footer, children }: Props) {
   return (
     <GamePageShell>
+      <FitScaler align="center" maxScale={0.8} className="absolute left-5 right-5 portrait:left-[6%] portrait:right-[6%] top-[28px] bottom-[88px] z-[2]">
       <motion.div
         initial={{ opacity: 0, y: 16 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.3, ease: 'easeOut' }}
-        className="relative z-1 w-[min(440px,calc(100vw-2rem))] rounded-2xl bg-white/[0.04] backdrop-blur-xl border border-white/10 shadow-2xl px-8 py-10"
+        className="glass-panel w-[644px] portrait:w-[460px] rounded-[28px] px-[52px] portrait:px-[30px] py-[44px] portrait:py-[38px]"
       >
         {showLogo && (
           <div className="text-center">
-            <p className="font-game text-[28px] leading-none text-primary" style={{ textShadow: '0 0 16px rgba(251,191,36,0.25)' }}>
-              ♠ UNO
-            </p>
-            {title && <h1 className="mt-4 font-game text-[28px] text-primary text-shadow-bold">{title}</h1>}
+            <div className="flex justify-center items-center gap-2.5 text-[var(--gold)] font-black text-[28px]" style={{ textShadow: '0 0 18px rgba(246,190,62,0.36)' }}>
+              <span>♠</span><span>UNO</span>
+            </div>
+            {title && (
+              <h1 className="mt-3 text-[var(--gold)] text-[48px] font-black tracking-[0.12em]">
+                {title}
+              </h1>
+            )}
             {subtitle && (
               <p className="mt-2 text-sm text-muted-foreground">{subtitle}</p>
             )}
           </div>
         )}
 
-        <div className={showLogo ? 'mt-8' : ''}>
+        <div className={showLogo ? 'mt-[30px]' : ''}>
           {children}
         </div>
 
         {footer && (
-          <div className="mt-6 text-center text-sm text-muted-foreground">
+          <div className="mt-[26px] text-center text-[17px] text-[#c8d0e6]">
             {footer}
           </div>
         )}
       </motion.div>
+      </FitScaler>
 
       <ServerStatusBar />
     </GamePageShell>

--- a/packages/client/src/features/auth/pages/RegisterPage.tsx
+++ b/packages/client/src/features/auth/pages/RegisterPage.tsx
@@ -51,56 +51,68 @@ export default function RegisterPage() {
   return (
     <AuthLayout
       title="注册"
-      footer={<Link to="/" className="hover:text-foreground transition-colors">已有账号？去登录</Link>}
+      footer={<Link to="/" className="text-[var(--gold)] font-extrabold no-underline hover:opacity-80">已有账号？去登录</Link>}
     >
-      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      <form onSubmit={handleSubmit} className="flex flex-col gap-[22px]">
         <div className="flex justify-center">
           <AvatarUpload avatarUrl={avatar} size={96} onUpload={setAvatar} />
         </div>
 
         <div>
-          <label className="block text-xs text-muted-foreground mb-1.5 tracking-wide">用户名（用于登录）</label>
-          <input
-            value={username}
-            onChange={(e) => { setUsername(e.target.value); setFieldError(''); }}
-            className="glass-input w-full text-foreground"
-            required
-            autoComplete="username"
-          />
+          <label className="block text-[#dce5ff] text-[18px] font-bold mb-2.5">用户名（用于登录）</label>
+          <div className="relative">
+            <svg className="absolute left-5 top-1/2 -translate-y-1/2 text-[var(--gold)]" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}><path d="M20 21a8 8 0 1 0-16 0"/><circle cx="12" cy="7" r="4"/></svg>
+            <input
+              value={username}
+              onChange={(e) => { setUsername(e.target.value); setFieldError(''); }}
+              className="h-[68px] w-full rounded-[16px] border border-[rgba(127,154,225,0.32)] bg-[rgba(13,20,39,0.64)] text-foreground outline-0 pl-14 pr-5 text-base placeholder:text-[rgba(216,224,245,0.38)] focus:border-[rgba(246,190,62,0.6)] focus:shadow-[0_0_0_4px_rgba(246,190,62,0.10)] transition-all"
+              required
+              autoComplete="username"
+            />
+          </div>
         </div>
 
         <div>
-          <label className="block text-xs text-muted-foreground mb-1.5 tracking-wide">昵称（游戏中显示，可选）</label>
-          <input
-            value={nickname}
-            onChange={(e) => setNickname(e.target.value)}
-            className="glass-input w-full text-foreground"
-            placeholder="留空则使用用户名"
-          />
+          <label className="block text-[#dce5ff] text-[18px] font-bold mb-2.5">昵称（游戏中显示，可选）</label>
+          <div className="relative">
+            <svg className="absolute left-5 top-1/2 -translate-y-1/2 text-[var(--gold)]" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}><path d="M12 20h9"/><path d="m16.5 3.5 4 4L7 21H3v-4L16.5 3.5Z"/></svg>
+            <input
+              value={nickname}
+              onChange={(e) => setNickname(e.target.value)}
+              placeholder="留空则使用用户名"
+              className="h-[68px] w-full rounded-[16px] border border-[rgba(127,154,225,0.32)] bg-[rgba(13,20,39,0.64)] text-foreground outline-0 pl-14 pr-5 text-base placeholder:text-[rgba(216,224,245,0.38)] focus:border-[rgba(246,190,62,0.6)] focus:shadow-[0_0_0_4px_rgba(246,190,62,0.10)] transition-all"
+            />
+          </div>
         </div>
 
         <div>
-          <label className="block text-xs text-muted-foreground mb-1.5 tracking-wide">密码（至少 8 位，需包含字母和数字）</label>
-          <input
-            type="password"
-            value={password}
-            onChange={(e) => { setPassword(e.target.value); setFieldError(''); }}
-            className="glass-input w-full text-foreground"
-            required
-            autoComplete="new-password"
-          />
+          <label className="block text-[#dce5ff] text-[18px] font-bold mb-2.5">密码（至少 8 位，需包含字母和数字）</label>
+          <div className="relative">
+            <svg className="absolute left-5 top-1/2 -translate-y-1/2 text-[var(--gold)]" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}><rect x="4" y="10" width="16" height="10" rx="2"/><path d="M8 10V7a4 4 0 0 1 8 0v3"/></svg>
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => { setPassword(e.target.value); setFieldError(''); }}
+              className="h-[68px] w-full rounded-[16px] border border-[rgba(127,154,225,0.32)] bg-[rgba(13,20,39,0.64)] text-foreground outline-0 pl-14 pr-5 text-base placeholder:text-[rgba(216,224,245,0.38)] focus:border-[rgba(246,190,62,0.6)] focus:shadow-[0_0_0_4px_rgba(246,190,62,0.10)] transition-all"
+              required
+              autoComplete="new-password"
+            />
+          </div>
         </div>
 
         <div>
-          <label className="block text-xs text-muted-foreground mb-1.5 tracking-wide">确认密码</label>
-          <input
-            type="password"
-            value={confirm}
-            onChange={(e) => { setConfirm(e.target.value); setFieldError(''); }}
-            className="glass-input w-full text-foreground"
-            required
-            autoComplete="new-password"
-          />
+          <label className="block text-[#dce5ff] text-[18px] font-bold mb-2.5">确认密码</label>
+          <div className="relative">
+            <svg className="absolute left-5 top-1/2 -translate-y-1/2 text-[var(--gold)]" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}><rect x="4" y="10" width="16" height="10" rx="2"/><path d="M8 10V7a4 4 0 0 1 8 0v3"/></svg>
+            <input
+              type="password"
+              value={confirm}
+              onChange={(e) => { setConfirm(e.target.value); setFieldError(''); }}
+              className="h-[68px] w-full rounded-[16px] border border-[rgba(127,154,225,0.32)] bg-[rgba(13,20,39,0.64)] text-foreground outline-0 pl-14 pr-5 text-base placeholder:text-[rgba(216,224,245,0.38)] focus:border-[rgba(246,190,62,0.6)] focus:shadow-[0_0_0_4px_rgba(246,190,62,0.10)] transition-all"
+              required
+              autoComplete="new-password"
+            />
+          </div>
         </div>
 
         {turnstileSiteKey && (
@@ -109,7 +121,7 @@ export default function RegisterPage() {
 
         {fieldError && <p className="text-sm text-destructive m-0">{fieldError}</p>}
 
-        <Button type="submit" variant="game" className="w-full mt-1" disabled={submitting} sound="click">
+        <Button type="submit" variant="game" className="w-full h-[76px] text-2xl tracking-[0.35em] mt-1" disabled={submitting} sound="click">
           {submitting ? '注册中...' : '注 册'}
         </Button>
       </form>

--- a/packages/client/src/features/game/components/Seat.tsx
+++ b/packages/client/src/features/game/components/Seat.tsx
@@ -27,10 +27,10 @@ export default function Seat({ index, player, isMe, isOwnerSeat, compact = false
         title={`座位 ${seatLabel}`}
       >
         <div
-          className="rounded-full border-2 border-dashed border-white/25 flex items-center justify-center relative transition-colors group-hover:border-white/50 group-hover:bg-white/5"
+          className="rounded-full border-2 border-dashed border-white/20 flex items-center justify-center relative transition-colors group-hover:border-[rgba(246,190,62,0.55)] group-hover:bg-[rgba(246,190,62,0.08)]"
           style={{ width: avatarSize, height: avatarSize }}
         >
-          <Plus size={compact ? 14 : 18} className="text-white/30 group-hover:text-white/60 transition-colors" />
+          <Plus size={compact ? 14 : 18} className="text-white/30 group-hover:text-[var(--gold)] transition-colors" />
         </div>
         <span className="text-xs text-muted-foreground/50">{seatLabel}</span>
       </button>

--- a/packages/client/src/features/game/components/SeatCircle.tsx
+++ b/packages/client/src/features/game/components/SeatCircle.tsx
@@ -34,10 +34,16 @@ export default function SeatCircle({ seats, onSeatClick, compact = false }: Seat
     <div className="relative" style={{ width: containerW, height: containerH }}>
       {/* Table ellipse in the center */}
       <div
-        className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 flex items-center justify-center rounded-[50%] border-2 border-green-700/60 bg-green-950/40"
-        style={{ width: rx * 1.1, height: ry * 1.1 }}
+        className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 flex items-center justify-center rounded-[50%] border border-[rgba(246,190,62,0.28)]"
+        style={{
+          width: rx * 1.1,
+          height: ry * 1.1,
+          background: 'radial-gradient(circle at 50% 38%, rgba(246,190,62,0.10), rgba(255,255,255,0.02) 55%, transparent 75%)',
+          boxShadow: 'inset 0 0 40px rgba(246,190,62,0.10), inset 0 1px 0 rgba(255,255,255,0.06), 0 18px 50px rgba(0,0,0,0.4)',
+          backdropFilter: 'blur(6px)',
+        }}
       >
-        <Layers size={compact ? 24 : 32} className="text-green-500/50" strokeWidth={1.5} />
+        <Layers size={compact ? 24 : 32} className="text-[var(--gold)]/55" strokeWidth={1.5} />
       </div>
 
       {/* Seats positioned around the ellipse */}

--- a/packages/client/src/features/game/components/SettingsDrawer.tsx
+++ b/packages/client/src/features/game/components/SettingsDrawer.tsx
@@ -1,4 +1,4 @@
-import { X } from 'lucide-react';
+import { X, Settings } from 'lucide-react';
 import { cn } from '@/shared/lib/utils';
 import { getSocket } from '@/shared/socket';
 import { Button } from '@/shared/components/ui/Button';
@@ -80,19 +80,22 @@ export default function SettingsDrawer({
       {/* Panel */}
       <div
         className={cn(
-          'fixed right-0 top-0 h-full w-[320px] max-w-[75vw] bg-[#0f1729]/98 border-l border-white/10 z-50 flex flex-col',
+          'fixed right-0 top-0 h-full w-[320px] max-w-[75vw] z-50 flex flex-col border-l border-[rgba(246,190,62,0.18)] backdrop-blur-xl shadow-[-20px_0_60px_rgba(0,0,0,0.45)]',
           'transition-transform duration-300',
           open ? 'translate-x-0' : 'translate-x-full',
         )}
+        style={{ background: 'linear-gradient(180deg, rgba(23,30,56,0.96), rgba(12,17,34,0.97))' }}
       >
         {/* Header */}
-        <div className="flex items-center justify-between px-4 py-3 border-b border-white/10 shrink-0">
-          <span className="text-sm font-bold font-game text-foreground">房间设置</span>
+        <div className="flex items-center justify-between px-5 py-4 border-b border-white/10 shrink-0">
+          <span className="flex items-center gap-2 text-base font-black text-foreground">
+            <Settings size={16} className="text-[var(--gold)]" /> 房间设置
+          </span>
           <button
             onClick={onClose}
-            className="w-7 h-7 rounded-md bg-white/10 flex items-center justify-center text-muted-foreground hover:text-foreground cursor-pointer transition-colors"
+            className="w-8 h-8 rounded-[10px] bg-white/[0.045] border border-white/[0.12] flex items-center justify-center text-[#c7d0ec] hover:text-[var(--gold)] hover:border-[rgba(246,190,62,0.46)] cursor-pointer transition-all"
           >
-            <X size={14} />
+            <X size={15} />
           </button>
         </div>
 
@@ -115,14 +118,19 @@ export default function SettingsDrawer({
                   }}
                   disabled={!isOwner}
                   className={cn(
-                    'w-11 h-6 rounded-xl relative transition-colors duration-200',
+                    'w-11 h-6 rounded-full relative transition-all duration-200',
                     !isOwner ? 'cursor-default opacity-50' : 'cursor-pointer',
-                    (room?.settings?.allowSpectators ?? true) ? 'bg-accent' : 'bg-white/15',
                   )}
+                  style={{
+                    background: (room?.settings?.allowSpectators ?? true)
+                      ? 'linear-gradient(135deg, var(--gold-2), var(--gold))'
+                      : 'rgba(255,255,255,0.15)',
+                    boxShadow: (room?.settings?.allowSpectators ?? true) ? '0 0 12px rgba(246,190,62,0.26)' : 'none',
+                  }}
                 >
                   <span
                     className={cn(
-                      'absolute top-0.5 left-0.5 h-5 w-5 rounded-full bg-white transition-transform',
+                      'absolute top-0.5 left-0.5 h-5 w-5 rounded-full bg-white shadow-[0_2px_5px_rgba(0,0,0,0.3)] transition-transform',
                       (room?.settings?.allowSpectators ?? true) ? 'translate-x-5' : '',
                     )}
                   />
@@ -141,9 +149,9 @@ export default function SettingsDrawer({
                           onClick={() => isOwner && getSocket().emit('room:update_settings', { spectatorMode: value })}
                           disabled={!isOwner}
                           className={cn(
-                            'px-3 py-1 rounded-lg text-sm transition-colors',
+                            'px-3 py-1 rounded-lg text-sm font-medium transition-colors',
                             isOwner ? 'cursor-pointer' : 'cursor-default',
-                            active ? 'bg-accent text-white' : 'text-muted-foreground hover:text-foreground',
+                            active ? 'bg-accent text-[#161513]' : 'text-muted-foreground hover:text-foreground',
                           )}
                         >
                           {label}
@@ -181,14 +189,19 @@ export default function SettingsDrawer({
                       onClick={() => toggleRule(rule.key)}
                       disabled={!isOwner}
                       className={cn(
-                        'w-11 h-6 rounded-xl border-none relative transition-colors duration-200',
+                        'w-11 h-6 rounded-full border-none relative transition-all duration-200',
                         !isOwner ? 'cursor-default' : 'cursor-pointer',
-                        houseRules[rule.key] ? 'bg-accent' : 'bg-switch-off',
                       )}
+                      style={{
+                        background: houseRules[rule.key]
+                          ? 'linear-gradient(135deg, var(--gold-2), var(--gold))'
+                          : 'rgba(255,255,255,0.15)',
+                        boxShadow: houseRules[rule.key] ? '0 0 12px rgba(246,190,62,0.26)' : 'none',
+                      }}
                     >
                       <div
                         className={cn(
-                          'w-toggle-knob h-toggle-knob rounded-full bg-white absolute top-toggle-off transition-[left] duration-200',
+                          'w-toggle-knob h-toggle-knob rounded-full bg-white shadow-[0_2px_5px_rgba(0,0,0,0.3)] absolute top-toggle-off transition-[left] duration-200',
                           houseRules[rule.key] ? 'left-toggle-on' : 'left-toggle-off',
                         )}
                       />

--- a/packages/client/src/features/game/pages/RoomPage.tsx
+++ b/packages/client/src/features/game/pages/RoomPage.tsx
@@ -292,8 +292,16 @@ export default function RoomPage() {
     <GamePageShell>
       <div className="relative z-1 flex flex-col items-center gap-4 md:gap-6 w-full h-full overflow-y-auto scrollbar-thin px-4 md:px-8 py-8 md:py-16">
         {/* Title */}
-        <h2 className="font-game text-2xl md:text-[36px] text-primary text-shadow-bold flex items-center gap-2 md:gap-3 shrink-0">
-          房间 {roomCode}
+        <div className="flex items-center gap-3 shrink-0">
+          <h2
+            className="text-2xl md:text-[32px] font-black text-[var(--gold)]"
+            style={{ textShadow: '0 0 20px rgba(246,190,62,0.35)' }}
+          >
+            房间
+          </h2>
+          <span className="font-mono text-xl md:text-[26px] font-bold tracking-[0.18em] indent-[0.18em] text-[var(--gold-2)] bg-[rgba(246,190,62,0.08)] border border-[rgba(246,190,62,0.32)] rounded-[14px] px-4 py-1 md:py-1.5">
+            {roomCode}
+          </span>
           <button
             onClick={() => {
               const url = `${window.location.origin}/room/${roomCode}`;
@@ -302,12 +310,12 @@ export default function RoomPage() {
               );
               useToastStore.getState().addToast('房间链接已复制', 'success');
             }}
-            className="bg-white/10 hover:bg-white/20 rounded-lg p-1.5 cursor-pointer transition-colors"
+            className="w-9 h-9 md:w-10 md:h-10 rounded-[12px] bg-white/[0.045] border border-white/[0.12] flex items-center justify-center text-[#c7d0ec] hover:text-[var(--gold)] hover:border-[rgba(246,190,62,0.46)] cursor-pointer transition-all shrink-0"
             title="复制房间链接"
           >
-            <Copy size={16} className="text-muted-foreground" />
+            <Copy size={16} />
           </button>
-        </h2>
+        </div>
 
         {/* Circular table */}
         <SeatCircle
@@ -364,7 +372,7 @@ export default function RoomPage() {
                 }}
                 sound="click"
                 size="sm"
-                className="text-xs px-3 py-1.5"
+                className="rounded-full bg-white/[0.045] border border-white/[0.12] text-[#dbe3f8] hover:bg-white/[0.08] hover:border-white/[0.18] text-xs font-medium px-4 py-2"
               >
                 <Eye size={12} className="inline align-middle mr-1" />
                 观战
@@ -375,7 +383,7 @@ export default function RoomPage() {
               onClick={leaveRoom}
               sound="click"
               size="sm"
-              className="text-xs px-3 py-1.5"
+              className="rounded-full bg-white/[0.045] border border-white/[0.12] text-[#dbe3f8] hover:bg-white/[0.08] hover:border-white/[0.18] text-xs font-medium px-4 py-2"
             >
               离开房间
             </Button>
@@ -385,7 +393,7 @@ export default function RoomPage() {
                 onClick={dissolveRoom}
                 sound="danger"
                 size="sm"
-                className="text-xs px-3 py-1.5"
+                className="rounded-full bg-[rgba(255,92,131,0.1)] border border-[rgba(255,92,131,0.35)] text-[#ff8da8] hover:bg-[rgba(255,92,131,0.18)] hover:border-[rgba(255,92,131,0.5)] text-xs font-medium px-4 py-2"
               >
                 <Trash2 size={12} className="inline align-middle mr-1" />
                 解散房间
@@ -396,11 +404,11 @@ export default function RoomPage() {
 
         {/* Settings gear (top-right) */}
         <button
-          className="absolute top-4 right-4 w-9 h-9 bg-white/[0.08] border border-white/15 rounded-lg flex items-center justify-center hover:bg-white/15 cursor-pointer transition-colors"
+          className="absolute top-5 right-5 w-11 h-11 bg-white/[0.045] border border-white/[0.12] rounded-[14px] flex items-center justify-center text-[#c7d0ec] hover:text-[var(--gold)] hover:border-[rgba(246,190,62,0.46)] cursor-pointer transition-all shadow-[inset_0_1px_0_rgba(255,255,255,0.05),0_12px_22px_rgba(0,0,0,0.26)]"
           onClick={() => setSettingsOpen(true)}
           title="房间设置"
         >
-          <Settings size={16} className="text-muted-foreground" />
+          <Settings size={18} />
         </button>
       </div>
 

--- a/packages/client/src/features/lobby/pages/LobbyPage.tsx
+++ b/packages/client/src/features/lobby/pages/LobbyPage.tsx
@@ -14,6 +14,7 @@ import BgmToast from '@/shared/components/BgmToast';
 import MusicHallModal from '@/shared/components/MusicHallModal';
 import GamePageShell from '@/shared/components/GamePageShell';
 import GameTopBar from '@/shared/components/GameTopBar';
+import FitScaler from '@/shared/components/FitScaler';
 import ServerStatusBar from '@/shared/components/ServerStatusBar';
 import { openChangelog } from '@/shared/components/ChangelogModal';
 import { useLobbyStore } from '../stores/lobby-store';
@@ -110,9 +111,10 @@ export default function LobbyPage() {
   };
 
   const ctrlIconBase =
-    'w-10 h-10 rounded-xl bg-white/[0.04] border border-white/[0.06] flex items-center justify-center text-base cursor-pointer text-[#475569] transition-all hover:bg-white/[0.08] hover:text-[#94a3b8]';
+    'w-14 h-14 max-sm:w-12 max-sm:h-12 shrink-0 rounded-[18px] max-sm:rounded-[14px] bg-white/[0.045] border border-white/[0.12] flex items-center justify-center cursor-pointer text-[#c7d0ec] transition-all shadow-[inset_0_1px_0_rgba(255,255,255,0.05),0_12px_22px_rgba(0,0,0,0.26)] hover:text-[var(--gold)] hover:border-[rgba(246,190,62,0.46)] hover:shadow-[0_0_24px_rgba(246,190,62,0.14),inset_0_1px_0_rgba(255,255,255,0.08)]';
   const ctrlIconActive =
-    'text-[#fbbf24] bg-[rgba(251,191,36,0.08)] border-[rgba(251,191,36,0.15)]';
+    'text-[var(--gold)] border-[rgba(246,190,62,0.46)] shadow-[0_0_24px_rgba(246,190,62,0.14),inset_0_1px_0_rgba(255,255,255,0.08)]';
+  const ctrlHideMobile = 'max-sm:hidden';
 
   return (
     <GamePageShell>
@@ -126,7 +128,7 @@ export default function LobbyPage() {
               className={`${ctrlIconBase} ${bgmEnabled ? ctrlIconActive : ''}`}
               title={bgmEnabled ? '关闭背景音乐' : '开启背景音乐'}
             >
-              {bgmEnabled ? <Volume2 size={16} /> : <VolumeX size={16} />}
+              {bgmEnabled ? <Volume2 size={24} /> : <VolumeX size={24} />}
             </button>
 
             {/* Music hall */}
@@ -135,21 +137,21 @@ export default function LobbyPage() {
               className={ctrlIconBase}
               title="音乐厅"
             >
-              <Music size={16} />
+              <Music size={24} />
             </button>
 
-            {/* Card pack */}
+            {/* Card pack (hidden on mobile — file picker is impractical there) */}
             {cardImagePack && isPackLoaded() ? (
               <button
                 onClick={() => { clearCardPack(); setCardImagePack(false); }}
-                className={ctrlIconBase}
+                className={`${ctrlIconBase} ${ctrlHideMobile}`}
                 title="卸载资源包"
               >
-                <X size={16} />
+                <X size={24} />
               </button>
             ) : (
-              <label className={`${ctrlIconBase}`} title="加载卡面资源包">
-                <Upload size={16} />
+              <label className={`${ctrlIconBase} ${ctrlHideMobile}`} title="加载卡面资源包">
+                <Upload size={24} />
                 <input
                   type="file"
                   accept=".zip"
@@ -175,7 +177,7 @@ export default function LobbyPage() {
               className={ctrlIconBase}
               title="游戏教程"
             >
-              <BookOpen size={16} />
+              <BookOpen size={24} />
             </button>
 
             {/* Changelog */}
@@ -184,107 +186,124 @@ export default function LobbyPage() {
               className={ctrlIconBase}
               title="更新日志"
             >
-              <Sparkles size={16} />
+              <Sparkles size={24} />
             </button>
           </>
         }
       />
 
-      {/* Center content */}
-      <div className="flex flex-col items-center justify-center relative z-[1]">
-        {/* Brand */}
-        <div className="text-center mb-16">
-          <h1
-            className="font-game text-[88px] font-black text-primary tracking-[10px]"
-            style={{ textShadow: '5px 6px 0px rgba(0,0,0,0.3), 0 0 80px rgba(251,191,36,0.1)' }}
-          >
-            &#9824; UNO
-          </h1>
-          <div className="text-[15px] text-[#3e4a63] tracking-[8px] font-medium mt-3">
-            ONLINE CARD GAME
-          </div>
-        </div>
-
-        {/* Actions */}
-        <div className="flex flex-col items-center gap-[22px] w-[440px] max-w-[90vw]">
-          {/* Create room */}
-          <Button
-            variant="game"
-            size="lg"
-            className="w-full tracking-[6px] text-2xl py-6"
-            onClick={handleCreate}
-            disabled={loading}
-            sound="ready"
-          >
-            {loading ? '创建中...' : '创 建 房 间'}
-          </Button>
-
-          {/* Divider */}
-          <div className="flex items-center gap-4 w-full">
-            <div className="flex-1 h-px" style={{ background: 'linear-gradient(90deg, transparent, rgba(255,255,255,0.08), transparent)' }} />
-            <span className="text-[13px] text-[#3e4a63] tracking-[2px]">或加入房间</span>
-            <div className="flex-1 h-px" style={{ background: 'linear-gradient(90deg, transparent, rgba(255,255,255,0.08), transparent)' }} />
-          </div>
-
-          {/* Join row */}
-          <div className="flex gap-2.5 w-full">
-            <input
-              value={joinCode}
-              onChange={(e) => { setJoinCode(extractRoomCode(e.target.value)); setError(''); }}
-              onKeyDown={(e) => e.key === 'Enter' && handleJoin()}
-              placeholder="房间码或链接"
-              maxLength={100}
-              className="glass-input flex-1 text-center uppercase tracking-[5px] text-lg"
+      {/* Center content — fixed logical layout, scaled to always fit (game-style canvas) */}
+      <FitScaler align="center" maxScale={0.8} className="absolute left-5 right-5 portrait:left-[6%] portrait:right-[6%] top-[92px] bottom-[84px] z-[2]">
+        <div className="flex flex-col items-center w-[760px] portrait:w-[440px]">
+          {/* Brand */}
+          <section className="text-center grid justify-items-center gap-3.5 mb-9 portrait:mb-7">
+            <div className="flex items-center justify-center gap-7 portrait:gap-5" style={{ color: 'var(--gold)', textShadow: '0 0 26px rgba(246, 190, 62, 0.42)' }}>
+              <span className="text-[120px] portrait:text-[74px] leading-none">♠</span>
+              <span
+                className="text-[120px] portrait:text-[74px] font-black leading-[0.9] tracking-[0.03em]"
+                style={{
+                  background: 'linear-gradient(180deg, var(--gold-2), var(--gold) 55%, var(--gold-3))',
+                  WebkitBackgroundClip: 'text',
+                  color: 'transparent',
+                }}
+              >
+                UNO
+              </span>
+            </div>
+            <div
+              className="h-px w-[520px] portrait:w-[300px] shadow-[0_0_16px_rgba(246,190,62,0.55)]"
+              style={{ background: 'linear-gradient(90deg, transparent, rgba(246,190,62,0.52), transparent)' }}
             />
-            <button
-              onClick={handlePaste}
-              className="w-[58px] flex-shrink-0 border border-white/[0.08] rounded-[18px] bg-white/[0.04] text-[#475569] text-[22px] cursor-pointer transition-all flex items-center justify-center hover:bg-white/[0.08] hover:text-[#94a3b8] hover:border-white/[0.12]"
-              title="从剪贴板粘贴"
-            >
-              <ClipboardPaste size={20} />
-            </button>
-            <button
-              onClick={handleJoin}
-              disabled={loading}
-              className="w-[62px] flex-shrink-0 border border-[rgba(251,191,36,0.2)] rounded-[18px] bg-[rgba(251,191,36,0.08)] text-[#fbbf24] text-2xl cursor-pointer transition-all flex items-center justify-center hover:bg-[rgba(251,191,36,0.15)] hover:border-[rgba(251,191,36,0.35)] hover:-translate-y-px disabled:opacity-50 disabled:cursor-not-allowed"
-              title="加入房间"
-            >
-              <ArrowRight size={22} />
-            </button>
-          </div>
+            <div className="text-[#7f89a8] tracking-[0.72em] portrait:tracking-[0.45em] text-[18px] portrait:text-[15px]" style={{ textIndent: '0.72em' }}>
+              ONLINE CARD GAME
+            </div>
+          </section>
 
-          {error && <p className="text-sm text-destructive text-center">{error}</p>}
+          {/* Glass panel actions */}
+          <section className="glass-panel w-[760px] portrait:w-[440px] rounded-[34px] portrait:rounded-[28px] px-[70px] py-[60px] portrait:px-[28px] portrait:py-[44px]">
+            {/* Create room */}
+            <Button
+              variant="game"
+              size="lg"
+              className="w-full h-[102px] text-[30px] tracking-[0.35em] flex items-center justify-center gap-[22px]"
+              onClick={handleCreate}
+              disabled={loading}
+              sound="ready"
+            >
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" className="w-[38px] h-[38px]" strokeWidth={2}><path d="M12 3 20 7.5v9L12 21l-8-4.5v-9L12 3Z"/><path d="M12 8v8"/><path d="M8 12h8"/></svg>
+              {loading ? '创建中...' : '创建房间'}
+            </Button>
+
+            {/* Divider */}
+            <div className="grid grid-cols-[1fr_auto_1fr] items-center gap-[22px] my-[36px] text-[#c6cee4] tracking-[0.28em]">
+              <div className="h-px" style={{ background: 'linear-gradient(90deg, transparent, rgba(246,190,62,0.48), transparent)' }} />
+              <span>或加入房间</span>
+              <div className="h-px" style={{ background: 'linear-gradient(90deg, transparent, rgba(246,190,62,0.48), transparent)' }} />
+            </div>
+
+            {/* Join row */}
+            <div className="grid grid-cols-[minmax(0,1fr)_82px_82px] gap-[18px]">
+              <label className="min-h-[74px] rounded-[20px] flex items-center gap-4 px-5 bg-[rgba(8,13,28,0.56)] border border-white/[0.13] text-[#d7def1] focus-within:border-[rgba(246,190,62,0.58)] focus-within:shadow-[0_0_0_4px_rgba(246,190,62,0.10)] transition-all">
+                <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} className="shrink-0 text-[#d7def1]"><path d="M10 3 8 21"/><path d="M16 3l-2 18"/><path d="M4 9h17"/><path d="M3 15h17"/></svg>
+                <input
+                  value={joinCode}
+                  onChange={(e) => { setJoinCode(extractRoomCode(e.target.value)); setError(''); }}
+                  onKeyDown={(e) => e.key === 'Enter' && handleJoin()}
+                  placeholder="房间码或链接"
+                  maxLength={100}
+                  className="min-w-0 flex-1 h-full border-0 outline-0 text-foreground bg-transparent uppercase tracking-[4px] text-base placeholder:text-[rgba(210,218,240,0.42)] placeholder:tracking-normal placeholder:normal-case"
+                />
+              </label>
+              <button
+                onClick={handlePaste}
+                className="min-h-[74px] rounded-[20px] grid place-items-center border border-white/[0.13] bg-white/[0.045] text-[#cbd5ef] cursor-pointer transition-all hover:bg-white/[0.08] hover:text-[#dbe3f8]"
+                title="从剪贴板粘贴"
+              >
+                <ClipboardPaste size={22} />
+              </button>
+              <button
+                onClick={handleJoin}
+                disabled={loading}
+                className="min-h-[74px] rounded-[20px] grid place-items-center border border-[rgba(246,190,62,0.72)] bg-[rgba(246,190,62,0.08)] text-[var(--gold)] cursor-pointer transition-all shadow-[0_0_22px_rgba(246,190,62,0.16)] hover:bg-[rgba(246,190,62,0.14)] hover:border-[rgba(246,190,62,0.9)] disabled:opacity-50 disabled:cursor-not-allowed"
+                title="加入房间"
+              >
+                <ArrowRight size={28} />
+              </button>
+            </div>
+
+            {error && <p className="text-sm text-destructive text-center mt-4">{error}</p>}
+          </section>
         </div>
-      </div>
+      </FitScaler>
 
       {/* Floating live games panel */}
       {activeRooms.length > 0 && (
-        <div className="absolute right-8 top-1/2 -translate-y-1/2 w-[280px] glass-panel p-5 z-[5]">
+        <div className="absolute right-8 top-1/2 -translate-y-1/2 w-[280px] glass-panel p-5 z-[5] hidden xl:block">
           {/* Header */}
           <div className="flex items-center gap-2.5 mb-4 px-1">
-            <span className="w-2 h-2 rounded-full bg-[#22c55e] shadow-[0_0_10px_rgba(34,197,94,0.4)] animate-pulse" />
-            <span className="text-sm font-semibold text-[#94a3b8]">正在进行的对战</span>
-            <span className="ml-auto text-xs text-[#475569] bg-white/[0.04] px-2.5 py-0.5 rounded-xl">
+            <span className="w-[9px] h-[9px] rounded-full bg-[#4dff73] shadow-[0_0_10px_#4dff73] animate-pulse" />
+            <span className="text-sm font-semibold text-[#8b95b3]">正在进行的对战</span>
+            <span className="ml-auto text-xs text-[#8b95b3] bg-white/[0.04] px-2.5 py-0.5 rounded-xl">
               {activeRooms.length} 场
             </span>
           </div>
           {/* List */}
-          <div className="flex flex-col gap-2 max-h-[340px] overflow-y-auto">
+          <div className="flex flex-col gap-2 max-h-[340px] overflow-y-auto scrollbar-thin">
             {activeRooms.map((room) => (
               <div
                 key={room.roomCode}
-                className="group bg-white/[0.03] rounded-[14px] p-3.5 cursor-pointer transition-all border border-transparent hover:bg-white/[0.06] hover:border-[rgba(251,191,36,0.1)]"
+                className="group bg-white/[0.035] rounded-[16px] p-3.5 cursor-pointer transition-all border border-white/[0.10] hover:bg-white/[0.06] hover:border-[rgba(246,190,62,0.26)]"
                 onClick={() => {
                   connectSocket();
                   navigate(`/game/${room.roomCode}`);
                 }}
               >
-                <div className="text-sm font-semibold text-[#cbd5e1]">
+                <div className="text-sm font-semibold text-[#eaf0ff]">
                   {room.players.map(p => p.nickname).join(' vs ')}
                 </div>
-                <div className="text-xs text-[#475569] mt-1 flex justify-between items-center">
+                <div className="text-xs text-[#8b95b3] mt-1 flex justify-between items-center">
                   <span>{room.playerCount} 人 · {room.spectatorCount} 人观战 · <GameDuration startedAt={room.gameStartedAt} /></span>
-                  <span className="text-[#fbbf24] text-xs font-semibold opacity-0 -translate-x-1 transition-all group-hover:opacity-100 group-hover:translate-x-0">
+                  <span className="text-[var(--gold)] text-xs font-semibold opacity-0 -translate-x-1 transition-all group-hover:opacity-100 group-hover:translate-x-0">
                     观战 ›
                   </span>
                 </div>
@@ -302,10 +321,10 @@ export default function LobbyPage() {
         href="https://github.com/letsuno/uno-online"
         target="_blank"
         rel="noopener noreferrer"
-        className="absolute bottom-6 right-8 z-[5] flex items-center gap-2 px-3.5 py-2 rounded-[14px] bg-white/[0.02] border border-white/[0.04] transition-all hover:bg-white/[0.04] hover:border-white/[0.08] text-[#64748b] hover:text-[#94a3b8] text-xs font-medium"
+        className="absolute bottom-7 max-sm:bottom-5 right-8 max-sm:right-5 z-[5] flex items-center justify-center gap-2.5 h-[44px] max-sm:h-[38px] px-[18px] max-sm:px-0 max-sm:w-[38px] rounded-full bg-white/[0.045] border border-white/[0.12] transition-all hover:bg-white/[0.07] hover:border-white/[0.18] text-[#dbe3f8] text-sm font-medium no-underline backdrop-blur-[16px] shadow-[0_16px_40px_rgba(0,0,0,0.24),inset_0_1px_0_rgba(255,255,255,0.05)]"
       >
-        <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z" /></svg>
-        GitHub
+        <svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor" className="shrink-0"><path d="M12 .5A12 12 0 0 0 8.2 23.9c.6.1.8-.2.8-.6v-2c-3.3.7-4-1.4-4-1.4-.5-1.4-1.3-1.8-1.3-1.8-1.1-.8.1-.8.1-.8 1.2.1 1.9 1.3 1.9 1.3 1.1 1.8 2.8 1.3 3.4 1 .1-.8.4-1.3.8-1.6-2.6-.3-5.3-1.3-5.3-5.8 0-1.3.5-2.3 1.2-3.2-.1-.3-.5-1.6.1-3.2 0 0 1-.3 3.3 1.2a11.4 11.4 0 0 1 6 0C17.3 4.5 18.3 4.8 18.3 4.8c.6 1.6.2 2.9.1 3.2.8.9 1.2 1.9 1.2 3.2 0 4.5-2.7 5.5-5.3 5.8.5.4.9 1.1.9 2.2v4.1c0 .4.2.7.8.6A12 12 0 0 0 12 .5Z"/></svg>
+        <span className="max-sm:hidden">GitHub</span>
       </a>
 
       {/* Modals */}

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -153,31 +153,38 @@
 }
 
 :root {
-  --background: #1a1a2e;
-  --foreground: #e2e8f0;
-  --card: #16213e;
-  --card-foreground: #e2e8f0;
-  --popover: #16213e;
-  --popover-foreground: #e2e8f0;
-  --primary: #fbbf24;
-  --primary-foreground: #1a1a2e;
-  --secondary: rgba(255, 255, 255, 0.08);
-  --secondary-foreground: #e2e8f0;
-  --muted: #0f3460;
-  --muted-foreground: #94a3b8;
-  --accent: #fbbf24;
-  --accent-foreground: #1a1a2e;
-  --destructive: #ff3366;
+  --background: #070b16;
+  --foreground: #f4f7ff;
+  --card: #0b1021;
+  --card-foreground: #f4f7ff;
+  --popover: #12172b;
+  --popover-foreground: #f4f7ff;
+  --primary: #f6be3e;
+  --primary-foreground: #161513;
+  --secondary: rgba(255, 255, 255, 0.045);
+  --secondary-foreground: #f4f7ff;
+  --muted: #12172b;
+  --muted-foreground: #8b95b3;
+  --accent: #f6be3e;
+  --accent-foreground: #161513;
+  --destructive: #ff5c83;
   --destructive-foreground: #ffffff;
-  --border: rgba(255, 255, 255, 0.15);
-  --input: rgba(255, 255, 255, 0.15);
-  --ring: rgba(251, 191, 36, 0.5);
+  --border: rgba(255, 255, 255, 0.11);
+  --input: rgba(255, 255, 255, 0.13);
+  --ring: rgba(246, 190, 62, 0.34);
   --radius: 0.75rem;
-  --radius-btn: 24px;
-  --radius-input: 12px;
-  --radius-card-ui: 16px;
-  --radius-panel-ui: 20px;
-  --border-glow: none;
+  --radius-btn: 18px;
+  --radius-input: 16px;
+  --radius-card-ui: 22px;
+  --radius-panel-ui: 28px;
+  --border-glow: 0 0 26px rgba(246, 190, 62, 0.34), 0 10px 30px rgba(0, 0, 0, 0.35);
+  --gold: #f6be3e;
+  --gold-2: #ffd66d;
+  --gold-3: #d8901d;
+  --panel: rgba(16, 22, 42, 0.78);
+  --panel-strong: rgba(18, 25, 48, 0.92);
+  --line: rgba(255, 255, 255, 0.11);
+  --line-gold: rgba(246, 191, 62, 0.38);
 }
 
 @layer base {
@@ -195,7 +202,7 @@
   }
   body {
     @apply bg-background text-foreground font-[family-name:var(--font-ui)];
-    background: linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%);
+    background: var(--background);
     min-height: 100vh;
     overflow-x: hidden;
   }
@@ -297,35 +304,49 @@
   }
 }
 @utility glass-panel {
-  background: rgba(22, 33, 62, 0.65);
-  backdrop-filter: blur(20px);
-  border: 1px solid rgba(255, 255, 255, 0.05);
-  border-radius: 22px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  background:
+    radial-gradient(circle at 50% 0%, rgba(255, 255, 255, 0.06), transparent 46%),
+    linear-gradient(180deg, rgba(22, 29, 54, 0.9), rgba(10, 15, 30, 0.84));
+  border: 1px solid rgba(246, 190, 62, 0.26);
+  box-shadow: 0 26px 80px rgba(0, 0, 0, 0.48), inset 0 1px 0 rgba(255, 255, 255, 0.07);
+  backdrop-filter: blur(18px);
+  border-radius: var(--radius-panel-ui);
 }
 @utility glass-input {
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 18px;
-  padding: 18px 24px;
+  background: rgba(8, 13, 28, 0.56);
+  border: 1px solid rgba(255, 255, 255, 0.13);
+  border-radius: 20px;
+  padding: 18px 20px;
   color: var(--foreground);
   font-size: 16px;
   outline: none;
-  transition: all 0.25s;
+  transition: all 0.2s;
   &::placeholder {
-    color: rgba(51, 65, 85, 1);
+    color: rgba(210, 218, 240, 0.42);
     letter-spacing: 1px;
-    font-size: 13px;
+    font-size: 14px;
   }
   &:focus {
-    border-color: rgba(251, 191, 36, 0.3);
-    background: rgba(255, 255, 255, 0.07);
-    box-shadow: 0 0 0 3px rgba(251, 191, 36, 0.06);
+    border-color: rgba(246, 190, 62, 0.58);
+    box-shadow: 0 0 0 4px rgba(246, 190, 62, 0.10);
   }
 }
 @utility glass-modal-backdrop {
   background: rgba(0, 0, 0, 0.6);
-  backdrop-filter: blur(4px);
+  backdrop-filter: blur(8px);
+}
+@utility gold-button-base {
+  border: 0;
+  border-radius: 18px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.28), transparent 24%),
+    linear-gradient(135deg, var(--gold-2), var(--gold) 52%, #f1a72d);
+  color: #161513;
+  font-weight: 900;
+  box-shadow: 0 0 26px rgba(246, 190, 62, 0.34), 0 10px 30px rgba(0, 0, 0, 0.35);
+  &:hover {
+    filter: brightness(1.05);
+  }
 }
 @utility bg-wild-gradient {
   background: conic-gradient(#ff3366 0deg 90deg, #4488ff 90deg 180deg, #33cc66 180deg 270deg, #fbbf24 270deg 360deg);

--- a/packages/client/src/shared/components/ChangelogModal.tsx
+++ b/packages/client/src/shared/components/ChangelogModal.tsx
@@ -39,7 +39,7 @@ export default function ChangelogModal() {
   return (
     <AnimatePresence>
       {open && (
-        <div className="fixed inset-0 z-modal flex items-center justify-center">
+        <div className="fixed inset-0 z-modal flex items-center justify-center px-4">
           <motion.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}

--- a/packages/client/src/shared/components/DecoCards.tsx
+++ b/packages/client/src/shared/components/DecoCards.tsx
@@ -1,23 +1,25 @@
 const CARDS = [
-  { value: '7', color: 'rgba(255,51,102,0.25)', border: '#ff3366', top: '8%', left: '6%', rotate: '-18deg' },
-  { value: '+2', color: 'rgba(68,136,255,0.25)', border: '#4488ff', top: '14%', right: '8%', rotate: '10deg' },
-  { value: '5', color: 'rgba(51,204,102,0.25)', border: '#33cc66', bottom: '10%', left: '8%', rotate: '12deg' },
-  { value: '9', color: 'rgba(251,191,36,0.25)', border: '#fbbf24', bottom: '12%', right: '12%', rotate: '-8deg' },
-  { value: '⇆', color: 'rgba(68,136,255,0.2)', border: '#4488ff', top: '40%', left: '4%', rotate: '6deg' },
-  { value: '0', color: 'rgba(255,51,102,0.2)', border: '#ff3366', bottom: '32%', right: '5%', rotate: '-14deg' },
+  { value: '7', color: '#ff5c63', borderColor: 'rgba(255, 92, 99, 0.28)', top: '15%', left: '7%', rotate: '-15deg' },
+  { value: '+2', color: '#4d7eff', borderColor: 'rgba(77, 126, 255, 0.28)', top: '17%', right: '7%', rotate: '12deg' },
+  { value: '↔', color: '#4d7eff', borderColor: 'rgba(77, 126, 255, 0.28)', top: '44%', left: '4%', rotate: '9deg' },
+  { value: '0', color: '#ff5c63', borderColor: 'rgba(255, 92, 99, 0.28)', top: '58%', right: '7%', rotate: '-14deg' },
+  { value: '5', color: '#50e16b', borderColor: 'rgba(80, 225, 107, 0.26)', bottom: '16%', left: '8%', rotate: '13deg' },
+  { value: '9', color: 'var(--gold)', borderColor: 'rgba(246, 190, 62, 0.28)', bottom: '13%', right: '12%', rotate: '-11deg' },
 ];
 
 export default function DecoCards() {
   return (
-    <div className="absolute inset-0 pointer-events-none z-0 overflow-hidden">
+    <div className="absolute inset-0 pointer-events-none z-[1] overflow-hidden">
       {CARDS.map((card, i) => (
         <div
           key={i}
-          className="absolute w-16 h-24 rounded-[10px] flex items-center justify-center text-2xl font-black opacity-[0.06]"
+          className="absolute w-[78px] h-[112px] rounded-[16px] grid place-items-center text-[26px] font-extrabold opacity-[0.32] select-none"
           style={{
-            background: card.color,
-            border: '2px solid rgba(255,255,255,0.08)',
-            color: card.border,
+            background: 'linear-gradient(145deg, rgba(255,255,255,0.07), rgba(255,255,255,0.015))',
+            border: `1px solid ${card.borderColor}`,
+            boxShadow: 'inset 0 0 24px rgba(255,255,255,0.04), 0 18px 42px rgba(0,0,0,0.26)',
+            filter: 'blur(0.2px)',
+            color: card.color,
             top: card.top, left: card.left, right: card.right, bottom: card.bottom,
             transform: `rotate(${card.rotate})`,
           }}

--- a/packages/client/src/shared/components/FitScaler.tsx
+++ b/packages/client/src/shared/components/FitScaler.tsx
@@ -1,0 +1,87 @@
+import { useLayoutEffect, useRef, useState, type CSSProperties, type ReactNode } from 'react';
+
+type Mode = 'contain' | 'width' | 'height';
+type Align = 'center' | 'start' | 'end';
+
+interface Props {
+  children: ReactNode;
+  /** contain = fit both axes (default), width/height = fit a single axis */
+  mode?: Mode;
+  /** Upper bound on scale. 1 = never upscale beyond the natural design size. */
+  maxScale?: number;
+  /** Alignment of the (pre-scale) content box inside the available area. */
+  align?: Align;
+  /** transform-origin for the scale; keep matching `align` so content stays anchored. */
+  origin?: CSSProperties['transformOrigin'];
+  /** Positions/sizes the available area (e.g. "absolute inset-x-0 top-[88px] bottom-[84px]"). */
+  className?: string;
+  style?: CSSProperties;
+}
+
+const ALIGN_CLASS: Record<Align, string> = {
+  center: 'items-center justify-center',
+  start: 'items-start justify-start',
+  end: 'items-start justify-end',
+};
+
+/**
+ * Game-style canvas scaling. Renders `children` at their natural (fixed) design
+ * size and scales the whole block uniformly so it always fits the available area
+ * — never reflowing, never clipping. This is the menu-screen analogue of a game
+ * engine's "scale with screen size" canvas: design once at a logical size, then
+ * the same layout shrinks (or grows up to maxScale) to fit any resolution/aspect.
+ *
+ * Children MUST use fixed (px) sizes, not vw/%/clamp — otherwise the natural size
+ * tracks the viewport and the scaling can't be measured reliably.
+ */
+export default function FitScaler({
+  children,
+  mode = 'contain',
+  maxScale = 1,
+  align = 'center',
+  origin = 'center center',
+  className,
+  style,
+}: Props) {
+  const areaRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [scale, setScale] = useState(1);
+
+  useLayoutEffect(() => {
+    const area = areaRef.current;
+    const content = contentRef.current;
+    if (!area || !content) return;
+
+    const compute = () => {
+      const aw = area.clientWidth;
+      const ah = area.clientHeight;
+      const cw = content.offsetWidth;
+      const ch = content.offsetHeight;
+      if (!aw || !ah || !cw || !ch) return;
+      const byW = aw / cw;
+      const byH = ah / ch;
+      const next =
+        mode === 'width' ? Math.min(maxScale, byW)
+        : mode === 'height' ? Math.min(maxScale, byH)
+        : Math.min(maxScale, byW, byH);
+      setScale(next > 0 ? next : maxScale);
+    };
+
+    compute();
+    const ro = new ResizeObserver(compute);
+    ro.observe(area);
+    ro.observe(content);
+    return () => ro.disconnect();
+  }, [mode, maxScale]);
+
+  return (
+    <div ref={areaRef} className={`flex ${ALIGN_CLASS[align]} ${className ?? ''}`} style={style}>
+      <div
+        ref={contentRef}
+        style={{ transform: `scale(${scale})`, transformOrigin: origin, flex: '0 0 auto' }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/shared/components/GamePageShell.tsx
+++ b/packages/client/src/shared/components/GamePageShell.tsx
@@ -8,10 +8,44 @@ interface Props {
 
 export default function GamePageShell({ children, showDecoCards = true }: Props) {
   return (
-    <div className="w-screen h-screen relative overflow-hidden flex items-center justify-center">
+    <div
+      className="w-screen h-screen relative overflow-hidden flex items-center justify-center"
+      style={{
+        background: `
+          radial-gradient(circle at 50% 42%, rgba(246, 190, 62, 0.12), transparent 30%),
+          radial-gradient(circle at 50% 100%, rgba(246, 190, 62, 0.12), transparent 26%),
+          linear-gradient(180deg, #0a1020 0%, #15172a 52%, #080d19 100%)
+        `,
+      }}
+    >
+      {/* Decorative ring arcs */}
+      <div
+        className="absolute pointer-events-none"
+        style={{
+          inset: '-20% -10% auto',
+          height: '90%',
+          opacity: 0.75,
+          background: `
+            radial-gradient(circle at 50% 50%, transparent 0 44%, rgba(246, 190, 62, 0.12) 44.3%, transparent 44.8%),
+            radial-gradient(circle at 50% 50%, transparent 0 56%, rgba(255, 255, 255, 0.04) 56.2%, transparent 56.6%)
+          `,
+        }}
+      />
+      {/* Bottom glow */}
+      <div
+        className="absolute bottom-0 left-0 right-0 h-[190px] pointer-events-none"
+        style={{
+          opacity: 0.55,
+          background: `
+            radial-gradient(circle at 50% 100%, rgba(246, 190, 62, 0.42), transparent 12%),
+            linear-gradient(180deg, transparent 0%, rgba(0, 0, 0, 0.72) 80%)
+          `,
+        }}
+      />
+      {/* Central breathing glow */}
       <div
         className="absolute top-[42%] left-[50%] -translate-x-1/2 -translate-y-1/2 w-[900px] h-[900px] rounded-full pointer-events-none animate-[breathe_6s_ease-in-out_infinite]"
-        style={{ background: 'radial-gradient(circle, rgba(251,191,36,0.06) 0%, rgba(251,191,36,0.02) 30%, transparent 60%)' }}
+        style={{ background: 'radial-gradient(circle, rgba(246,190,62,0.08) 0%, rgba(246,190,62,0.03) 30%, transparent 60%)' }}
       />
       {showDecoCards && <DecoCards />}
       {children}

--- a/packages/client/src/shared/components/GameTopBar.tsx
+++ b/packages/client/src/shared/components/GameTopBar.tsx
@@ -7,10 +7,8 @@ interface Props {
 
 export default function GameTopBar({ leftControls }: Props) {
   return (
-    <div className="absolute top-0 left-0 right-0 px-8 py-6 flex justify-between items-center z-10">
-      <div className="flex items-center gap-2">
-        {leftControls}
-      </div>
+    <div className="absolute top-0 left-0 right-0 px-8 max-sm:px-5 py-[34px] max-sm:py-5 flex justify-between items-center z-10">
+      <div className="flex items-center gap-4 max-sm:gap-2">{leftControls}</div>
       <UserCapsule />
     </div>
   );

--- a/packages/client/src/shared/components/NotificationPermissionDialog.tsx
+++ b/packages/client/src/shared/components/NotificationPermissionDialog.tsx
@@ -36,7 +36,7 @@ export default function NotificationPermissionDialog() {
   return (
     <AnimatePresence>
       {open && (
-        <div className="fixed inset-0 z-modal flex items-center justify-center">
+        <div className="fixed inset-0 z-modal flex items-center justify-center px-4">
           <motion.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}

--- a/packages/client/src/shared/components/ServerSelectModal.tsx
+++ b/packages/client/src/shared/components/ServerSelectModal.tsx
@@ -163,7 +163,7 @@ export function ServerSelectModal() {
   return (
     <AnimatePresence>
       {isModalOpen && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center">
+        <div className="fixed inset-0 z-50 flex items-center justify-center px-4">
           {/* Backdrop */}
           <motion.div
             initial={{ opacity: 0 }}

--- a/packages/client/src/shared/components/ServerStatusBar.tsx
+++ b/packages/client/src/shared/components/ServerStatusBar.tsx
@@ -24,23 +24,23 @@ export default function ServerStatusBar() {
   return (
     <button
       onClick={openModal}
-      className="absolute bottom-6 left-8 z-[5] flex items-center gap-3 px-3.5 py-2 rounded-[14px] bg-white/[0.02] border border-white/[0.04] cursor-pointer transition-all hover:bg-white/[0.04] hover:border-white/[0.08]"
+      className="absolute bottom-7 max-sm:bottom-5 left-8 max-sm:left-5 z-[5] flex items-center gap-3.5 max-sm:gap-2 h-[46px] max-sm:h-[38px] px-[18px] max-sm:px-3 rounded-full bg-white/[0.045] border border-white/[0.12] cursor-pointer transition-all hover:bg-white/[0.07] hover:border-white/[0.18] backdrop-blur-[16px] shadow-[0_16px_40px_rgba(0,0,0,0.24),inset_0_1px_0_rgba(255,255,255,0.05)]"
     >
-      <span className="flex items-center gap-1.5 text-xs text-[#64748b] font-medium">
-        <Globe size={12} /> {info?.name ?? current?.name ?? '服务器'}
+      <span className="flex items-center gap-2 max-sm:gap-1.5 text-[13px] max-sm:text-[12px] text-[#dbe3f8] font-medium">
+        <Globe size={16} className="max-sm:w-3.5 max-sm:h-3.5" /> {info?.name ?? current?.name ?? '服务器'}
       </span>
-      <span className="w-px h-3.5 bg-white/[0.06]" />
-      <span className="flex items-center gap-[5px] text-[11px]">
+      <span className="w-px h-[22px] max-sm:h-4 bg-white/[0.18]" />
+      <span className="flex items-center gap-[6px] max-sm:gap-1 text-[13px] max-sm:text-[12px]">
         <span
-          className="w-1.5 h-1.5 rounded-full"
-          style={{ background: ping.dot, boxShadow: `0 0 6px ${ping.dot}60` }}
+          className="w-[9px] h-[9px] max-sm:w-2 max-sm:h-2 rounded-full"
+          style={{ background: ping.dot, boxShadow: `0 0 10px ${ping.dot}` }}
         />
-        <span style={{ color: ping.text }} className="font-medium">
+        <span style={{ color: ping.text }} className="font-bold">
           {latency != null ? `${latency}ms` : '--'}
         </span>
       </span>
-      <span className="w-px h-3.5 bg-white/[0.06]" />
-      <span className="text-[11px] text-[#334155]">v{BUILD_VERSION}</span>
+      <span className="w-px h-[22px] max-sm:h-4 bg-white/[0.18]" />
+      <span className="text-[13px] max-sm:text-[12px] text-[#8b95b3]">v{BUILD_VERSION}</span>
     </button>
   );
 }

--- a/packages/client/src/shared/components/ServerUpdateDialog.tsx
+++ b/packages/client/src/shared/components/ServerUpdateDialog.tsx
@@ -10,7 +10,7 @@ export default function ServerUpdateDialog() {
   return (
     <AnimatePresence>
       {needsRefresh && (
-        <div className="fixed inset-0 z-modal flex items-center justify-center">
+        <div className="fixed inset-0 z-modal flex items-center justify-center px-4">
           <motion.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}

--- a/packages/client/src/shared/components/TutorialModal.tsx
+++ b/packages/client/src/shared/components/TutorialModal.tsx
@@ -181,11 +181,18 @@ export default function TutorialModal({ open, onClose }: { open: boolean; onClos
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
           transition={{ duration: 0.3 }}
-          className="fixed inset-0 z-modal flex flex-col bg-[linear-gradient(135deg,#1a1a2e_0%,#16213e_50%,#0f3460_100%)]"
+          className="fixed inset-0 z-modal flex flex-col"
+          style={{
+            background: `
+              radial-gradient(circle at 50% 42%, rgba(246, 190, 62, 0.12), transparent 30%),
+              radial-gradient(circle at 50% 100%, rgba(246, 190, 62, 0.12), transparent 26%),
+              linear-gradient(180deg, #0a1020 0%, #15172a 52%, #080d19 100%)
+            `,
+          }}
         >
           <div
             className="absolute top-[42%] left-[50%] -translate-x-1/2 -translate-y-1/2 w-[900px] h-[900px] rounded-full pointer-events-none animate-[breathe_6s_ease-in-out_infinite]"
-            style={{ background: 'radial-gradient(circle, rgba(251,191,36,0.06) 0%, rgba(251,191,36,0.02) 30%, transparent 60%)' }}
+            style={{ background: 'radial-gradient(circle, rgba(246,190,62,0.08) 0%, rgba(246,190,62,0.03) 30%, transparent 60%)' }}
           />
           <button
             onClick={close}

--- a/packages/client/src/shared/components/UserCapsule.tsx
+++ b/packages/client/src/shared/components/UserCapsule.tsx
@@ -28,19 +28,19 @@ export default function UserCapsule() {
     <div ref={ref} className="relative">
       <button
         onClick={() => setOpen((v) => !v)}
-        className="flex items-center gap-3 cursor-pointer px-[18px] py-2 pr-2 rounded-[28px] bg-white/[0.03] border border-white/[0.06] transition-all hover:bg-white/[0.06] hover:border-white/10"
+        className="flex items-center gap-3 cursor-pointer h-[58px] max-sm:h-12 px-[22px] max-sm:px-0 pr-[10px] max-sm:pr-0 rounded-full bg-white/[0.045] max-sm:bg-transparent border border-white/[0.12] max-sm:border-0 transition-all hover:bg-white/[0.07] hover:border-white/[0.18] shadow-[0_18px_40px_rgba(0,0,0,0.25),inset_0_1px_0_rgba(255,255,255,0.06)] max-sm:shadow-none"
       >
-        <span className="text-[13px] text-muted-foreground">
-          欢迎, <span className="font-semibold text-foreground" style={roleColor ? { color: roleColor } : undefined}>
+        <span className="text-[14px] text-[#d7def2] max-sm:hidden">
+          欢迎, <b className="text-[var(--gold)]" style={roleColor ? { color: roleColor } : undefined}>
             {user?.nickname ?? user?.username}
-          </span>
+          </b>
         </span>
-        <span className="w-9 h-9 rounded-full bg-gradient-to-br from-[#fbbf24] to-[#f59e0b] flex items-center justify-center text-sm font-bold text-[#1a1a2e] overflow-hidden">
+        <ChevronDown size={16} className={`text-[#d7def2] transition-transform max-sm:hidden ${open ? 'rotate-180' : ''}`} />
+        <span className="w-[46px] h-[46px] max-sm:w-12 max-sm:h-12 rounded-full bg-gradient-to-br from-[#ffd66d] to-[#f6be3e] flex items-center justify-center text-base font-bold text-[#161513] overflow-hidden border-2 border-[rgba(246,190,62,0.55)] shadow-[0_0_22px_rgba(246,190,62,0.32)]">
           {user?.avatarUrl
             ? <img src={user.avatarUrl} alt={initial} className="w-full h-full object-cover" referrerPolicy="no-referrer" onError={(e) => { e.currentTarget.style.display = 'none'; }} />
             : initial}
         </span>
-        <ChevronDown size={12} className={`text-[#475569] transition-transform ${open ? 'rotate-180' : ''}`} />
       </button>
 
       <div className={`absolute top-[calc(100%+8px)] right-0 w-[180px] glass-panel p-1.5 z-20 transition-all duration-200 ${

--- a/packages/client/src/shared/components/ui/Button.tsx
+++ b/packages/client/src/shared/components/ui/Button.tsx
@@ -20,7 +20,7 @@ const buttonVariants = cva(
         outline:
           'bg-transparent text-primary border-2 border-primary/50 px-5 py-2 text-sm hover:bg-primary/10',
         game:
-          'bg-gradient-to-br from-[#fbbf24] to-[#f59e0b] text-[#1a1a2e] px-6 py-[22px] text-xl font-[family-name:var(--font-game)] tracking-[4px] shadow-[0_6px_28px_rgba(251,191,36,0.25),inset_0_1px_0_rgba(255,255,255,0.2)] hover:translate-y-[-3px] hover:shadow-[0_10px_40px_rgba(251,191,36,0.35),inset_0_1px_0_rgba(255,255,255,0.2)] active:translate-y-[-1px] relative overflow-hidden',
+          'gold-button-base text-[#161513] px-6 py-[22px] text-xl font-[family-name:var(--font-game)] tracking-[6px] hover:translate-y-[-2px] active:translate-y-[-1px] relative overflow-hidden',
       },
       size: {
         default: '',


### PR DESCRIPTION
## Summary

客户端全局视觉重构，纯样式/布局变更，无逻辑改动。

### 主题与色系
- 整体色调从蓝灰 (`#1a1a2e`/`#16213e`) 换为深暗蓝黑 (`#070b16`/`#0b1021`)
- 统一金色为 CSS 变量体系：`--gold`、`--gold-2`、`--gold-3`
- 新增 `--panel`、`--line`、`--line-gold` 等语义变量

### 新组件
- **FitScaler** — 游戏风格等比缩放容器，固定设计尺寸自动适配屏幕（ResizeObserver），不重排不裁切

### 页面重构
- **大厅** — 品牌标题渐变金色、glass-panel 操作面板、FitScaler 包裹、更大按钮和输入框
- **注册页** — 表单字段加左侧图标、统一 68px 高度输入框
- **AuthLayout** — FitScaler 包裹、更大面板和标题
- **房间页** — 房间码改为带边框标签、按钮统一圆角胶囊样式、设置齿轮加金色 hover

### 组件统一
- SeatCircle 桌面改金色辉光、Seat 空位 hover 金色
- SettingsDrawer 开关改金色渐变、面板加毛玻璃效果
- Button game 变体使用新 `gold-button-base` utility
- UserCapsule 金色头像边框和阴影
- DecoCards 改为半透明毛玻璃风格

### 响应式
- GameTopBar / ServerStatusBar / GitHub 链接 / UserCapsule 加 `max-sm:` 移动端适配
- 卡面资源包按钮移动端隐藏（文件选择器体验差）
- 活跃房间面板 `xl:` 以上才显示

### 防溢出
- ChangelogModal / NotificationPermissionDialog / ServerSelectModal / ServerUpdateDialog 加 `px-4`

### CSS Utilities
- 新增 `gold-button-base`
- 重构 `glass-panel`（radial-gradient 高光 + 金色边框）
- 重构 `glass-input`（更深底色 + 更亮 placeholder）

## Test plan

- [ ] `pnpm --filter client build` 构建通过
- [ ] 登录页、注册页视觉正常
- [ ] 大厅页面品牌标题、创建/加入房间面板正常
- [ ] 游戏房间页座位、设置面板、按钮样式正常
- [ ] 移动端窄屏下布局不溢出、弹窗正常显示
- [ ] FitScaler 缩放行为：缩小浏览器窗口时内容等比缩小，不重排

🤖 Generated with [Claude Code](https://claude.com/claude-code)