### PR TITLE
fix: Passkey 登录按钮图标和文字换行

### DIFF
--- a/packages/client/src/features/auth/pages/HomePage.tsx
+++ b/packages/client/src/features/auth/pages/HomePage.tsx
@@ -198,12 +198,12 @@ export default function HomePage() {
             </div>
             <Button
               variant="game"
-              className="w-full h-[76px] text-2xl tracking-[0.35em]"
+              className="w-full h-[76px] text-2xl tracking-[0.35em] flex items-center justify-center gap-2"
               onClick={handlePasskeyLogin}
               disabled={passkeyLoggingIn}
               sound="click"
             >
-              <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} className="mr-2">
+              <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} className="shrink-0">
                 <path d="M2 18v3c0 .6.4 1 1 1h4v-3h3v-3h2l1.4-1.4a6.5 6.5 0 1 0-4-4Z" />
                 <circle cx="16.5" cy="7.5" r=".5" fill="currentColor" />
               </svg>


### PR DESCRIPTION
## Summary

- Passkey 登录按钮的 SVG 图标和文字被换行显示
- 添加 `flex items-center justify-center gap-2` 使图标和文字水平居中排列
- SVG 加 `shrink-0` 防止被压缩

🤖 Generated with [Claude Code](https://claude.com/claude-code)