### PR TITLE
fix(server): Passkey rpID/origin 改为从 CLIENT_URL 推导，修复反代后验证必然失败

### DIFF
--- a/packages/server/src/plugins/core/auth/passkey-routes.ts
+++ b/packages/server/src/plugins/core/auth/passkey-routes.ts
@@ -20,26 +20,27 @@ export function registerPasskeyRoutes(fastify: FastifyInstance, ctx: PluginConte
   const preHandler = authPreHandler(config.jwtSecret);
   const loginLimiter = createRateLimiter({ windowMs: 60_000, max: 10 });
 
-  function getRpId(request: { hostname: string }): string | string[] {
-    if (!config.webauthnRpId) return request.hostname.split(':')[0]!;
-    return config.webauthnRpId.includes(',')
-      ? config.webauthnRpId.split(',').map((s) => s.trim())
-      : config.webauthnRpId;
+  function getRpId(): string | string[] {
+    if (config.webauthnRpId) {
+      return config.webauthnRpId.includes(',')
+        ? config.webauthnRpId.split(',').map((s) => s.trim())
+        : config.webauthnRpId;
+    }
+    return new URL(config.clientUrl).hostname;
   }
 
-  function getFirstRpId(request: { hostname: string }): string {
-    const rpId = getRpId(request);
+  function getFirstRpId(): string {
+    const rpId = getRpId();
     return Array.isArray(rpId) ? rpId[0]! : rpId;
   }
 
-  function getOrigin(request: { protocol: string; hostname: string }): string | string[] {
-    if (!config.webauthnOrigin) {
-      const proto = request.protocol ?? 'https';
-      return `${proto}://${request.hostname}`;
+  function getOrigin(): string | string[] {
+    if (config.webauthnOrigin) {
+      return config.webauthnOrigin.includes(',')
+        ? config.webauthnOrigin.split(',').map((s) => s.trim())
+        : config.webauthnOrigin;
     }
-    return config.webauthnOrigin.includes(',')
-      ? config.webauthnOrigin.split(',').map((s) => s.trim())
-      : config.webauthnOrigin;
+    return new URL(config.clientUrl).origin;
   }
 
   // ── Registration (authenticated) ──
@@ -50,7 +51,7 @@ export function registerPasskeyRoutes(fastify: FastifyInstance, ctx: PluginConte
 
     const options = await generateRegistrationOptions({
       rpName: config.webauthnRpName ?? 'UNO Online',
-      rpID: getFirstRpId(request),
+      rpID: getFirstRpId(),
       userName: username,
       attestationType: 'none',
       excludeCredentials: userPasskeys.map((pk) => ({
@@ -89,10 +90,11 @@ export function registerPasskeyRoutes(fastify: FastifyInstance, ctx: PluginConte
         verification = await verifyRegistrationResponse({
           response: credential as any,
           expectedChallenge,
-          expectedOrigin: getOrigin(request),
-          expectedRPID: getRpId(request),
+          expectedOrigin: getOrigin(),
+          expectedRPID: getRpId(),
         });
-      } catch {
+      } catch (err) {
+        fastify.log.warn({ err }, 'Passkey registration verification failed');
         return reply.code(400).send({ error: '验证失败' });
       }
 
@@ -120,7 +122,7 @@ export function registerPasskeyRoutes(fastify: FastifyInstance, ctx: PluginConte
 
   fastify.post('/auth/passkey/login-options', async (request) => {
     const options = await generateAuthenticationOptions({
-      rpID: getFirstRpId(request),
+      rpID: getFirstRpId(),
       userVerification: 'preferred',
       allowCredentials: [],
     });
@@ -158,8 +160,8 @@ export function registerPasskeyRoutes(fastify: FastifyInstance, ctx: PluginConte
         verification = await verifyAuthenticationResponse({
           response: credential as any,
           expectedChallenge,
-          expectedOrigin: getOrigin(request),
-          expectedRPID: getRpId(request),
+          expectedOrigin: getOrigin(),
+          expectedRPID: getRpId(),
           credential: {
             id: passkey.id,
             publicKey: isoBase64URL.toBuffer(passkey.publicKey),
@@ -167,7 +169,8 @@ export function registerPasskeyRoutes(fastify: FastifyInstance, ctx: PluginConte
             transports: passkey.transports ? (JSON.parse(passkey.transports) as AuthenticatorTransportFuture[]) : undefined,
           },
         });
-      } catch {
+      } catch (err) {
+        fastify.log.warn({ err }, 'Passkey login verification failed');
         return reply.code(401).send({ error: '验证失败' });
       }
 


### PR DESCRIPTION
## 问题

服务端未配置 `trustProxy`，在 Caddy 反代后面 `request.protocol` 恒为 `http`。Passkey 路由在 `WEBAUTHN_ORIGIN` 未显式配置时用 `request.protocol + hostname` 推导 `expectedOrigin`，得到 `http://uno.aunly.cn`，与浏览器实际 origin（`https://uno.aunly.cn`）不匹配——生产环境 passkey 注册/登录验证必然失败，且 catch 静默吞错，日志无任何线索。

## 修复

- rpID / origin 未显式配置时改从 `config.clientUrl`（生产 = `https://${DOMAIN}`）推导，不再依赖请求头
- `WEBAUTHN_ORIGIN` 支持逗号分隔多值，与 `WEBAUTHN_RP_ID` 行为对齐
- 注册/登录验证失败的 catch 中补充 `fastify.log.warn`，便于后续排查

## 验证

- `pnpm --filter server exec tsc --noEmit` 通过
- 生产环境配置已确认：仅设 `DOMAIN=uno.aunly.cn`，未设 `WEBAUTHN_*`/`CLIENT_URL`，`clientUrl` 推导为 `https://uno.aunly.cn`，与浏览器 origin 一致
- WebAuthn 需 HTTPS 安全上下文，无法在局域网 dev 环境实测；待下次发版部署后在生产实测 passkey 注册/登录闭环

🤖 Generated with [Claude Code](https://claude.com/claude-code)