### PR TITLE
feat(client): 移动端手牌手势——滑动选牌 + 上滑拖出手牌区出牌

### DIFF
--- a/packages/client/src/features/game/components/mobile/MobileHand.tsx
+++ b/packages/client/src/features/game/components/mobile/MobileHand.tsx
@@ -46,6 +46,9 @@ function isColorBoundary(sorted: CardType[], index: number): boolean {
  * 移动端手牌区（全新实现，不与桌面 PlayerHand 共用逻辑）：
  * - 原生横向滚动（touch 惯性），牌少时间距摊开居中，牌多时固定槽位重叠滑动
  * - 点一下：牌抬起放大（自动滚入视野）；再点一下：出牌
+ * - 滑动选牌：按住牌稍作停留后横向拖动，经过的牌依次抬起，边缘自动滚动，松开即选中
+ * - 上滑出牌：按住牌向上滑出阈值后松手直接打出（不可出则弹回）；快速横滑仍是滚动
+ * - 双指捏合调整牌距（持久化）
  * - 可出牌金色发光、不可出置灰；万能牌叠加场景先弹选色
  */
 export default function MobileHand({ onPlayCard }: MobileHandProps) {
@@ -76,29 +79,242 @@ export default function MobileHand({ onPlayCard }: MobileHandProps) {
   spreadRef.current = spread;
   const pinchRef = useRef<{ startDist: number; startSpread: number; latest: number } | null>(null);
 
+  // ---- 单指手势（滑动选牌 / 上滑出牌）----
+  // 上滑拖拽中的牌、纵向偏移与是否已达打出线（松手后清空，牌弹回或打出）
+  const [dragState, setDragState] = useState<{ id: string; dy: number; canPlay: boolean } | null>(null);
+  // 容器 overflow 放开标记：松手回弹（弹簧 ~0.4s）期间保持放开，否则回弹中的牌会被容器上沿裁断
+  const [dragOverflowFree, setDragOverflowFree] = useState(false);
+  useEffect(() => {
+    if (dragState) {
+      setDragOverflowFree(true);
+      return;
+    }
+    const t = setTimeout(() => setDragOverflowFree(false), 500);
+    return () => clearTimeout(t);
+  }, [dragState]);
+  // 拖拽手势已处理选择/出牌时，抑制随后的 click（避免 tap 逻辑重复触发）
+  const suppressClickRef = useRef(false);
+  const gestureRef = useRef<{
+    touchId: number;
+    cardId: string;
+    x0: number;
+    y0: number;
+    t0: number;
+    /** 打出线：手牌区容器上沿，松手时手指在其上方才算打出（防误触） */
+    playLineY: number;
+    mode: 'undecided' | 'scroll' | 'hold' | 'browse' | 'play';
+    lastX: number;
+    lastY: number;
+  } | null>(null);
+  const edgeScrollIvRef = useRef<number | null>(null);
+  // 原生 touch 监听器（[] 依赖）通过 ref 读最新数据
+  const dataRef = useRef({ sorted, playableIds });
+  dataRef.current = { sorted, playableIds };
+
+  /** 确认出牌（可出校验 + 选色 + 飞牌起点），tap 与上滑共用 */
+  const confirmPlay = (card: CardType): boolean => {
+    if (!dataRef.current.playableIds.has(card.id)) return false;
+    if (shouldPickColorBeforePlay(card)) {
+      setPendingColorCardId(card.id);
+      return true;
+    }
+    // 出牌前记录精确槽位，飞牌从这里起飞
+    const el = scrollRef.current?.querySelector(`[data-card-id="${card.id}"]`);
+    const rect = el?.getBoundingClientRect();
+    if (rect) useFxStore.getState().setPlayOrigin(card.id, { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 });
+    onPlayCard(card.id);
+    setSelectedId(null);
+    return true;
+  };
+  const confirmPlayRef = useRef(confirmPlay);
+  confirmPlayRef.current = confirmPlay;
+  // hold 模式 preventDefault 会抑制 click，松手时需手动走 tap 逻辑
+  const tapRef = useRef<(card: CardType) => void>(() => {});
+  tapRef.current = (card) => handleTap(card);
+
   // React 的 touch 监听是 passive 的，preventDefault 需要原生监听
   useEffect(() => {
     const el = scrollRef.current;
     if (!el) return;
+
+    const stopEdgeScroll = () => {
+      if (edgeScrollIvRef.current != null) {
+        clearInterval(edgeScrollIvRef.current);
+        edgeScrollIvRef.current = null;
+      }
+    };
+    // 浏览模式命中检测：在牌列底部边缘取样（抬起的牌上移了 RAISE，盖不到这里），
+    // 避免命中「已抬起牌」导致选中滞后一张
+    const hitCardId = (x: number, y?: number): string | null => {
+      const rect = scrollRef.current?.getBoundingClientRect();
+      const sampleY = rect ? rect.bottom - 16 : (y ?? 0);
+      return (document.elementFromPoint(x, sampleY)?.closest('[data-card-id]') as HTMLElement | null)?.dataset.cardId ?? null;
+    };
+    // 浏览模式下手指停在屏幕边缘时自动滚动手牌，并重新命中指下的牌
+    const startEdgeScroll = () => {
+      if (edgeScrollIvRef.current != null) return;
+      edgeScrollIvRef.current = window.setInterval(() => {
+        const g = gestureRef.current;
+        const container = scrollRef.current;
+        if (!g || !container || g.mode !== 'browse') return;
+        const vw = container.clientWidth;
+        if (g.lastX < 44) container.scrollLeft -= 16;
+        else if (g.lastX > vw - 44) container.scrollLeft += 16;
+        else return;
+        const hit = hitCardId(g.lastX, g.lastY);
+        if (hit) setSelectedId(hit);
+      }, 30);
+    };
+
     const onStart = (e: TouchEvent) => {
       // 多点触控是逐个手指 touchstart 的：第二指落下时 touches.length 才为 2
       if (e.touches.length === 2) {
         pinchRef.current = { startDist: touchDist(e.touches), startSpread: spreadRef.current, latest: spreadRef.current };
+        // 双指捏合接管：取消进行中的单指手势
+        if (gestureRef.current) {
+          gestureRef.current = null;
+          setDragState(null);
+          stopEdgeScroll();
+        }
+        return;
+      }
+      if (e.touches.length !== 1) return;
+      const t = e.touches[0]!;
+      const cardId = (t.target as HTMLElement).closest('[data-card-id]')?.getAttribute('data-card-id');
+      if (!cardId) return;
+      gestureRef.current = {
+        touchId: t.identifier, cardId,
+        x0: t.clientX, y0: t.clientY, t0: Date.now(),
+        playLineY: (scrollRef.current?.getBoundingClientRect().top ?? t.clientY) - 4,
+        mode: 'undecided', lastX: t.clientX, lastY: t.clientY,
+      };
+    };
+
+    const onMove = (e: TouchEvent) => {
+      if (e.touches.length === 2 && pinchRef.current) {
+        e.preventDefault(); // 阻止页面缩放与横滑
+        const ratio = touchDist(e.touches) / pinchRef.current.startDist;
+        const next = Math.min(SPREAD_MAX, Math.max(SPREAD_MIN, pinchRef.current.startSpread * ratio));
+        pinchRef.current.latest = next; // state 异步，touchend 持久化要用这个同步值
+        setSpread(next);
+        return;
+      }
+      const g = gestureRef.current;
+      if (!g || g.mode === 'scroll') return;
+      const t = [...e.changedTouches].find((x) => x.identifier === g.touchId);
+      if (!t) return;
+      g.lastX = t.clientX;
+      g.lastY = t.clientY;
+      const dx = t.clientX - g.x0;
+      const dy = t.clientY - g.y0;
+      const elapsed = Date.now() - g.t0;
+      // 浏览器可能已在判定窗口内接管了原生滚动（不可 cancel），此时让位滚动而不是报错
+      const tryPrevent = (): boolean => {
+        if (e.cancelable) {
+          e.preventDefault();
+          return true;
+        }
+        g.mode = 'scroll';
+        setDragState(null);
+        stopEdgeScroll();
+        return false;
+      };
+      // 跟手拖拽状态：附带是否已过打出线（手指拖出手牌区上沿）
+      const updateDrag = (dy: number) =>
+        setDragState({ id: g.cardId, dy, canPlay: t.clientY < g.playLineY });
+
+      if (g.mode === 'undecided') {
+        // 首个 move 必须当场决断：一旦放过未 cancel 的 move，浏览器会锁定本次触摸
+        // 为原生滚动（后续全 cancelable=false），手势就再也接管不了
+        if (Math.abs(dx) >= 6 && Math.abs(dx) > Math.abs(dy) * 1.5 && elapsed < 140) {
+          g.mode = 'scroll'; // 明显横向快滑：交还原生滚动（保留惯性）
+          return;
+        }
+        if (!tryPrevent()) return;
+        if (dy < -10) {
+          // 上滑出牌：立即抬起跟手（未过打出线松手弹回，轻微抖动无害）
+          g.mode = 'play';
+          setSelectedId(g.cardId);
+          updateDrag(Math.min(0, dy));
+        } else {
+          g.mode = 'hold'; // 垂直/微动：按住，等浏览判定
+        }
+        return;
+      }
+
+      if (g.mode === 'hold') {
+        if (!tryPrevent()) return;
+        if (dy < -14 && Math.abs(dy) > Math.abs(dx)) {
+          g.mode = 'play';
+          setSelectedId(g.cardId);
+          updateDrag(Math.min(0, dy));
+          return;
+        }
+        if (elapsed >= 140) {
+          // 按住停留：进入浏览选牌
+          g.mode = 'browse';
+          setSelectedId(g.cardId);
+          startEdgeScroll();
+        }
+        return;
+      }
+
+      if (g.mode === 'browse') {
+        if (!tryPrevent()) return;
+        if (dy < -50 && Math.abs(dy) > Math.abs(dx)) {
+          // 浏览中向上提：切换为上滑出牌（打当前指下的牌）
+          g.mode = 'play';
+          g.cardId = hitCardId(t.clientX, t.clientY) ?? g.cardId;
+          setSelectedId(g.cardId);
+          updateDrag(Math.min(0, dy));
+          stopEdgeScroll();
+          return;
+        }
+        const hit = hitCardId(t.clientX, t.clientY);
+        if (hit) setSelectedId(hit);
+        return;
+      }
+
+      // play：牌跟手上下移动
+      if (!tryPrevent()) return;
+      updateDrag(Math.max(-320, Math.min(24, dy)));
+    };
+
+    const onEnd = (e: TouchEvent) => {
+      if (pinchRef.current) {
+        localStorage.setItem(SPREAD_KEY, String(pinchRef.current.latest));
+        pinchRef.current = null;
+      }
+      const g = gestureRef.current;
+      if (!g) return;
+      const t = [...e.changedTouches].find((x) => x.identifier === g.touchId);
+      if (!t) return;
+      gestureRef.current = null;
+      stopEdgeScroll();
+
+      if (g.mode === 'hold') {
+        // hold 里 preventDefault 抑制了 click，手动补一次 tap（选择/确认/取消）
+        const card = dataRef.current.sorted.find((c) => c.id === g.cardId);
+        if (card) tapRef.current(card);
+        return;
+      }
+      if (g.mode === 'browse') {
+        suppressClickRef.current = true;
+        setTimeout(() => { suppressClickRef.current = false; }, 300);
+        return; // 选中保持抬起，等下一次 tap/上滑打出
+      }
+      if (g.mode === 'play') {
+        suppressClickRef.current = true;
+        setTimeout(() => { suppressClickRef.current = false; }, 300);
+        // 只有松手时手指已拖出手牌区上沿才打出，区内松手一律弹回（防误触）
+        if (t.clientY < g.playLineY) {
+          const card = dataRef.current.sorted.find((c) => c.id === g.cardId);
+          if (card) confirmPlayRef.current(card);
+        }
+        setDragState(null); // 未过打出线或不可出：弹回
       }
     };
-    const onMove = (e: TouchEvent) => {
-      if (e.touches.length !== 2 || !pinchRef.current) return;
-      e.preventDefault(); // 阻止页面缩放与横滑
-      const ratio = touchDist(e.touches) / pinchRef.current.startDist;
-      const next = Math.min(SPREAD_MAX, Math.max(SPREAD_MIN, pinchRef.current.startSpread * ratio));
-      pinchRef.current.latest = next; // state 异步，touchend 持久化要用这个同步值
-      setSpread(next);
-    };
-    const onEnd = () => {
-      if (!pinchRef.current) return;
-      localStorage.setItem(SPREAD_KEY, String(pinchRef.current.latest));
-      pinchRef.current = null;
-    };
+
     el.addEventListener('touchstart', onStart, { passive: true });
     el.addEventListener('touchmove', onMove, { passive: false });
     el.addEventListener('touchend', onEnd, { passive: true });
@@ -108,6 +324,7 @@ export default function MobileHand({ onPlayCard }: MobileHandProps) {
       el.removeEventListener('touchmove', onMove);
       el.removeEventListener('touchend', onEnd);
       el.removeEventListener('touchcancel', onEnd);
+      stopEdgeScroll();
     };
   }, []);
 
@@ -161,6 +378,7 @@ export default function MobileHand({ onPlayCard }: MobileHandProps) {
   };
 
   const handleTap = (card: CardType) => {
+    if (suppressClickRef.current) return; // 拖拽手势刚结束，忽略残余 click
     if (selectedId !== card.id) {
       setSelectedId(card.id);
       // 把选中牌滚入视野
@@ -173,16 +391,7 @@ export default function MobileHand({ onPlayCard }: MobileHandProps) {
       setSelectedId(null);
       return;
     }
-    if (shouldPickColorBeforePlay(card)) {
-      setPendingColorCardId(card.id);
-      return;
-    }
-    // 出牌前记录精确槽位，飞牌从这里起飞
-    const el = scrollRef.current?.querySelector(`[data-card-id="${card.id}"]`);
-    const rect = el?.getBoundingClientRect();
-    if (rect) useFxStore.getState().setPlayOrigin(card.id, { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 });
-    onPlayCard(card.id);
-    setSelectedId(null);
+    confirmPlay(card);
   };
 
   // 选中后点页面任意非牌位置取消（capture 阶段，不影响其他按钮正常触发）
@@ -208,13 +417,36 @@ export default function MobileHand({ onPlayCard }: MobileHandProps) {
           }}
         />
       )}
+      {/* 上滑拖拽提示：过线变「松手打出」 */}
+      <AnimatePresence>
+        {dragState && (
+          <motion.div
+            key="drag-hint"
+            initial={{ opacity: 0, y: 6 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 4 }}
+            transition={{ duration: 0.15 }}
+            className={cn(
+              'absolute left-1/2 -translate-x-1/2 -top-9 z-fab pointer-events-none',
+              'rounded-full px-3 py-1 text-xs font-game font-bold whitespace-nowrap',
+              dragState.canPlay
+                ? 'bg-primary text-primary-foreground shadow-[0_0_14px_rgba(251,191,36,0.6)]'
+                : 'bg-black/60 text-white/70',
+            )}
+          >
+            {dragState.canPlay ? '松手打出' : '拖出手牌区打出'}
+          </motion.div>
+        )}
+      </AnimatePresence>
       <div
         ref={scrollRef}
         className={cn(
           'overflow-x-auto scrollbar-hidden px-3 pt-10 pb-3',
           centered && 'flex justify-center',
         )}
-        style={{ touchAction: 'pan-x' }}
+        // 上滑拖拽时牌要飞出手牌区上沿，overflow-x:auto 会把 y 方向也算成 auto 裁掉；
+        // 拖拽及松手回弹期间放开（回弹约 0.4s，提前恢复会把回弹中的牌裁断）
+        style={{ touchAction: 'pan-x', ...(dragOverflowFree ? { overflow: 'visible' } : {}) }}
       >
         <div className="relative flex items-end" style={{ height: CARD_H + RAISE, width: baseWidth || '100%' }}>
           <AnimatePresence mode="popLayout">
@@ -222,6 +454,8 @@ export default function MobileHand({ onPlayCard }: MobileHandProps) {
             const isPlayable = playableIds.has(card.id);
             const isDimmed = isMyTurn && phase === 'playing' && !hintedIds.has(card.id);
             const isSelected = selectedId === card.id;
+            const isDragging = dragState?.id === card.id;
+            const canPlayNow = isDragging && dragState!.canPlay;
             const boundary = isColorBoundary(sorted, i);
             return (
               <motion.button
@@ -230,12 +464,12 @@ export default function MobileHand({ onPlayCard }: MobileHandProps) {
                 initial={{ opacity: 0, y: 24, scale: 0.85 }}
                 animate={{
                   opacity: 1,
-                  y: isSelected ? -RAISE : 0,
-                  scale: isSelected ? 1.06 : 1,
-                  zIndex: isSelected ? 40 : i,
+                  y: isDragging ? -RAISE + dragState!.dy : isSelected ? -RAISE : 0,
+                  scale: isDragging ? (canPlayNow ? 1.14 : 1.1) : isSelected ? 1.06 : 1,
+                  zIndex: isDragging ? 50 : isSelected ? 40 : i,
                 }}
                 exit={{ opacity: 0, scale: 0.6 }}
-                transition={{ type: 'spring', stiffness: 380, damping: 30 }}
+                transition={isDragging ? { duration: 0 } : { type: 'spring', stiffness: 380, damping: 30 }}
                 data-card-id={card.id}
                 onClick={() => handleTap(card)}
                 className="relative shrink-0 bg-transparent border-0 p-0 cursor-pointer"
@@ -254,7 +488,11 @@ export default function MobileHand({ onPlayCard }: MobileHandProps) {
                   )}
                   style={{
                     width: CARD_W, height: CARD_H,
-                    filter: isPlayable && isMyTurn ? 'drop-shadow(0 0 10px rgba(251,191,36,0.45))' : undefined,
+                    filter: canPlayNow
+                      ? 'drop-shadow(0 0 16px rgba(251,191,36,0.9))'
+                      : isPlayable && isMyTurn
+                        ? 'drop-shadow(0 0 10px rgba(251,191,36,0.45))'
+                        : undefined,
                   }}
                 >
                   <Card

--- a/packages/e2e/touch-gesture.mjs
+++ b/packages/e2e/touch-gesture.mjs
@@ -1,0 +1,189 @@
+// 触屏手势测试：上滑出牌、滑动选牌、不可出牌弹回（CDP Input.dispatchTouchEvent）
+import { launchBrowser, newAuthedPage, setupGame, dismissGameOverlays, emit } from '/root/uno-online/packages/e2e/lib/driver.mjs';
+
+const browser = await launchBrowser();
+const { page, errors } = await newAuthedPage(browser, { username: 'gesture-test', width: 390, height: 844 });
+await setupGame(page, { botCount: 3 });
+await page.waitForTimeout(2000);
+await dismissGameOverlays(page);
+await page.waitForTimeout(11000); // 等反作弊 toast 消失
+
+const cdp = await page.context().newCDPSession(page);
+let touchId = 0;
+async function touch(type, points) {
+  await cdp.send('Input.dispatchTouchEvent', {
+    type,
+    touchPoints: points.map((p, i) => ({ x: p.x, y: p.y, id: touchId + i })),
+  });
+  if (type === 'touchEnd') touchId++;
+}
+async function swipe(points, { holdMs = 0, stepMs = 16 } = {}) {
+  await touch('touchStart', [points[0]]);
+  if (holdMs) await page.waitForTimeout(holdMs);
+  for (let i = 1; i < points.length; i++) {
+    await touch('touchMove', [points[i]]);
+    await page.waitForTimeout(stepMs);
+  }
+  await touch('touchEnd', [points[points.length - 1]]);
+  await page.waitForTimeout(400);
+}
+
+// 等到我的回合
+async function waitMyTurn() {
+  await page.waitForFunction(() => {
+    const s = window.__uno.useGameStore.getState();
+    const me = s.players.find((p) => p.id === s.viewerId);
+    return s.phase === 'playing' && s.players[s.currentPlayerIndex]?.id === me?.id;
+  }, null, { timeout: 30000 });
+  await page.waitForTimeout(600);
+}
+
+const state = () => page.evaluate(() => {
+  const s = window.__uno.useGameStore.getState();
+  const me = s.players.find((p) => p.id === s.viewerId);
+  return { handCount: me?.hand.length ?? -1, phase: s.phase, current: s.players[s.currentPlayerIndex]?.id, me: s.viewerId };
+});
+const cardCenter = (id) => page.evaluate((cid) => {
+  const el = document.querySelector(`[data-card-id="${cid}"]`);
+  if (!el) return null;
+  const r = el.getBoundingClientRect();
+  return { x: r.x + r.width / 2, y: r.y + r.height / 2 };
+}, id);
+// 等手牌停止滚动/动画（坐标连续 3 次稳定）
+async function waitHandStable() {
+  await page.waitForFunction(() => {
+    const els = [...document.querySelectorAll('[data-card-id]')];
+    if (els.length === 0) return false;
+    const key = els.map((el) => Math.round(el.getBoundingClientRect().x)).join(',');
+    if (window.__handKey === key) {
+      window.__handStable = (window.__handStable ?? 0) + 1;
+    } else {
+      window.__handKey = key;
+      window.__handStable = 0;
+    }
+    return window.__handStable >= 3;
+  }, null, { timeout: 10000, polling: 150 }).catch(() => {});
+}
+// 可出牌（带金色 drop-shadow 的）
+const playableCardIds = () => page.evaluate(() =>
+  [...document.querySelectorAll('[data-card-id]')]
+    .filter((el) => el.querySelector('span')?.style.filter.includes('drop-shadow'))
+    .map((el) => el.getAttribute('data-card-id')));
+const raisedCardId = () => page.evaluate(() => {
+  for (const el of document.querySelectorAll('[data-card-id]')) {
+    const m = new DOMMatrixReadOnly(getComputedStyle(el).transform);
+    if (m.m42 < -20) return el.getAttribute('data-card-id'); // translateY < -20px = 抬起
+  }
+  return null;
+});
+
+let pass = 0, fail = 0;
+const check = (ok, label) => { console.log(`${ok ? '✓' : '✗'} ${label}`); ok ? pass++ : fail++; };
+
+// ---------- 1. 上滑出牌 ----------
+await waitMyTurn();
+await waitHandStable();
+const before1 = await state();
+const playable1 = await playableCardIds();
+check(playable1.length > 0, `轮到我且有 ${playable1.length} 张可出牌`);
+if (playable1.length > 0) {
+  const target = playable1[Math.floor(playable1.length / 2)];
+  await page.evaluate((cid) => {
+    document.querySelector(`[data-card-id="${cid}"]`)?.scrollIntoView({ behavior: 'instant', inline: 'center', block: 'nearest' });
+  }, target);
+  await waitHandStable();
+  const c = await cardCenter(target);
+  console.log(`  [debug] 目标牌 ${target} 中心 (${Math.round(c.x)},${Math.round(c.y)})`);
+  const path = [];
+  for (let i = 1; i <= 8; i++) path.push({ x: c.x, y: c.y - i * 18 }); // 上滑 144px
+  await swipe([c, ...path]);
+  const after1 = await state();
+  if (!(after1.handCount === before1.handCount - 1 || after1.current !== before1.me || after1.phase !== 'playing')) {
+    const dbg = await page.evaluate(() => {
+      let raised = null;
+      for (const el of document.querySelectorAll('[data-card-id]')) {
+        const m = new DOMMatrixReadOnly(getComputedStyle(el).transform);
+        if (m.m42 < -20) raised = el.getAttribute('data-card-id');
+      }
+      return { raised, overlays: [...document.querySelectorAll('body > div')].length };
+    });
+    console.log('  [debug] 上滑未生效:', JSON.stringify({ target, ...dbg }));
+  }
+  check(after1.handCount === before1.handCount - 1 || after1.current !== before1.me || after1.phase !== 'playing',
+    `上滑出牌生效（手牌 ${before1.handCount} → ${after1.handCount}）`);
+}
+
+// ---------- 2. 滑动选牌 ----------
+await waitMyTurn().catch(() => {});
+await waitHandStable();
+const all = await page.evaluate(() =>
+  [...document.querySelectorAll('[data-card-id]')].map((el) => {
+    const r = el.getBoundingClientRect();
+    return { id: el.getAttribute('data-card-id'), cx: r.x + r.width / 2 };
+  }).sort((a, b) => a.cx - b.cx));
+check(all.length >= 3, `手牌 ${all.length} 张足以滑选`);
+if (all.length >= 3) {
+  const visible = all.filter((c) => c.cx > 20 && c.cx < 370);
+  const from = visible[0] ?? all[0];
+  const to = visible[Math.min(visible.length - 1, 3)] ?? from; // 滑到右侧第 4 张可见牌附近
+  const y = (await cardCenter(from.id)).y;
+  console.log(`  [debug] 滑选 from ${from.id}(${Math.round(from.cx)},${Math.round(y)}) → ${to.id}(${Math.round(to.cx)})`);
+  const path = [];
+  const steps = 10;
+  for (let i = 1; i <= steps; i++) path.push({ x: from.cx + ((to.cx - from.cx) * i) / steps, y });
+  await swipe([{ x: from.cx, y }, ...path], { holdMs: 300, stepMs: 30 });
+  const raised = await raisedCardId();
+  const raisedX = all.find((c) => c.id === raised)?.cx ?? -999;
+  check(raised !== null && Math.abs(raisedX - to.cx) < 60,
+    `滑动选牌：期望选中 x≈${Math.round(to.cx)} 的牌，实际 ${raised} x≈${Math.round(raisedX)}`);
+  // 点空白取消选中
+  await touch('touchStart', [{ x: 195, y: 400 }]);
+  await page.waitForTimeout(40);
+  await touch('touchEnd', [{ x: 195, y: 400 }]);
+  await page.waitForTimeout(300);
+}
+
+// ---------- 3. 上滑未过打出线：可出牌也不打出（防误触） ----------
+await waitMyTurn().catch(() => {});
+await waitHandStable();
+const before25 = await state();
+const playable25 = await playableCardIds();
+if (playable25.length > 0) {
+  const target = playable25[0];
+  await page.evaluate((cid) => {
+    document.querySelector(`[data-card-id="${cid}"]`)?.scrollIntoView({ behavior: 'instant', inline: 'center', block: 'nearest' });
+  }, target);
+  await waitHandStable();
+  const c = await cardCenter(target);
+  const path = [];
+  for (let i = 1; i <= 4; i++) path.push({ x: c.x, y: c.y - i * 18 }); // 只上滑 72px，不过打出线
+  await swipe([c, ...path]);
+  const after25 = await state();
+  check(after25.handCount === before25.handCount && after25.current === before25.current,
+    `上滑未过线不打出（手牌仍 ${after25.handCount} 张）`);
+} else {
+  console.log('… 无可出牌，跳过未过线用例');
+}
+
+// ---------- 4. 不可出牌上滑弹回 ----------
+await waitMyTurn().catch(() => {});
+await waitHandStable();
+const before3 = await state();
+const playable3 = await playableCardIds();
+const allIds = (await page.evaluate(() => [...document.querySelectorAll('[data-card-id]')].map((el) => el.getAttribute('data-card-id'))));
+const unplayable = allIds.filter((id) => !playable3.includes(id));
+if (unplayable.length > 0) {
+  const c = await cardCenter(unplayable[0]);
+  const path = [];
+  for (let i = 1; i <= 8; i++) path.push({ x: c.x, y: c.y - i * 18 });
+  await swipe([c, ...path]);
+  const after3 = await state();
+  check(after3.handCount === before3.handCount, `不可出牌上滑弹回（手牌仍 ${after3.handCount} 张）`);
+} else {
+  console.log('… 全部可出，跳过弹回用例');
+}
+
+console.log(`\n结果: ${pass} 通过, ${fail} 失败`);
+console.log('console errors:', errors.length ? errors : '无');
+await browser.close();
+process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
## 新增
- **滑动选牌**：按住牌稍作停留后横向拖动，经过的牌依次抬起，屏幕边缘自动滚动，松手即选中
- **上滑出牌**：按住牌向上拖，牌跟手飞出手牌区；松手时手指已拖出手牌区上沿才打出（防误触），区内松手弹回保持选中；过线时提示条变金色「松手打出」并加亮放大

## 交互兼容性
- 快速横滑保持原生惯性滚动，双指捏合调间距不变，点按（选中/再点出牌）逻辑完全保留

## 实现要点
- 手势判定在首个 touchmove 当场决断（之后浏览器锁定原生滚动，cancelable=false 无法接管）
- hold 分支 preventDefault 抑制 click 后松手手动补 tap
- 滑选命中在牌列底部取样，避免被已抬起牌遮挡导致选中滞后一张
- 拖拽及松手回弹期间放开容器 overflow，避免飞牌/回弹被容器上沿裁断

## 验证
- e2e 新增 touch-gesture.mjs（CDP 真实触摸事件）：上滑打出、滑选位置精确命中、未过线不打出、不可出弹回，6 用例全过零 console 错误
- human.mjs 拟人回归三场景通过