### PR TITLE
fix(client): 大倒计时遮罩改用 portal 渲染

### DIFF
--- a/packages/client/src/features/game/components/TurnTimer.tsx
+++ b/packages/client/src/features/game/components/TurnTimer.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import { Timer } from 'lucide-react';
 import { useGameStore } from '../stores/game-store';
 import { useCountdown } from '../hooks/useCountdown';
@@ -29,12 +30,13 @@ export default function TurnTimer() {
       )}>
         <Timer size={14} className="inline align-middle" /> {secondsLeft}s
       </span>
-      {isCritical && secondsLeft > 0 && (
+      {isCritical && secondsLeft > 0 && createPortal(
         <div className="fixed inset-0 flex items-center justify-center pointer-events-none z-timer-overlay">
           <span className="text-timer-critical font-black font-game text-destructive animate-timer-flash opacity-80 text-shadow-bold">
             {secondsLeft}
           </span>
-        </div>
+        </div>,
+        document.body,
       )}
     </>
   );


### PR DESCRIPTION
TurnTimer 的临界大数字（≤5s）是 position:fixed 全屏居中，但重构后它被渲染进 GameHUD 右侧的 FitScaler（transform: scale）容器——transform 会让 fixed 元素相对缩放容器定位而不是视口，导致大数字跑到右上角且被裁切。改为 createPortal 到 document.body。已用 6s 短回合实测验证全屏居中。