### PR TITLE
perf(client): 修复对局中持续重栅格化导致的移动端发热

### DIFF
--- a/packages/client/src/features/game/components/ColorWave.tsx
+++ b/packages/client/src/features/game/components/ColorWave.tsx
@@ -7,6 +7,8 @@ import { UNO_COLOR_HEX } from '../constants/colors';
 interface WaveState {
   id: number;
   color: string;
+  /** 涟漪终态直径：盖住视口对角线即可，再大都是白烧栅格化 */
+  size: number;
 }
 
 export default function ColorWave() {
@@ -30,7 +32,8 @@ export default function ColorWave() {
     if (!hex) return;
 
     const id = ++waveIdRef.current;
-    setWave({ id, color: hex });
+    const size = Math.ceil(Math.hypot(window.innerWidth, window.innerHeight));
+    setWave({ id, color: hex, size });
     const timer = setTimeout(() => setWave(null), 1200);
     return () => clearTimeout(timer);
   }, [currentColor, lastAction, phase]);
@@ -46,35 +49,39 @@ export default function ColorWave() {
           exit={{ opacity: 0 }}
           transition={{ duration: 0.15 }}
         >
+          {/* 关键：两层都按「最终尺寸」布局，再从 scale 0 放大到 1。
+              旧写法是 8px/40px 的小元素放大到 scale 200/60 —— 浏览器会随着 scale 增长
+              反复以更高分辨率重新栅格化这个巨型图层（实测占整个渲染进程 CPU 的 ~40%）。
+              按终态尺寸布局后只栅格化一次，之后纯合成器缩放。 */}
           <motion.div
-            className="absolute rounded-full" data-allow-overflow
+            className="absolute rounded-full will-change-transform" data-allow-overflow
             style={{
               left: '50%',
               top: '50%',
-              width: 40,
-              height: 40,
-              marginLeft: -20,
-              marginTop: -20,
+              width: wave.size,
+              height: wave.size,
+              marginLeft: -wave.size / 2,
+              marginTop: -wave.size / 2,
               background: `radial-gradient(circle, ${wave.color}44 0%, ${wave.color}00 70%)`,
-              boxShadow: `0 0 60px 20px ${wave.color}55`,
             }}
             initial={{ scale: 0, opacity: 0.9 }}
-            animate={{ scale: 60, opacity: 0 }}
+            animate={{ scale: 1, opacity: 0 }}
             transition={{ duration: 1, ease: 'easeOut' }}
           />
           <motion.div
-            className="absolute rounded-full" data-allow-overflow
+            className="absolute rounded-full will-change-transform" data-allow-overflow
             style={{
               left: '50%',
               top: '50%',
-              width: 8,
-              height: 8,
-              marginLeft: -4,
-              marginTop: -4,
-              border: `2px solid ${wave.color}`,
+              width: wave.size,
+              height: wave.size,
+              marginLeft: -wave.size / 2,
+              marginTop: -wave.size / 2,
+              // 旧写法 2px 边框被放大 200 倍 ≈ 400 视觉像素，这里按比例直接给到终态
+              border: `${Math.round(wave.size * 0.25)}px solid ${wave.color}`,
             }}
             initial={{ scale: 0, opacity: 1 }}
-            animate={{ scale: 200, opacity: 0 }}
+            animate={{ scale: 1, opacity: 0 }}
             transition={{ duration: 1.1, ease: 'easeOut' }}
           />
         </motion.div>

--- a/packages/client/src/features/game/components/GameEffects.tsx
+++ b/packages/client/src/features/game/components/GameEffects.tsx
@@ -239,10 +239,14 @@ export default function GameEffects() {
           {effects.map((effect) => (
             <motion.div
               key={effect.id}
-              initial={{ scale: 0.3, opacity: 0, y: 20 }}
+              // 缩放区间从 0.3→1.2→2（6.7 倍跨度）收窄到 0.9→1.2→1.35（1.5 倍）：
+              // 大字幕带 SVG 图标和 text-shadow，scale 每变一档就要重新栅格化整屏文字，
+              // 跨度越大重栅格化次数越多。静止态仍是 1.2，观感不变。
+              initial={{ scale: 0.9, opacity: 0, y: 20 }}
               animate={{ scale: 1.2, opacity: 1, y: 0 }}
-              exit={{ scale: 2, opacity: 0, y: -30 }}
+              exit={{ scale: 1.35, opacity: 0, y: -30 }}
               transition={{ type: 'spring', stiffness: 300, damping: 15 }}
+              style={{ willChange: 'transform, opacity' }}
               className={cn(
                 'absolute font-game font-black max-w-[94vw] text-center flex flex-col items-center gap-2 text-shadow-bold text-white',
                 effect.type === 'victory' ? 'text-effect-xl' : 'text-effect',

--- a/packages/e2e/heat-ablate.mjs
+++ b/packages/e2e/heat-ablate.mjs
@@ -1,0 +1,91 @@
+// 消融实验：逐个「摘掉」可疑特效，量出各自对 raster / CPU 的真实贡献
+// 用法: ABLATE='<css selector>' node heat-ablate.mjs   (空 = 基线)
+import { launchBrowser, newAuthedPage, setupGame, dismissGameOverlays, emit } from './lib/driver.mjs';
+
+const ABLATE = process.env.ABLATE ?? '';
+const SECS = Number(process.env.SECS ?? 15);
+const LABEL = process.env.LABEL ?? (ABLATE || 'baseline');
+
+const browser = await launchBrowser();
+const { page } = await newAuthedPage(browser, { username: 'heat-abl', width: 390, height: 844 });
+
+// 在任何渲染前挂上 observer：匹配到的节点一出现就摘掉，等价于该特效不存在
+if (ABLATE) {
+  await page.addInitScript((sel) => {
+    const kill = (root) => {
+      for (const el of root.querySelectorAll?.(sel) ?? []) el.remove();
+    };
+    const start = () => {
+      kill(document);
+      new MutationObserver((recs) => {
+        for (const r of recs)
+          for (const n of r.addedNodes) {
+            if (n.nodeType !== 1) continue;
+            if (n.matches?.(sel)) { n.remove(); continue; }
+            kill(n);
+          }
+      }).observe(document.documentElement, { childList: true, subtree: true });
+    };
+    if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', start);
+    else start();
+  }, ABLATE);
+}
+
+await setupGame(page, { botCount: 3 });
+await page.waitForTimeout(2000);
+await dismissGameOverlays(page);
+await page.waitForTimeout(11000);
+
+const cdp = await page.context().newCDPSession(page);
+await cdp.send('Performance.enable');
+const get = (m, n) => m.metrics.find((x) => x.name === n)?.value ?? 0;
+const snap = async () => {
+  const m = await cdp.send('Performance.getMetrics');
+  return { recalc: get(m, 'RecalcStyleCount'), layout: get(m, 'LayoutCount'), task: get(m, 'TaskDuration'), proc: get(m, 'ProcessTime') };
+};
+
+let raster = 0;
+let rasterMs = 0;
+let paintFull = 0;
+cdp.on('Tracing.dataCollected', (d) => {
+  for (const e of d.value) {
+    if (e.name === 'RasterTask' && e.ph === 'X') { raster++; rasterMs += (e.dur ?? 0) / 1000; }
+    if (e.name === 'Paint' && e.ph === 'X') paintFull++;
+  }
+});
+
+const before = await snap();
+await cdp.send('Tracing.start', {
+  traceConfig: { includedCategories: ['devtools.timeline', 'disabled-by-default-devtools.timeline', 'cc', 'toplevel'] },
+  transferMode: 'ReportEvents',
+});
+
+const end = Date.now() + SECS * 1000;
+let plays = 0;
+while (Date.now() < end) {
+  await emit(page, 'game:autopilot_once');
+  plays++;
+  await page.waitForTimeout(400);
+}
+
+const done = new Promise((r) => cdp.once('Tracing.tracingComplete', r));
+await cdp.send('Tracing.end');
+await done;
+const after = await snap();
+
+// 摘掉的节点数（确认消融真的生效）
+console.log(JSON.stringify({
+  实验: LABEL,
+  秒数: SECS,
+  出牌次数: plays,
+  RasterTask次数: raster,
+  RasterTask每秒: +(raster / SECS).toFixed(1),
+  Raster线程耗时秒: +(rasterMs / 1000).toFixed(2),
+  Paint次数: paintFull,
+  渲染进程CPU秒: +(after.proc - before.proc).toFixed(2),
+  渲染进程CPU核数: +((after.proc - before.proc) / SECS).toFixed(2),
+  主线程Task秒: +(after.task - before.task).toFixed(2),
+  RecalcStyle每秒: +((after.recalc - before.recalc) / SECS).toFixed(1),
+  Layout次数: Math.round(after.layout - before.layout),
+}));
+await browser.close();


### PR DESCRIPTION
## 问题

手机打牌时机身发烫、风扇狂转，但画面并不卡。用 CDP trace 抓下来看，典型特征是**主线程很闲、栅格化线程满载**：

| 指标 | 静置 10s | 打牌 15s |
|---|---|---|
| 渲染进程 CPU | 0.06 核 | **0.38 核** |
| RasterTask | **0** | **480 次/秒** |
| 主线程占用 | 2% | 11% |

栅格化占了整个渲染进程 CPU 的 61%。静置态 raster 为 0、打牌态 480/秒，说明问题不是页面本身重，而是**动画方式把「移动」变成了「持续重绘」**。

## 定责

用消融实验（逐个摘掉可疑元素后重测，出牌次数对齐）定位：

| 实验 | 栅格化耗时 | 渲染进程 CPU | RasterTask/s |
|---|---|---|---|
| 基线 | 3.70s | 0.40 核 | 531 |
| 摘掉 ColorWave | 1.55s | 0.25 核 | 323 |
| 摘掉大字幕 | 2.88s | 0.27 核 | 396 |
| **两个都摘** | **0.15s** | **0.04 核** | **39** |
| 摘掉罗盘节点 | 5.69s | 0.49 核 | 564（无改善）|

两个全屏特效吃掉约 90% 的渲染 CPU。framer-motion 的罗盘/手牌弹簧**不是** raster 来源。

根因是同一个模式：**把小元素用 transform 放大到巨大尺寸**。浏览器的栅格化分辨率跟随当前 transform scale，scale 从 0 涨到 200 意味着这个巨型图层被反复以越来越高的分辨率重新栅格化。

- `ColorWave`：8px 圆环 `scale: 200`（→1600×1600，**7.8 倍视口**）；40px 渐变圆 `scale: 60`，且 `box-shadow: 0 0 60px 20px` 的模糊半径被同步放大 60 倍。每次变色触发，bot 局里几乎一直在跑。
- `GameEffects` 大字幕：`scale 0.3 → 1.2 → 2`（6.7 倍跨度），内容是整屏文字 + 120px SVG + `text-shadow`，文字栅格化本身就贵。

## 改动

两处都改为**按终态尺寸布局，再从 `scale 0` 放大到 `1`** —— 只栅格化一次，之后纯合成器缩放。

- **ColorWave**：终态直径改为视口对角线（930px，而非 1600px，少 66% 峰值图层面积）；边框按比例给到终态（`size × 0.25`，等价于旧的 2px×200）；去掉被放大 60 倍的 `box-shadow`（径向渐变已提供辉光）；加 `will-change: transform`。
- **GameEffects**：缩放区间收窄到 `0.9 → 1.2 → 1.35`（1.5 倍跨度），**静止态仍是 1.2，观感不变**；加 `will-change`。

## 效果

3 次运行 vs 4 次基线，同一 harness、出牌次数对齐：

| | 基线 main | 本 PR | 降幅 |
|---|---|---|---|
| 栅格化线程耗时 | 3.54s | **0.84s** | **−76%** |
| 渲染进程 CPU | 0.38 核 | **0.19 核** | **−50%** |
| RasterTask/s | 480 | **199** | **−59%** |
| 主线程 Task | 1.11s | 1.05s | 不变（本就不是主线程问题）|

修复后再做消融：**摘掉 ColorWave 已无任何收益**（0.23 vs 0.22 核），该点已榨干。

## 验证

- `tsc --noEmit`（client + server）通过，`client build` 通过
- `pnpm test` 378 项全过
- e2e `visual.mjs`：8 种分辨率 32 个场景全过，0 溢出、0 console 错误
- e2e `smoke.mjs` 通过
- 手动抓涟漪动画中间帧截图确认观感正常（几何：布局 930px、边框 233px、`will-change` 生效）

## 附带

新增 `packages/e2e/heat-ablate.mjs` —— 消融归因工具，`ABLATE='<selector>' node heat-ablate.mjs` 即可复现上表所有数字，后续排查同类问题可直接复用。

## 后续可做（未包含在本 PR）

1. 大字幕 + ColorWave + `bg-black/50` 三层全屏特效叠加时仍会互相逼迫重绘，这是从 0.19 核到 0.04 核理论下限之间的主要差距，需要动 z-effects 整层结构。
2. `index.css:80` 的 `drawReadyPulse` 无限动画让**静置时也保持 60 帧/秒**，真机上会一直吊着 GPU 不降频。建议只在真轮到自己时跑 + 页面隐藏时暂停。
3. 全仓库无 `prefers-reduced-motion` 支持，也没有省电/低特效开关。

> 测量环境为 headless + 软件栅格化，绝对 CPU 秒数不能直接套到真机；可迁移的是降幅比例与 RasterTask 计数。

🤖 Generated with [Claude Code](https://claude.com/claude-code)