### PR TITLE
feat(game): 终局展示窗 + 🐷 可扔表情 + 转向牌经典双箭头图标

### DIFF
--- a/packages/client/src/features/game/components/Card.tsx
+++ b/packages/client/src/features/game/components/Card.tsx
@@ -9,11 +9,29 @@ function getCardLabel(card: CardType): string {
   switch (card.type) {
     case 'number': return String(card.value);
     case 'skip': return '⊘';
-    case 'reverse': return '⟲';
+    case 'reverse': return '转向';
     case 'draw_two': return '+2';
     case 'wild': return 'W';
     case 'wild_draw_four': return '+4';
   }
+}
+
+/** 经典双箭头转向符号——文字字形 ⟲ 与禁止 ⊘ 形近，改用 SVG 区分 */
+function ReverseIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      className={cn('inline-block w-[1em] h-[1em]', className)}
+      style={{ filter: 'drop-shadow(2px 2px 0px rgba(0, 0, 0, 0.2))' }}
+    >
+      <g transform="rotate(45 12 12)">
+        <path d="M4 7h8V4l7 5-7 5v-3H4z" />
+        <path d="M20 17h-8v3l-7-5 7-5v3h8z" />
+      </g>
+    </svg>
+  );
 }
 
 const colorClasses: Record<string, string> = {
@@ -55,6 +73,7 @@ export default function Card({ card, playable = false, clickable = playable, dim
     : colorClasses[card.color!] ?? '';
 
   const label = getCardLabel(card);
+  const symbol = card.type === 'reverse' ? <ReverseIcon /> : label;
   const showCorners = (!isWild || forceCornerLabel) && !mini;
 
   if (cardImagePack && isPackLoaded()) {
@@ -81,7 +100,7 @@ export default function Card({ card, playable = false, clickable = playable, dim
           <img src={imgUrl} alt={label} className="w-full h-full object-contain pointer-events-none" draggable={false} />
           {forceCornerLabel && (
             <span className="absolute top-0.5 left-1 leading-none text-white text-shadow-card">
-              <span className="text-2xs font-bold">{label}</span>
+              <span className="text-2xs font-bold">{symbol}</span>
             </span>
           )}
           {colorBlindMode && card.color && <ColorBlindOverlay color={card.color} />}
@@ -115,17 +134,17 @@ export default function Card({ card, playable = false, clickable = playable, dim
     >
       {showCorners && (
         <span className="absolute top-0.5 left-1 leading-none">
-          <span className="text-2xs font-bold">{label}</span>
+          <span className="text-2xs font-bold">{symbol}</span>
         </span>
       )}
 
       <span className={mini ? 'text-2xs font-bold leading-none' : typeFontClasses[card.type] ?? ''}>
-        {label}
+        {symbol}
       </span>
 
       {showCorners && (
         <span className="absolute bottom-0.5 right-1 leading-none rotate-180">
-          <span className="text-2xs font-bold">{label}</span>
+          <span className="text-2xs font-bold">{symbol}</span>
         </span>
       )}
 

--- a/packages/client/src/features/game/components/EndRevealBanner.tsx
+++ b/packages/client/src/features/game/components/EndRevealBanner.tsx
@@ -1,0 +1,59 @@
+import { motion } from 'framer-motion';
+import { Trophy, ChevronRight } from 'lucide-react';
+import { useGameStore } from '../stores/game-store';
+import { cn } from '@/shared/lib/utils';
+import Card from './Card';
+
+interface EndRevealBannerProps {
+  secondsLeft: number;
+  onSkip: () => void;
+  /** strip（移动端）模式放在手牌上方空档，避免遮挡顶部玩家罗盘（扔表情的点击目标） */
+  placement?: 'top' | 'lower';
+}
+
+/**
+ * 终局展示横幅：最后一张牌打出后先停留数秒再进结算板，
+ * 期间牌桌保持可交互（可继续扔表情），横幅展示赢家与最后一张牌。
+ */
+export default function EndRevealBanner({ secondsLeft, onSkip, placement = 'top' }: EndRevealBannerProps) {
+  const players = useGameStore((s) => s.players);
+  const winnerId = useGameStore((s) => s.winnerId);
+  const phase = useGameStore((s) => s.phase);
+  const topCard = useGameStore((s) => s.discardPile?.[s.discardPile.length - 1]);
+  const winner = players.find((p) => p.id === winnerId);
+
+  return (
+    <div
+      className={cn(
+        'fixed inset-x-0 z-actions flex justify-center pointer-events-none',
+        placement === 'top' ? 'top-[10%]' : 'bottom-[17%]',
+      )}
+    >
+      <motion.div
+        initial={{ opacity: 0, y: -16, scale: 0.95 }}
+        animate={{ opacity: 1, y: 0, scale: 1 }}
+        transition={{ duration: 0.3, ease: 'easeOut' }}
+        className="glass-panel pointer-events-auto flex items-center gap-4 px-5 py-3"
+      >
+        {topCard && (
+          <div className="shrink-0 pointer-events-none">
+            <Card card={topCard} />
+          </div>
+        )}
+        <div className="flex flex-col items-start gap-1.5">
+          <span className="font-game text-lg font-black text-white flex items-center gap-1.5">
+            <Trophy size={18} className="text-primary shrink-0" />
+            {winner ? `${winner.name} 获胜！` : phase === 'game_over' ? '游戏结束' : '本轮结束'}
+          </span>
+          <span className="text-xs text-muted-foreground">这是最后一张牌 · {secondsLeft}s 后进入结算</span>
+          <button
+            onClick={onSkip}
+            className="inline-flex items-center gap-0.5 rounded-full bg-primary/80 px-3 py-1 text-xs text-primary-foreground transition-colors hover:bg-primary cursor-pointer"
+          >
+            查看结算 <ChevronRight size={12} />
+          </button>
+        </div>
+      </motion.div>
+    </div>
+  );
+}

--- a/packages/client/src/features/game/components/ThrowAnimation.tsx
+++ b/packages/client/src/features/game/components/ThrowAnimation.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import { motion, AnimatePresence, useAnimationControls } from 'framer-motion';
 
-const ROTATING_ITEMS = new Set(['🥚', '🍅']);
+const ROTATING_ITEMS = new Set(['🥚', '🍅', '🐷']);
 
 interface ThrowAnimationProps {
   from: { x: number; y: number };
@@ -16,6 +16,7 @@ function getParticleColors(item: string): string[] {
     case '🍅': return ['#ef4444', '#f87171', '#dc2626'];
     case '🌹': return ['#ec4899', '#f472b6', '#be185d'];
     case '💩': return ['#92400e', '#a16207', '#78350f'];
+    case '🐷': return ['#f9a8d4', '#f472b6', '#fda4af'];
     case '👍': return ['#fbbf24', '#f59e0b', '#d97706'];
     case '💖': return ['#ec4899', '#f472b6', '#f9a8d4'];
     default: return ['#fbbf24', '#f59e0b', '#d97706'];

--- a/packages/client/src/features/game/components/ThrowItemPicker.tsx
+++ b/packages/client/src/features/game/components/ThrowItemPicker.tsx
@@ -7,6 +7,7 @@ const ITEMS = [
   { emoji: '🍅', label: '番茄' },
   { emoji: '🌹', label: '玫瑰' },
   { emoji: '💩', label: '便便' },
+  { emoji: '🐷', label: '猪猪' },
   { emoji: '👍', label: '点赞' },
   { emoji: '💖', label: '爱心' },
 ];

--- a/packages/client/src/features/game/components/mobile/PlayerCompass.tsx
+++ b/packages/client/src/features/game/components/mobile/PlayerCompass.tsx
@@ -36,6 +36,7 @@ export default function PlayerCompass({ compact = false }: PlayerCompassProps) {
   const currentPlayerIndex = useGameStore((s) => s.currentPlayerIndex);
   const direction = useGameStore((s) => s.direction);
   const phase = useGameStore((s) => s.phase);
+  const endRevealing = useGameStore((s) => s.endRevealLeft > 0);
   const turnEndTime = useGameStore((s) => s.turnEndTime);
   const settings = useGameStore((s) => s.settings);
   const roundNumber = useGameStore((s) => s.roundNumber);
@@ -95,7 +96,8 @@ export default function PlayerCompass({ compact = false }: PlayerCompassProps) {
     observerRef.current = observer;
   }, []);
 
-  if (phase === 'round_end' || phase === 'game_over' || players.length === 0) return null;
+  // 终局展示窗期间保留罗盘（还能继续向玩家扔表情）；结算板真正显示时才隐藏
+  if (((phase === 'round_end' || phase === 'game_over') && !endRevealing) || players.length === 0) return null;
 
   const n = players.length;
   const R = compact ? 260 : 380;

--- a/packages/client/src/features/game/components/mobile/StageCenter.tsx
+++ b/packages/client/src/features/game/components/mobile/StageCenter.tsx
@@ -91,6 +91,7 @@ export default function StageCenter({ onDraw, compact = false }: StageCenterProp
   const drawStack = useGameStore((s) => s.drawStack);
   const direction = useGameStore((s) => s.direction);
   const phase = useGameStore((s) => s.phase);
+  const endRevealing = useGameStore((s) => s.endRevealLeft > 0);
   const players = useGameStore((s) => s.players);
   const currentPlayerIndex = useGameStore((s) => s.currentPlayerIndex);
   const userId = useEffectiveUserId();
@@ -109,7 +110,8 @@ export default function StageCenter({ onDraw, compact = false }: StageCenterProp
   const currentPlayer = players[currentPlayerIndex];
   const isMyTurn = currentPlayer?.id === userId;
 
-  if (phase === 'round_end' || phase === 'game_over') return null;
+  // 终局展示窗期间（endRevealLeft > 0）保留舞台，让玩家看清最后一张牌；结算板真正显示时才隐藏
+  if ((phase === 'round_end' || phase === 'game_over') && !endRevealing) return null;
 
   const DirIcon = direction === 'clockwise' ? RotateCw : RotateCcw;
   const colorHex = currentColor ? COLOR_HEX[currentColor] : null;

--- a/packages/client/src/features/game/pages/GamePage.tsx
+++ b/packages/client/src/features/game/pages/GamePage.tsx
@@ -46,6 +46,10 @@ import MobileHand from '../components/mobile/MobileHand';
 import InfoSheet from '../components/mobile/InfoSheet';
 import { useGameLayoutMode, useShortLandscape } from '../hooks/useGameLayoutMode';
 import FitScaler from '@/shared/components/FitScaler';
+import EndRevealBanner from '../components/EndRevealBanner';
+
+/** 终局展示窗时长：最后一张牌打出后保留牌桌的秒数（与结算板 10s 开局冷却完全重叠，不拖慢节奏） */
+const END_REVEAL_S = 10;
 
 export default function GamePage() {
   const { roomCode } = useParams<{ roomCode: string }>();
@@ -67,7 +71,32 @@ export default function GamePage() {
   const playableIds = usePlayableCardIds();
   const noop = () => {};
   const needsColorPick = phase === 'choosing_color' && isMyTurn && !myAutopilot;
-  const showScoreBoard = phase === 'round_end' || phase === 'game_over';
+
+  // 终局展示窗：现场经历"对局 → 终局"切换时，先保留牌桌若干秒再进结算板；
+  // 中途加入/刷新（prev 不是对局中 phase）则直接显示结算板。
+  const revealLeft = useGameStore((s) => s.endRevealLeft);
+  const setEndRevealLeft = useGameStore((s) => s.setEndRevealLeft);
+  const prevPhaseRef = useRef<typeof phase>(null);
+  const isEndPhase = phase === 'round_end' || phase === 'game_over';
+
+  useEffect(() => {
+    const prev = prevPhaseRef.current;
+    prevPhaseRef.current = phase;
+    const isEnd = phase === 'round_end' || phase === 'game_over';
+    const wasInGame = prev === 'playing' || prev === 'challenging' || prev === 'choosing_color' || prev === 'choosing_swap_target';
+    if (isEnd && wasInGame) {
+      setEndRevealLeft(END_REVEAL_S);
+      const interval = window.setInterval(() => {
+        const left = Math.max(0, useGameStore.getState().endRevealLeft - 1);
+        setEndRevealLeft(left);
+        if (left <= 0) window.clearInterval(interval);
+      }, 1000);
+      return () => window.clearInterval(interval);
+    }
+  }, [phase, setEndRevealLeft]);
+
+  const endRevealing = isEndPhase && revealLeft > 0;
+  const showScoreBoard = isEndPhase && !endRevealing;
 
   const connectionStatus = useGameSocket(roomCode);
 
@@ -325,6 +354,13 @@ export default function GamePage() {
       {!isSpectator && <AutopilotOverlay />}
       {(phase === 'round_end' || phase === 'game_over') && <Confetti />}
       {needsColorPick && <ColorPicker onPick={chooseColor} />}
+      {endRevealing && (
+        <EndRevealBanner
+          secondsLeft={revealLeft}
+          onSkip={() => setEndRevealLeft(0)}
+          placement={mode === 'strip' ? 'lower' : 'top'}
+        />
+      )}
       {showScoreBoard && (
         <ScoreBoard
           isSpectator={isSpectator}

--- a/packages/client/src/features/game/stores/game-store.ts
+++ b/packages/client/src/features/game/stores/game-store.ts
@@ -55,6 +55,8 @@ interface GameState {
   nextRoundVote: NextRoundVoteState | null;
   roundEndAt: number | null;
   gameOverAt: number | null;
+  /** 终局展示窗剩余秒数：>0 时压住结算板、保留牌桌（可继续扔表情、查看最后一张牌） */
+  endRevealLeft: number;
   cheatDetected: boolean;
   dissolvedReason: string | null;
   ownerTransferAt: number | null;
@@ -73,6 +75,7 @@ interface GameState {
   setNextRoundVote: (vote: NextRoundVoteState | null) => void;
   setRoundEndAt: (t: number | null) => void;
   setGameOverAt: (t: number | null) => void;
+  setEndRevealLeft: (n: number) => void;
   setDrawnCard: (card: Card | null) => void;
   setTurnEndTime: (t: number | null) => void;
   clearGame: () => void;
@@ -104,6 +107,7 @@ export const useGameStore = create<GameState>((set) => ({
   nextRoundVote: null,
   roundEndAt: null,
   gameOverAt: null,
+  endRevealLeft: 0,
   cheatDetected: false,
   dissolvedReason: null,
   ownerTransferAt: null,
@@ -165,12 +169,14 @@ export const useGameStore = create<GameState>((set) => ({
         nextRoundVote: phase === 'round_end' ? state.nextRoundVote : null,
         roundEndAt: phase === 'round_end' ? state.roundEndAt : null,
         gameOverAt: phase === 'game_over' ? state.gameOverAt : null,
+        endRevealLeft: phase === 'round_end' || phase === 'game_over' ? state.endRevealLeft : 0,
         ...spectatorChange,
       };
     }),
   setNextRoundVote: (vote) => set({ nextRoundVote: vote }),
   setRoundEndAt: (t) => set({ roundEndAt: t }),
   setGameOverAt: (t) => set({ gameOverAt: t }),
+  setEndRevealLeft: (n) => set({ endRevealLeft: n }),
   setDrawnCard: (card) => set({ lastDrawnCard: card, hasDrawnThisTurn: true }),
   setTurnEndTime: (t) => set({ turnEndTime: t }),
   clearGame: () =>
@@ -200,6 +206,7 @@ export const useGameStore = create<GameState>((set) => ({
       nextRoundVote: null,
       roundEndAt: null,
       gameOverAt: null,
+      endRevealLeft: 0,
       cheatDetected: false,
       dissolvedReason: null,
       ownerTransferAt: null,

--- a/packages/client/src/shared/sound/sound-manager.ts
+++ b/packages/client/src/shared/sound/sound-manager.ts
@@ -57,6 +57,7 @@ const FREQUENCIES: Record<SoundName, { freq: number; duration: number; type: Osc
 const THROW_HIT_SOUND_BY_ITEM: Record<string, string> = {
   '🍅': '/sounds/throw-tomato-squish.mp3',
   '💩': '/sounds/throw-slime-impact.mp3',
+  '🐷': '/sounds/throw-boing.mp3',
   '🥚': '/sounds/throw-cartoon-hit.mp3',
   '🌹': '/sounds/throw-cartoon-hit.mp3',
   '👍': '/sounds/throw-boing.mp3',

--- a/packages/server/src/plugins/core/interaction/ws.ts
+++ b/packages/server/src/plugins/core/interaction/ws.ts
@@ -1,7 +1,7 @@
 import type { Server as SocketIOServer, Socket } from 'socket.io';
 import { ROLE_CONFIG, type UserRole } from '@uno-online/shared';
 
-const VALID_ITEMS = ['🥚', '🍅', '🌹', '💩', '👍', '💖'];
+const VALID_ITEMS = ['🥚', '🍅', '🌹', '💩', '🐷', '👍', '💖'];
 const MIN_THROW_INTERVAL_MS = 300;
 
 const throwTimestamps = new Map<string, number>();


### PR DESCRIPTION
实现 #187 中的三项改进（第 4 项经典卡面因授权问题另行跟踪，见 issue 内回复）。

## 变更

### 1. 终局展示窗
最后一张牌打出后不再立刻跳结算板：牌桌保留 10 秒，横幅展示赢家与最后一张牌，期间可继续扔表情（含给第二名扔 💩🐷），可点"查看结算"跳过。10 秒与结算板"开始下一轮"冷却完全重叠，整体节奏不变。

- `game-store` 新增 `endRevealLeft`，`GamePage` 驱动倒计时；只在现场经历"对局 → 终局"切换时触发，中途加入/刷新直接看结算板
- 移动端 `StageCenter`/`PlayerCompass` 原"终局立即隐藏"改为"结算板真正显示时才隐藏"（结算板半透明背景的干净度不受影响）
- strip 模式横幅放手牌上方空档，不遮挡罗盘（移动端扔表情的点击目标）；table 模式放顶部

### 2. 可扔表情新增 🐷
选择器、服务端白名单、粉色溅射粒子、旋转飞行、boing 音效。

### 3. 转向牌图标区分
`⟲` 与 `⊘` 形近，转向改为自绘经典双箭头 SVG（牌面中心 + 四角统一），带与文字阴影一致的 drop-shadow。

## 验证

- shared 287 测试全过；client/server tsc 通过；client 生产构建通过
- e2e 拟人回归（human.mjs）全过
- 新终局探针在桌面 1280×800、竖屏 390×844、短横屏 844×390 三布局验证：`endRevealLeft` 启动、横幅出现、结算板被压住、牌桌保留、倒计时结束后结算板正常出现
- 用户已在局域网真机实测确认

相关 issue：#187

🤖 Generated with [Claude Code](https://claude.com/claude-code)