### PR TITLE
refactor(client): 个人信息区、对局玩家列表、结算板视觉重构

### DIFF
--- a/packages/client/src/features/game/components/PlayerAvatar.tsx
+++ b/packages/client/src/features/game/components/PlayerAvatar.tsx
@@ -1,0 +1,57 @@
+import { Bot } from 'lucide-react';
+import { AVATAR_COLORS, AVATAR_EMOJIS } from '../constants/avatars';
+import { DIFFICULTY_DISPLAY } from '../constants/bot-difficulty';
+import type { BotConfig } from '@uno-online/shared';
+import { cn } from '@/shared/lib/utils';
+
+interface PlayerAvatarProps {
+  /** 玩家在 players 数组中的原始序号（决定兜底配色与 emoji） */
+  index: number;
+  name: string;
+  avatarUrl?: string | null;
+  isBot?: boolean;
+  botConfig?: BotConfig;
+  /** 直径 px */
+  size?: number;
+  className?: string;
+  /** 主色描边高亮（如当前回合） */
+  highlighted?: boolean;
+}
+
+/** 圆形玩家头像：真实头像 > Bot 难度配色 > 序号 emoji 兜底；img 在容器内裁圆 */
+export default function PlayerAvatar({ index, name, avatarUrl, isBot, botConfig, size = 28, className, highlighted = false }: PlayerAvatarProps) {
+  const botDisplay = isBot && botConfig ? DIFFICULTY_DISPLAY[botConfig.difficulty] : undefined;
+  return (
+    <div
+      className={cn(
+        'relative rounded-full flex items-center justify-center overflow-hidden shrink-0 transition-shadow duration-300',
+        highlighted && 'ring-2 ring-primary/70 shadow-[0_0_10px_rgba(246,190,62,0.35)]',
+        className,
+      )}
+      style={{
+        width: size,
+        height: size,
+        fontSize: size * 0.5,
+        background: botDisplay ? botDisplay.avatarBg : AVATAR_COLORS[index % AVATAR_COLORS.length],
+        boxShadow: !highlighted && botDisplay ? `inset 0 0 0 1.5px ${botDisplay.ringColor}` : undefined,
+      }}
+    >
+      {botDisplay ? (
+        <Bot size={size * 0.5} className="text-white drop-shadow-sm" />
+      ) : (
+        <>
+          <span>{AVATAR_EMOJIS[index % AVATAR_EMOJIS.length]}</span>
+          {avatarUrl && (
+            <img
+              src={avatarUrl}
+              alt={name}
+              className="absolute inset-0 w-full h-full object-cover"
+              referrerPolicy="no-referrer"
+              onError={(e) => { e.currentTarget.style.display = 'none'; }}
+            />
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/client/src/features/game/components/PlayerListPanel.tsx
+++ b/packages/client/src/features/game/components/PlayerListPanel.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef } from 'react';
 import { motion, useDragControls, AnimatePresence } from 'framer-motion';
-import { ArrowRightLeft, Bot, ChevronDown, Crown, Eye, GripHorizontal, UserPlus } from 'lucide-react';
+import { ArrowRightLeft, ChevronDown, Crown, Eye, GripHorizontal, UserPlus, Users } from 'lucide-react';
 import { getSocket } from '@/shared/socket';
 import { showConfirm } from '@/shared/stores/confirm-store';
 import { useToastStore } from '@/shared/stores/toast-store';
@@ -8,13 +8,15 @@ import { useGameStore } from '../stores/game-store';
 import { useSpectatorStore } from '../stores/spectator-store';
 import { useRoomStore } from '@/shared/stores/room-store';
 import { useEffectiveUserId } from '../hooks/useEffectiveUserId';
-import { AVATAR_COLORS, AVATAR_EMOJIS } from '../constants/avatars';
-import { DIFFICULTY_DISPLAY } from '../constants/bot-difficulty';
-import GoogleRing from '@/shared/components/ui/GoogleRing';
+import PlayerAvatar from './PlayerAvatar';
 import PlayerVoiceStatus from '@/shared/voice/PlayerVoiceStatus';
 import { cn, getRoleColor } from '@/shared/lib/utils';
 import { AiBadge } from '@/shared/components/ui/AiBadge';
 
+/**
+ * 对局内右上角玩家列表（桌面 table 模式）：可拖拽、可折叠。
+ * 当前回合玩家：左侧主色条 + 行高亮 + 头像主色描边；手牌数用迷你卡片型徽记，剩 1 张时红色告警（UNO 时刻）。
+ */
 export default function PlayerListPanel() {
   const players = useGameStore((s) => s.players);
   const currentPlayerIndex = useGameStore((s) => s.currentPlayerIndex);
@@ -30,158 +32,167 @@ export default function PlayerListPanel() {
 
   return (
     <div ref={constraintsRef} className="fixed inset-0 pointer-events-none z-fab hidden md:block">
-    <motion.div
-      drag
-      dragConstraints={constraintsRef}
-      dragControls={dragControls}
-      dragListener={false}
-      dragMomentum={false}
-      dragElastic={0}
-      className="absolute top-12 right-3 pointer-events-auto"
-    >
-      <div className="rounded-card-ui bg-card/80 backdrop-blur-sm shadow-card shadow-tech border border-border w-48">
-        <div
-          className="px-3 py-2 border-b border-border text-xs text-muted-foreground font-bold flex items-center gap-1 cursor-grab active:cursor-grabbing select-none"
-          onPointerDown={(e) => dragControls.start(e)}
-        >
-          <GripHorizontal size={12} className="shrink-0 opacity-40" />
-          <span className="flex-1">玩家 ({players.length})</span>
-          <button
-            type="button"
-            className="p-0.5 rounded hover:bg-white/10 transition-colors cursor-pointer"
-            onClick={() => setCollapsed((c) => !c)}
-            onPointerDown={(e) => e.stopPropagation()}
+      <motion.div
+        drag
+        dragConstraints={constraintsRef}
+        dragControls={dragControls}
+        dragListener={false}
+        dragMomentum={false}
+        dragElastic={0}
+        className="absolute top-12 right-3 pointer-events-auto"
+      >
+        <div className="glass-panel-sm w-[228px] overflow-hidden">
+          {/* 头部：拖拽手柄 + 标题 + 折叠 */}
+          <div
+            className="pl-3.5 pr-2 py-2.5 flex items-center gap-2 cursor-grab active:cursor-grabbing select-none"
+            onPointerDown={(e) => dragControls.start(e)}
           >
-            <ChevronDown size={12} className={cn('transition-transform', !collapsed && 'rotate-180')} />
-          </button>
-        </div>
-        <AnimatePresence initial={false}>
-          {!collapsed && (
-            <motion.div
-              initial={{ height: 0 }}
-              animate={{ height: 'auto' }}
-              exit={{ height: 0 }}
-              transition={{ duration: 0.15, ease: 'easeInOut' }}
-              className="overflow-hidden"
+            <GripHorizontal size={13} className="shrink-0 text-muted-foreground/40" />
+            <span className="flex-1 flex items-center gap-1.5 text-xs font-bold text-muted-foreground">
+              <Users size={12} /> 玩家
+              <span className="rounded-full bg-white/[0.07] px-1.5 py-px text-[10px] tabular-nums">{players.length}</span>
+            </span>
+            <button
+              type="button"
+              className="p-1 rounded-md text-muted-foreground hover:bg-white/10 hover:text-foreground transition-colors cursor-pointer"
+              onClick={() => setCollapsed((c) => !c)}
+              onPointerDown={(e) => e.stopPropagation()}
+              title={collapsed ? '展开' : '折叠'}
             >
-              <div className="max-h-64 overflow-y-auto scrollbar-thin">
-                <div className="py-1">
-                  {players.map((p, i: number) => {
-                    const isActive = i === currentPlayerIndex;
-                    const isMe = p.id === userId;
-                    const roleColor = getRoleColor(p.role);
-                    return (
-                      <div
-                        key={p.id}
-                        className={cn(
-                          'flex items-center gap-2 px-3 py-1.5 transition-colors',
-                          isActive && 'bg-primary/10',
-                          p.eliminated && 'opacity-40',
-                        )}
-                      >
-                        {(() => {
-                          const isConfiguredBot = p.isBot && !!p.botConfig;
-                          const botDisplay = isConfiguredBot ? DIFFICULTY_DISPLAY[p.botConfig!.difficulty] : undefined;
-                          return (
-                            <div
-                              className="relative w-6 h-6 rounded-full flex items-center justify-center text-xs shrink-0 overflow-hidden"
-                              style={{
-                                background: botDisplay
-                                  ? botDisplay.avatarBg
-                                  : AVATAR_COLORS[i % AVATAR_COLORS.length],
-                              }}
+              <ChevronDown size={13} className={cn('transition-transform duration-200', !collapsed && 'rotate-180')} />
+            </button>
+          </div>
+
+          <AnimatePresence initial={false}>
+            {!collapsed && (
+              <motion.div
+                initial={{ height: 0, opacity: 0 }}
+                animate={{ height: 'auto', opacity: 1 }}
+                exit={{ height: 0, opacity: 0 }}
+                transition={{ duration: 0.18, ease: 'easeInOut' }}
+                className="overflow-hidden"
+              >
+                <div className="max-h-72 overflow-y-auto scrollbar-thin border-t border-white/[0.07]">
+                  <div className="py-1.5 px-1.5 flex flex-col gap-0.5">
+                    {players.map((p, i: number) => {
+                      const isActive = i === currentPlayerIndex;
+                      const isMe = p.id === userId;
+                      const roleColor = getRoleColor(p.role);
+                      const unoAlert = p.handCount === 1 && !p.eliminated;
+                      return (
+                        <div
+                          key={p.id}
+                          className={cn(
+                            // 行圆角与面板同心：16px 外圆角 − 6px 内边距 = 10px
+                            'group relative flex items-center gap-2.5 pl-3 pr-2 py-1.5 rounded-[10px] transition-colors duration-200',
+                            isActive && 'bg-primary/[0.09]',
+                            p.eliminated && 'opacity-40',
+                            !p.connected && 'opacity-60',
+                          )}
+                        >
+                          {/* 当前回合指示条 */}
+                          <span className={cn(
+                            'absolute left-0 top-1/2 -translate-y-1/2 w-[3px] h-0 rounded-full bg-primary transition-all duration-300',
+                            isActive && 'h-[60%]',
+                          )} />
+
+                          {/* 头像（Bot 用难度配色，掉线红点角标） */}
+                          <div className="relative shrink-0">
+                            <PlayerAvatar
+                              index={i}
+                              name={p.name}
+                              avatarUrl={p.avatarUrl}
+                              isBot={p.isBot}
+                              botConfig={p.botConfig}
+                              size={28}
+                              highlighted={isActive}
+                            />
+                            {!p.connected && (
+                              <span className="absolute -bottom-px -right-px w-2 h-2 rounded-full bg-destructive border-2 border-[#141a2e]" title="已断线" />
+                            )}
+                          </div>
+
+                          {/* 名字 + 徽记 */}
+                          <div className="flex-1 min-w-0 flex items-center gap-1">
+                            <span
+                              className={cn(
+                                'text-xs truncate transition-colors',
+                                isActive ? 'text-primary font-bold' : isMe ? 'text-foreground font-bold' : 'text-foreground/85',
+                              )}
+                              style={(!isActive && roleColor) ? { color: roleColor } : undefined}
                             >
-                              {isConfiguredBot ? (
-                                <Bot size={13} className="text-white drop-shadow-sm" />
-                              ) : (
-                                <>
-                                  <span>{AVATAR_EMOJIS[i % AVATAR_EMOJIS.length]}</span>
-                                  {p.avatarUrl && (
-                                    <img
-                                      src={p.avatarUrl}
-                                      alt={p.name}
-                                      className="absolute inset-0 w-full h-full object-cover"
-                                      referrerPolicy="no-referrer"
-                                      onError={(e) => {
-                                        e.currentTarget.style.display = 'none';
-                                      }}
-                                    />
-                                  )}
-                                </>
+                              {p.name}
+                            </span>
+                            {isMe && <span className="shrink-0 inline-flex items-center rounded bg-primary/15 text-primary text-[10px] leading-none px-1 py-0.5">你</span>}
+                            {p.id === ownerId && <Crown size={10} className="shrink-0 text-primary" />}
+                            {p.isBot && <AiBadge className="shrink-0" />}
+                          </div>
+
+                          {/* 右侧：语音（闲置隐藏）、移交房主（hover 显示）、手牌数徽记 */}
+                          <div className="flex items-center gap-1.5 shrink-0">
+                            <PlayerVoiceStatus playerId={p.id} playerName={p.name} isSelf={isMe} hideIdle />
+                            {ownerId === userId && !isMe && !p.isBot && (
+                              <button
+                                onClick={async () => {
+                                  if (!(await showConfirm({ title: '移交房主', message: `确定要将房主移交给 ${p.name} 吗？`, confirmText: '移交' }))) return;
+                                  getSocket().emit('room:transfer_owner', { targetId: p.id }, (res: { success?: boolean; error?: string }) => {
+                                    if (!res?.success) useToastStore.getState().addToast(res?.error ?? '移交失败', 'error');
+                                  });
+                                }}
+                                className="opacity-0 group-hover:opacity-100 text-primary/50 hover:text-primary cursor-pointer transition-all"
+                                title="移交房主"
+                              >
+                                <ArrowRightLeft size={11} />
+                              </button>
+                            )}
+                            <span
+                              className={cn(
+                                'w-[19px] h-[25px] rounded-[5px] border flex items-center justify-center text-[10px] font-bold tabular-nums transition-colors duration-300',
+                                unoAlert
+                                  ? 'border-destructive/60 bg-destructive/15 text-destructive shadow-[0_0_8px_rgba(255,51,102,0.35)]'
+                                  : isActive
+                                    ? 'border-primary/40 bg-primary/10 text-primary'
+                                    : 'border-white/[0.13] bg-white/[0.05] text-muted-foreground',
                               )}
-                              {botDisplay ? (
-                                <div
-                                  className="absolute inset-0 rounded-full pointer-events-none"
-                                  style={{
-                                    border: `1.5px solid ${botDisplay.ringColor}`,
-                                  }}
-                                />
-                              ) : (
-                                <GoogleRing size={0} className="w-full h-full" />
-                              )}
+                              title={`剩余 ${p.handCount} 张`}
+                            >
+                              {p.handCount}
+                            </span>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+
+                  {spectators.length > 0 && (
+                    <>
+                      <div className="mx-3.5 pt-2 pb-1 border-t border-white/[0.07] flex items-center gap-1.5 text-[10px] font-bold text-muted-foreground/70">
+                        <Eye size={11} /> 观众
+                        <span className="rounded-full bg-white/[0.07] px-1.5 py-px tabular-nums">{spectators.length}</span>
+                      </div>
+                      <div className="pb-2 px-1.5">
+                        {spectators.map((s) => {
+                          const queued = pendingJoinQueue.includes(s.nickname);
+                          return (
+                            <div key={s.nickname} className={cn('flex items-center gap-2 pl-3 pr-2 py-1 text-xs text-muted-foreground', !s.connected && 'opacity-50')}>
+                              {queued
+                                ? <UserPlus size={12} className="shrink-0 text-accent" />
+                                : <span className="w-1 h-1 rounded-full bg-muted-foreground/40 mx-[5px] shrink-0" />}
+                              <span className={cn('truncate flex-1', queued && 'text-accent')}>{s.nickname}</span>
+                              {!s.connected && <span className="w-1.5 h-1.5 rounded-full bg-destructive shrink-0" />}
+                              {queued && <span className="text-[10px] text-accent shrink-0">下局加入</span>}
                             </div>
                           );
-                        })()}
-                        <div className="flex-1 min-w-0">
-                          <div className={cn(
-                            'text-xs truncate',
-                            isActive && 'text-primary font-bold',
-                            isMe && !isActive && 'text-primary',
-                            !isActive && !isMe && 'text-foreground',
-                          )} style={(!isActive && !isMe && roleColor) ? { color: roleColor } : undefined}>
-                            {p.name}{isMe ? ' (你)' : ''}{p.id === ownerId && <Crown size={10} className="inline align-middle ml-1 text-primary" />}{p.isBot && <AiBadge className="ml-1" />}
-                          </div>
-                        </div>
-                        <div className="flex items-center gap-1 shrink-0">
-                          <PlayerVoiceStatus playerId={p.id} playerName={p.name} isSelf={isMe} />
-                          {ownerId === userId && !isMe && !p.isBot && (
-                            <button
-                              onClick={async () => {
-                                if (!(await showConfirm({ title: '移交房主', message: `确定要将房主移交给 ${p.name} 吗？`, confirmText: '移交' }))) return;
-                                getSocket().emit('room:transfer_owner', { targetId: p.id }, (res: { success?: boolean; error?: string }) => {
-                                  if (!res?.success) useToastStore.getState().addToast(res?.error ?? '移交失败', 'error');
-                                });
-                              }}
-                              className="text-primary/40 hover:text-primary cursor-pointer transition-colors"
-                              title="移交房主"
-                            >
-                              <ArrowRightLeft size={10} />
-                            </button>
-                          )}
-                          <span className="text-2xs text-muted-foreground">{p.handCount}</span>
-                          {!p.connected && <span className="w-1.5 h-1.5 rounded-full bg-destructive" />}
-                          {isActive && <span className="text-2xs">◀</span>}
-                        </div>
+                        })}
                       </div>
-                    );
-                  })}
+                    </>
+                  )}
                 </div>
-                {spectators.length > 0 && (
-                  <>
-                    <div className="px-3 py-2 border-t border-border text-xs text-muted-foreground font-bold">
-                      观众 ({spectators.length})
-                    </div>
-                    <div className="py-1">
-                      {spectators.map((s) => {
-                        const queued = pendingJoinQueue.includes(s.nickname);
-                        return (
-                          <div key={s.nickname} className={cn('flex items-center gap-2 px-3 py-1 text-xs text-muted-foreground', !s.connected && 'opacity-50')}>
-                            {queued ? <UserPlus size={12} className="shrink-0 text-accent" /> : <Eye size={12} className="shrink-0" />}
-                            <span className={cn('truncate', queued && 'text-accent')}>{s.nickname}</span>
-                            {!s.connected && <span className="w-1.5 h-1.5 rounded-full bg-destructive shrink-0 ml-auto" />}
-                            {queued && <span className="text-2xs text-accent ml-auto shrink-0">加入中</span>}
-                          </div>
-                        );
-                      })}
-                    </div>
-                  </>
-                )}
-              </div>
-            </motion.div>
-          )}
-        </AnimatePresence>
-      </div>
-    </motion.div>
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
+      </motion.div>
     </div>
   );
 }

--- a/packages/client/src/features/game/components/ScoreBoard.tsx
+++ b/packages/client/src/features/game/components/ScoreBoard.tsx
@@ -3,6 +3,7 @@ import { Trophy, BarChart3, Crown, Check, UserX, UserPlus, WifiOff, Eye, X, Arro
 import { showConfirm } from '@/shared/stores/confirm-store';
 import { useGameStore } from '../stores/game-store';
 import { useEffectiveUserId } from '../hooks/useEffectiveUserId';
+import PlayerAvatar from './PlayerAvatar';
 import { useRoomStore } from '@/shared/stores/room-store';
 import { useSpectatorStore } from '../stores/spectator-store';
 import { useAuthStore } from '@/features/auth/stores/auth-store';
@@ -29,6 +30,7 @@ export default function ScoreBoard({ isSpectator = false, onPlayAgain, onBackToR
   const players = useGameStore((s) => s.players);
   const winnerId = useGameStore((s) => s.winnerId);
   const phase = useGameStore((s) => s.phase);
+  const roundNumber = useGameStore((s) => s.roundNumber);
   const vote = useGameStore((s) => s.nextRoundVote);
   const roundEndAt = useGameStore((s) => s.roundEndAt);
   const gameOverAt = useGameStore((s) => s.gameOverAt);
@@ -135,62 +137,95 @@ export default function ScoreBoard({ isSpectator = false, onPlayAgain, onBackToR
 
   return (
     <div className="fixed inset-0 glass-modal-backdrop flex items-center justify-center z-modal">
-      <div className="glass-panel px-10 py-8 min-w-room-min text-center">
-        <h2 className="font-game text-accent mb-4">
-          {isGameOver ? <><Trophy size={20} className="inline align-middle" /> 游戏结束!</> : <><BarChart3 size={20} className="inline align-middle" /> 本轮结束</>}
+      <div className="glass-panel w-[460px] max-w-[94vw] px-7 py-6 max-md:px-5 text-center">
+        <h2 className="font-game text-lg font-black text-accent mb-5 inline-flex items-center gap-2">
+          {isGameOver
+            ? <><Trophy size={18} /> 游戏结束</>
+            : <><BarChart3 size={18} /> {roundNumber > 0 ? `第 ${roundNumber} 轮结束` : '本轮结束'}</>}
         </h2>
-        <table className="w-full border-collapse mb-5">
-          <thead>
-            <tr className="text-muted-foreground text-xs">
-              <th className="text-left px-2 py-1">玩家</th>
-              {!isGameOver && <th className="px-2 py-1">状态</th>}
-              <th className="text-right px-2 py-1">分数</th>
-            </tr>
-          </thead>
-          <tbody>
-            {sorted.map((p) => {
-              const ready = !!vote?.voters.includes(p.id);
-              const disconnected = !p.connected;
-              const isSelf = p.id === userId;
-              return (
-                <tr key={p.id} className={cn(p.id === winnerId ? 'text-accent' : 'text-foreground')}>
-                  <td className="px-2 py-1.5 text-left">
-                    {p.id === winnerId && <Crown size={14} className="inline align-middle mr-1" />}
-                    <span className={cn(disconnected && 'opacity-50')}>{p.name}</span>
-                    {p.id === ownerId && <span title="房主"><Crown size={12} className="inline align-middle ml-1 text-primary" /></span>}
-                    {p.isBot && <AiBadge className="ml-1" />}
-                    {disconnected && <WifiOff size={12} className="inline align-middle ml-1 text-destructive" />}
-                    {canTransfer && !isSelf && !p.isBot && (
-                      <button
-                        onClick={async () => {
-                          if (!(await showConfirm({ title: '移交房主', message: `确定要将房主移交给 ${p.name} 吗？`, confirmText: '移交' }))) return;
-                          getSocket().emit('room:transfer_owner', { targetId: p.id }, (res: { success?: boolean; error?: string }) => {
-                            if (!res?.success) useToastStore.getState().addToast(res?.error ?? '移交失败', 'error');
-                          });
-                        }}
-                        className="ml-1 text-primary/50 hover:text-primary cursor-pointer bg-transparent border-none transition-colors"
-                        title="移交房主"
-                      >
-                        <ArrowRightLeft size={12} className="inline align-middle" />
-                      </button>
-                    )}
-                  </td>
-                  {!isGameOver && (
-                    <td className="px-2 py-1.5 text-center whitespace-nowrap">
-                      <span className="inline-flex items-center gap-1">
-                        {ready ? <Check size={14} className="inline text-speaking" /> : <span className="text-xs text-muted-foreground">等待中</span>}
-                        {isHost && !isSelf && !isSpectator && (
-                          <button onClick={() => onKickPlayer(p.id)} className="text-destructive hover:text-destructive/80 cursor-pointer bg-transparent border-none" title={p.isBot ? '移除机器人' : '移至观战席'}><UserX size={14} className="inline" /></button>
-                        )}
-                      </span>
-                    </td>
+
+        {/* 排名列表 */}
+        <div className="flex flex-col gap-1.5 mb-5">
+          {sorted.map((p, rank) => {
+            const ready = !!vote?.voters.includes(p.id);
+            const disconnected = !p.connected;
+            const isSelf = p.id === userId;
+            const isWinner = p.id === winnerId;
+            const playerIndex = players.findIndex((pl) => pl.id === p.id);
+            return (
+              <div
+                key={p.id}
+                className={cn(
+                  'flex items-center gap-3 rounded-xl pl-2.5 pr-3.5 py-2 border text-left',
+                  isWinner
+                    ? 'bg-primary/[0.08] border-primary/30'
+                    : 'bg-white/[0.03] border-transparent',
+                  disconnected && 'opacity-60',
+                )}
+              >
+                {/* 名次徽章：前三名奖牌色 */}
+                <span className={cn(
+                  'w-6 h-6 rounded-full flex items-center justify-center text-xs font-black tabular-nums shrink-0',
+                  rank === 0 && 'bg-primary text-background',
+                  rank === 1 && 'bg-white/25 text-foreground',
+                  rank === 2 && 'bg-[#b0793f]/55 text-foreground',
+                  rank > 2 && 'bg-white/[0.06] text-muted-foreground',
+                )}>
+                  {rank + 1}
+                </span>
+
+                {/* 头像（冠军戴皇冠角标） */}
+                <div className="relative shrink-0">
+                  <PlayerAvatar index={playerIndex} name={p.name} avatarUrl={p.avatarUrl} isBot={p.isBot} botConfig={p.botConfig} size={32} highlighted={isWinner} />
+                  {isWinner && <Crown size={13} className="absolute -top-2 -right-1.5 rotate-[18deg] text-primary drop-shadow-[0_1px_2px_rgba(0,0,0,0.6)]" />}
+                </div>
+
+                {/* 名字 + 徽记 */}
+                <div className="flex-1 min-w-0 flex items-center gap-1.5">
+                  <span className={cn('text-sm truncate', isWinner ? 'text-primary font-bold' : 'text-foreground')}>{p.name}</span>
+                  {isSelf && <span className="shrink-0 inline-flex items-center rounded bg-primary/15 text-primary text-[10px] leading-none px-1 py-0.5">你</span>}
+                  {p.id === ownerId && <span title="房主"><Crown size={11} className="shrink-0 text-primary" /></span>}
+                  {p.isBot && <AiBadge className="shrink-0" />}
+                  {disconnected && <WifiOff size={11} className="shrink-0 text-destructive" />}
+                  {canTransfer && !isSelf && !p.isBot && (
+                    <button
+                      onClick={async () => {
+                        if (!(await showConfirm({ title: '移交房主', message: `确定要将房主移交给 ${p.name} 吗？`, confirmText: '移交' }))) return;
+                        getSocket().emit('room:transfer_owner', { targetId: p.id }, (res: { success?: boolean; error?: string }) => {
+                          if (!res?.success) useToastStore.getState().addToast(res?.error ?? '移交失败', 'error');
+                        });
+                      }}
+                      className="shrink-0 text-primary/50 hover:text-primary cursor-pointer bg-transparent border-none transition-colors"
+                      title="移交房主"
+                    >
+                      <ArrowRightLeft size={11} />
+                    </button>
                   )}
-                  <td className="px-2 py-1.5 text-right font-bold">{p.score}</td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
+                </div>
+
+                {/* 状态（下一轮准备/踢人）+ 分数 */}
+                <div className="flex items-center gap-2 shrink-0">
+                  {!isGameOver && (
+                    <>
+                      {ready
+                        ? <span className="w-4.5 h-4.5 rounded-full bg-uno-green/15 flex items-center justify-center" title="已同意下一轮"><Check size={11} className="text-uno-green" /></span>
+                        : <span className="text-[10px] text-muted-foreground/70">等待</span>}
+                      {isHost && !isSelf && !isSpectator && (
+                        <button onClick={() => onKickPlayer(p.id)} className="text-destructive/60 hover:text-destructive cursor-pointer bg-transparent border-none transition-colors" title={p.isBot ? '移除机器人' : '移至观战席'}>
+                          <UserX size={13} />
+                        </button>
+                      )}
+                    </>
+                  )}
+                  <span className={cn('min-w-[36px] text-right font-black tabular-nums', isWinner ? 'text-primary text-base' : 'text-foreground text-sm')}>
+                    {p.score}
+                    <span className="ml-0.5 text-[10px] font-normal text-muted-foreground">分</span>
+                  </span>
+                </div>
+              </div>
+            );
+          })}
+        </div>
         {isSpectatorOwner && (
           <div className="mb-3 flex items-center gap-2 rounded-lg bg-primary/10 border border-primary/30 px-3 py-2 text-xs text-primary">
             <Crown size={14} className="shrink-0" />

--- a/packages/client/src/shared/components/ProfileModal.tsx
+++ b/packages/client/src/shared/components/ProfileModal.tsx
@@ -26,6 +26,17 @@ const TABS = [
 
 type TabId = (typeof TABS)[number]['id'];
 
+/** 内容区块：统一的分组卡片外观 */
+const SECTION_CLS = 'rounded-2xl p-6 max-md:p-5 mb-4 bg-white/[0.035] border border-white/[0.10]';
+
+function SectionTitle({ icon: Icon, children }: { icon: typeof Lock; children: React.ReactNode }) {
+  return (
+    <h2 className="flex items-center gap-2 text-[15px] font-bold text-foreground mb-3">
+      <Icon size={16} className="text-primary" /> {children}
+    </h2>
+  );
+}
+
 export default function ProfileModal() {
   const isOpen = useProfileModalStore((s) => s.isOpen);
   const close = useProfileModalStore((s) => s.close);
@@ -193,14 +204,15 @@ export default function ProfileModal() {
           </Button>
         </div>
       ) : (
-        <p className="text-primary text-[30px] font-black cursor-pointer inline-flex items-center gap-2"
+        <p className="text-primary text-[21px] font-black cursor-pointer inline-flex items-center gap-1.5 group"
           onClick={() => setEditingNickname(true)}
+          title="修改昵称"
           style={profileRoleColor ? { color: profileRoleColor } : undefined}>
           {profile?.user.nickname}
-          <Edit3 size={16} className="text-muted-foreground" />
+          <Edit3 size={13} className="text-muted-foreground group-hover:text-foreground transition-colors" />
         </p>
       )}
-      <p className="text-muted-foreground mt-1">@{profile?.user.username}</p>
+      <p className="text-xs text-muted-foreground mt-0.5">@{profile?.user.username}</p>
     </>
   );
 
@@ -208,24 +220,19 @@ export default function ProfileModal() {
     <Modal
       open={isOpen}
       onClose={close}
-      width={1110}
-      className="h-[min(820px,calc(100svh-80px))] overflow-hidden"
+      width={900}
+      className="h-[min(620px,calc(100svh-80px))] overflow-hidden"
     >
       {/* 全出血布局：抵消 Modal 内容区内边距，保持左右分栏结构 */}
-      <div className="absolute inset-0 grid grid-cols-[270px_1fr] max-md:grid-cols-1">
+      <div className="absolute inset-0 grid grid-cols-[236px_1fr] max-md:grid-cols-1">
         {/* Left: Sidebar */}
-        <div className="border-r border-white/[0.08] p-[34px_22px] bg-white/[0.025] flex flex-col max-md:hidden overflow-y-auto scrollbar-thin shrink-0">
-          <div className="self-stretch flex items-center gap-3 text-[26px] font-black mb-8">
-            <span className="text-primary">♠</span>
-            <span>设置</span>
-          </div>
-
+        <div className="border-r border-white/[0.08] px-4 py-7 bg-white/[0.025] flex flex-col max-md:hidden overflow-y-auto scrollbar-thin shrink-0">
           {profile && (
-            <div className="text-center mb-8">
+            <div className="text-center mb-7">
               <div className="flex justify-center">
-                <AvatarUpload avatarUrl={profile.user.avatarUrl} size={100} onUpload={handleAvatarUpload} />
+                <AvatarUpload avatarUrl={profile.user.avatarUrl} size={84} onUpload={handleAvatarUpload} />
               </div>
-              <div className="mt-[18px]">{nicknameBlock}</div>
+              <div className="mt-3.5">{nicknameBlock}</div>
             </div>
           )}
 
@@ -236,65 +243,67 @@ export default function ProfileModal() {
                 key={id}
                 onClick={() => setActiveTab(id)}
                 className={cn(
-                  'flex items-center gap-3 px-4 py-3 rounded-[14px] text-[15px] font-bold transition-all text-left cursor-pointer border',
+                  'flex items-center gap-2.5 px-3.5 py-2.5 rounded-xl text-sm font-bold transition-all text-left cursor-pointer border',
                   activeTab === id
                     ? 'bg-primary/10 text-primary border-primary/28'
                     : 'text-muted-foreground border-transparent hover:bg-white/[0.04] hover:text-foreground',
                 )}
               >
-                <Icon size={18} />
+                <Icon size={16} />
                 {label}
               </button>
             ))}
           </nav>
-
-          <div className="flex-1" />
-          <Button variant="ghost" className="w-full text-muted-foreground" onClick={close} sound="click">关闭</Button>
         </div>
 
         {/* Right: Settings main */}
-        <div className="relative p-[42px_34px_36px] max-md:p-[22px_18px_36px] overflow-y-auto scrollbar-thin">
-          {/* Close button */}
-          <IconButton
-            size="md"
-            onClick={close}
-            title="关闭"
-            className="absolute top-6 right-6 max-md:hidden"
-          >
-            <X size={20} />
-          </IconButton>
+        <div className="relative p-[22px_30px_28px] max-md:p-[16px_16px_32px] overflow-y-auto scrollbar-thin">
+          {/* Desktop pane header：当前 Tab 名 + 关闭，不再悬浮压内容 */}
+          <div className="flex max-md:hidden items-center justify-between mb-4">
+            {(() => {
+              const tab = TABS.find((t) => t.id === activeTab)!;
+              const Icon = tab.icon;
+              return (
+                <h1 className="flex items-center gap-2.5 text-lg font-black text-foreground">
+                  <Icon size={18} className="text-primary" /> {tab.label}
+                </h1>
+              );
+            })()}
+            <IconButton size="md" onClick={close} title="关闭">
+              <X size={20} />
+            </IconButton>
+          </div>
 
           {/* Mobile header */}
-          <div className="hidden max-md:flex items-center justify-between mb-[26px]">
-            <IconButton size="lg" active onClick={close} title="返回">
-              <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}><path d="m15 18-6-6 6-6"/></svg>
+          <div className="hidden max-md:flex items-center gap-2 mb-4">
+            <IconButton size="md" onClick={close} title="返回">
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}><path d="m15 18-6-6 6-6"/></svg>
             </IconButton>
-            <h1 className="text-[34px] font-black">设置</h1>
-            <div className="w-14" />
+            <h1 className="text-lg font-black">个人信息</h1>
           </div>
 
           {/* Mobile profile card */}
           {profile && (
-            <div className="hidden max-md:flex items-center gap-[22px] rounded-[24px] p-[26px_24px] mb-[18px] border border-primary/22 bg-white/[0.035]">
-              <AvatarUpload avatarUrl={profile.user.avatarUrl} size={92} onUpload={handleAvatarUpload} />
-              <div>{nicknameBlock}</div>
+            <div className="hidden max-md:flex items-center gap-4 rounded-2xl p-4 mb-3.5 border border-white/[0.10] bg-white/[0.035]">
+              <AvatarUpload avatarUrl={profile.user.avatarUrl} size={64} onUpload={handleAvatarUpload} />
+              <div className="min-w-0 [&_p]:text-left">{nicknameBlock}</div>
             </div>
           )}
 
           {/* Mobile tab bar */}
-          <div className="hidden max-md:flex gap-2 mb-[18px] overflow-x-auto scrollbar-thin">
+          <div className="hidden max-md:flex gap-2 mb-3.5 overflow-x-auto scrollbar-hidden">
             {TABS.map(({ id, icon: Icon, label }) => (
               <button
                 key={id}
                 onClick={() => setActiveTab(id)}
                 className={cn(
-                  'flex items-center gap-2 px-4 py-2.5 rounded-full text-sm font-bold whitespace-nowrap transition-all cursor-pointer border',
+                  'flex items-center gap-1.5 px-3.5 py-2 rounded-full text-[13px] font-bold whitespace-nowrap transition-all cursor-pointer border',
                   activeTab === id
                     ? 'bg-primary/[0.12] text-primary border-primary/32'
                     : 'text-muted-foreground border-white/[0.10] bg-white/[0.03]',
                 )}
               >
-                <Icon size={15} />
+                <Icon size={14} />
                 {label}
               </button>
             ))}
@@ -305,48 +314,48 @@ export default function ProfileModal() {
 
           {/* Security section (Password + Passkey) */}
           {activeTab === 'security' && <>
-          <div className="rounded-[22px] p-[22px_26px_26px] mb-[18px] bg-white/[0.035] border border-white/[0.10] shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
-            <h2 className="flex items-center gap-3 text-foreground text-[22px] font-black mb-4">
-              <Lock size={22} /> 设置密码
-            </h2>
+          <div className={SECTION_CLS}>
+            <SectionTitle icon={Lock}>设置密码</SectionTitle>
             <Input type="password" value={password} onChange={(e) => setPassword(e.target.value)} placeholder="新密码"
               className="mb-3" autoComplete="new-password" />
             <Input type="password" value={passwordConfirm} onChange={(e) => setPasswordConfirm(e.target.value)} placeholder="确认密码"
               className="mb-3" autoComplete="new-password" />
-            {passwordMsg && (
-              <p className={cn('text-xs mb-3', passwordMsg.includes('成功') ? 'text-uno-green' : 'text-destructive')}>{passwordMsg}</p>
-            )}
-            <Button variant="game" className="w-full h-[58px] text-base tracking-[0.08em]" onClick={handleSetPassword} sound="click">保存密码</Button>
+            <div className="flex items-center justify-between gap-3">
+              <p className={cn('text-xs min-w-0', passwordMsg ? (passwordMsg.includes('成功') ? 'text-uno-green' : 'text-destructive') : 'text-muted-foreground')}>
+                {passwordMsg || '至少 8 位，需包含字母和数字'}
+              </p>
+              <Button variant="primary" className="shrink-0 whitespace-nowrap" onClick={handleSetPassword} sound="click">保存密码</Button>
+            </div>
           </div>
 
           {/* Passkey section */}
           {browserSupportsWebAuthn() && (
-            <div className="rounded-[22px] p-[22px_26px_26px] mb-[18px] bg-white/[0.035] border border-white/[0.10] shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
-              <h2 className="flex items-center gap-3 text-foreground text-[22px] font-black mb-4">
-                <Fingerprint size={22} /> Passkey
-              </h2>
-              <p className="text-foreground/80 mb-3.5 leading-[1.7]">绑定 Passkey 后可免密码登录，支持指纹、面容或安全密钥</p>
+            <div className={SECTION_CLS}>
+              <SectionTitle icon={Fingerprint}>Passkey</SectionTitle>
+              <p className="text-[13px] text-muted-foreground mb-3.5 leading-relaxed">绑定 Passkey 后可免密码登录，支持指纹、面容或安全密钥</p>
 
               {passkeyError && <p className="text-xs text-destructive mb-2">{passkeyError}</p>}
               {passkeySuccess && <p className="text-xs text-uno-green mb-2">{passkeySuccess}</p>}
 
-              <Input
-                type="text"
-                placeholder="Passkey 名称（如：我的 MacBook）"
-                value={newPasskeyName}
-                onChange={(e) => setNewPasskeyName(e.target.value)}
-                maxLength={50}
-                className="mb-3"
-              />
-              <Button
-                variant="game"
-                className="w-full h-[58px] text-base tracking-[0.08em]"
-                onClick={handleRegisterPasskey}
-                disabled={registeringPasskey || !newPasskeyName.trim()}
-                sound="click"
-              >
-                {registeringPasskey ? '注册中...' : '添加 Passkey'}
-              </Button>
+              <div className="flex gap-2.5">
+                <Input
+                  type="text"
+                  placeholder="Passkey 名称（如：我的 MacBook）"
+                  value={newPasskeyName}
+                  onChange={(e) => setNewPasskeyName(e.target.value)}
+                  maxLength={50}
+                  className="flex-1"
+                />
+                <Button
+                  variant="primary"
+                  className="shrink-0"
+                  onClick={handleRegisterPasskey}
+                  disabled={registeringPasskey || !newPasskeyName.trim()}
+                  sound="click"
+                >
+                  {registeringPasskey ? '注册中...' : '添加'}
+                </Button>
+              </div>
 
               {passkeys.length > 0 && (
                 <div className="flex flex-col gap-2 mt-4">
@@ -370,11 +379,8 @@ export default function ProfileModal() {
 
           {/* API Keys section */}
           {activeTab === 'apikeys' && (
-          <div className="rounded-[22px] p-[22px_26px_26px] mb-[18px] bg-white/[0.035] border border-white/[0.10] shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
-            <h2 className="flex items-center gap-3 text-foreground text-[22px] font-black mb-4">
-              <Key size={22} /> API Keys
-            </h2>
-            <p className="text-foreground/80 mb-3.5 leading-[1.7]">用于连接 MCP 客户端（如 Claude Code），让 AI 代你玩游戏</p>
+          <div className={SECTION_CLS}>
+            <p className="text-[13px] text-muted-foreground mb-3.5 leading-relaxed">用于连接 MCP 客户端（如 Claude Code），让 AI 代你玩游戏</p>
 
             {newKeyFull && (
               <div className="mb-3 rounded-[14px] border border-uno-green/30 bg-uno-green/10 p-4">
@@ -397,17 +403,19 @@ export default function ProfileModal() {
               <p className="text-xs text-destructive mb-2">{keyError}</p>
             )}
 
-            <Input
-              type="text"
-              placeholder="Key 名称（如：我的 Claude）"
-              value={newKeyName}
-              onChange={(e) => setNewKeyName(e.target.value)}
-              maxLength={50}
-              className="mb-3"
-            />
-            <Button variant="game" className="w-full h-[58px] text-base tracking-[0.08em]" onClick={handleCreateKey} disabled={creatingKey || !newKeyName.trim()} sound="click">
-              生成 Key
-            </Button>
+            <div className="flex gap-2.5">
+              <Input
+                type="text"
+                placeholder="Key 名称（如：我的 Claude）"
+                value={newKeyName}
+                onChange={(e) => setNewKeyName(e.target.value)}
+                maxLength={50}
+                className="flex-1"
+              />
+              <Button variant="primary" className="shrink-0" onClick={handleCreateKey} disabled={creatingKey || !newKeyName.trim()} sound="click">
+                生成 Key
+              </Button>
+            </div>
 
             {apiKeys.length > 0 && (
               <div className="flex flex-col gap-2 mt-4">
@@ -453,10 +461,8 @@ function NotificationSettingsInline() {
   };
 
   return (
-    <div className="rounded-[22px] p-[22px_26px_26px] mb-[18px] bg-white/[0.035] border border-white/[0.10] shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
-      <h2 className="flex items-center gap-3 text-foreground text-[22px] font-black mb-4">
-        <Bell size={22} /> 通知设置
-      </h2>
+    <div className={SECTION_CLS}>
+      <p className="text-[13px] text-muted-foreground mb-2 leading-relaxed">切到其他窗口时，以下事件会推送桌面通知提醒你</p>
 
       {permission !== 'granted' && (
         <div className="mb-4 rounded-[14px] border border-primary/26 bg-primary/[0.06] px-4 py-3">
@@ -477,7 +483,7 @@ function NotificationSettingsInline() {
 
       <div className="flex flex-col">
         {NOTIFICATION_LABELS.map(({ key, label }) => (
-          <label key={key} className="flex items-center justify-between cursor-pointer min-h-[48px] border-b border-white/[0.07] last:border-b-0 text-[17px]">
+          <label key={key} className="flex items-center justify-between cursor-pointer min-h-[46px] border-b border-white/[0.07] last:border-b-0 text-[15px]">
             <span>{label}</span>
             <Switch
               checked={preferences[key]}

--- a/packages/client/src/shared/components/UserCapsule.tsx
+++ b/packages/client/src/shared/components/UserCapsule.tsx
@@ -2,7 +2,7 @@ import { useState, useRef, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { User, LogOut, ChevronDown } from 'lucide-react';
 import { useAuthStore } from '@/features/auth/stores/auth-store';
-import { getRoleColor } from '@/shared/lib/utils';
+import { getRoleColor, cn } from '@/shared/lib/utils';
 import { useProfileModalStore } from '@/shared/stores/profile-modal-store';
 
 export default function UserCapsule() {
@@ -22,44 +22,66 @@ export default function UserCapsule() {
   }, []);
 
   const roleColor = getRoleColor(user?.role);
-  const initial = (user?.nickname ?? user?.username ?? '?')[0]!.toUpperCase();
+  const nickname = user?.nickname ?? user?.username ?? '?';
+  const initial = nickname[0]!.toUpperCase();
+  const isEphemeral = !!user?.id.startsWith('ephemeral_');
+
+  const avatar = (size: string) => (
+    <span className={cn(
+      size,
+      'rounded-full bg-gradient-to-br from-[#ffd66d] to-[#f6be3e] flex items-center justify-center font-bold text-background overflow-hidden shrink-0',
+      'border-2 border-primary/55 shadow-[0_0_18px_rgba(246,190,62,0.28)]',
+    )}>
+      {user?.avatarUrl
+        ? <img src={user.avatarUrl} alt={initial} className="w-full h-full object-cover" referrerPolicy="no-referrer" onError={(e) => { e.currentTarget.style.display = 'none'; }} />
+        : initial}
+    </span>
+  );
 
   return (
     <div ref={ref} className="relative">
       <button
         onClick={() => setOpen((v) => !v)}
-        className="flex items-center gap-3 cursor-pointer h-[58px] max-sm:h-12 px-[22px] max-sm:px-0 pr-[10px] max-sm:pr-0 rounded-full bg-white/[0.045] max-sm:bg-transparent border border-white/[0.12] max-sm:border-0 transition-all hover:bg-white/[0.07] hover:border-white/[0.18] shadow-[0_18px_40px_rgba(0,0,0,0.25),inset_0_1px_0_rgba(255,255,255,0.06)] max-sm:shadow-none"
+        className={cn(
+          'flex items-center gap-2.5 cursor-pointer h-[58px] max-sm:h-12 pl-5 pr-2 max-sm:p-0 rounded-full transition-colors',
+          'bg-white/5 border border-white/10 hover:bg-white/[0.08] hover:border-white/[0.18]',
+          'max-sm:bg-transparent max-sm:border-0',
+          open && 'bg-white/[0.08] border-white/[0.18]',
+        )}
       >
-        <span className="text-[14px] text-[#d7def2] max-sm:hidden">
-          欢迎, <b className="text-[var(--gold)]" style={roleColor ? { color: roleColor } : undefined}>
-            {user?.nickname ?? user?.username}
-          </b>
+        <span className="text-sm font-bold max-sm:hidden" style={roleColor ? { color: roleColor } : undefined}>
+          <span className={roleColor ? undefined : 'text-primary'}>{nickname}</span>
         </span>
-        <ChevronDown size={16} className={`text-[#d7def2] transition-transform max-sm:hidden ${open ? 'rotate-180' : ''}`} />
-        <span className="w-[46px] h-[46px] max-sm:w-12 max-sm:h-12 rounded-full bg-gradient-to-br from-[#ffd66d] to-[#f6be3e] flex items-center justify-center text-base font-bold text-[#161513] overflow-hidden border-2 border-[rgba(246,190,62,0.55)] shadow-[0_0_22px_rgba(246,190,62,0.32)]">
-          {user?.avatarUrl
-            ? <img src={user.avatarUrl} alt={initial} className="w-full h-full object-cover" referrerPolicy="no-referrer" onError={(e) => { e.currentTarget.style.display = 'none'; }} />
-            : initial}
-        </span>
+        <ChevronDown size={15} className={cn('text-muted-foreground transition-transform max-sm:hidden', open && 'rotate-180')} />
+        {avatar('w-[42px] h-[42px] max-sm:w-12 max-sm:h-12 text-base')}
       </button>
 
-      <div className={`absolute top-[calc(100%+8px)] right-0 w-[180px] glass-panel p-1.5 z-actions transition-all duration-200 ${
-        open ? 'opacity-100 translate-y-0 scale-100 pointer-events-auto' : 'opacity-0 -translate-y-2 scale-[0.96] pointer-events-none'
-      }`}>
-        {!user?.id.startsWith('ephemeral_') && (
-          <>
-            <button
-              onClick={() => { setOpen(false); openProfile(); }}
-              className="flex items-center gap-2.5 w-full px-3.5 py-2.5 rounded-[10px] text-[13px] text-muted-foreground hover:bg-white/[0.06] hover:text-foreground transition-all cursor-pointer"
-            >
-              <User size={15} /> 个人信息
-            </button>
-            <div className="h-px bg-white/[0.06] mx-2 my-1" />
-          </>
+      <div className={cn(
+        'absolute top-[calc(100%+8px)] right-0 w-[236px] glass-panel p-2.5 z-actions transition-all duration-200 origin-top-right',
+        open ? 'opacity-100 translate-y-0 scale-100 pointer-events-auto' : 'opacity-0 -translate-y-1.5 scale-[0.96] pointer-events-none',
+      )}>
+        {/* 身份头 */}
+        <div className="flex items-center gap-3 px-2.5 pt-1.5 pb-2.5">
+          {avatar('w-10 h-10 text-sm')}
+          <div className="min-w-0">
+            <p className="text-sm font-bold truncate" style={roleColor ? { color: roleColor } : undefined}>{nickname}</p>
+            <p className="text-xs text-muted-foreground truncate">{isEphemeral ? '临时用户' : `@${user?.username}`}</p>
+          </div>
+        </div>
+        <div className="h-px bg-white/[0.07] mx-1 mb-1.5" />
+
+        {/* 菜单项圆角与面板同心：28px 外圆角 − 10px 内边距 = 18px（rounded-btn） */}
+        {!isEphemeral && (
+          <button
+            onClick={() => { setOpen(false); openProfile(); }}
+            className="flex items-center gap-2.5 w-full px-3.5 py-2.5 rounded-btn text-[13px] text-muted-foreground hover:bg-white/[0.06] hover:text-foreground transition-colors cursor-pointer"
+          >
+            <User size={15} /> 个人信息
+          </button>
         )}
         <button
           onClick={() => { setOpen(false); logout(); navigate('/'); }}
-          className="flex items-center gap-2.5 w-full px-3.5 py-2.5 rounded-[10px] text-[13px] text-muted-foreground hover:bg-[rgba(255,51,102,0.08)] hover:text-[#ff6b8a] transition-all cursor-pointer"
+          className="flex items-center gap-2.5 w-full px-3.5 py-2.5 rounded-btn text-[13px] text-muted-foreground hover:bg-destructive/10 hover:text-[#ff6b8a] transition-colors cursor-pointer"
         >
           <LogOut size={15} /> 退出登录
         </button>

--- a/packages/client/src/shared/voice/PlayerVoiceStatus.tsx
+++ b/packages/client/src/shared/voice/PlayerVoiceStatus.tsx
@@ -7,13 +7,15 @@ interface PlayerVoiceStatusProps {
   playerName: string;
   isSelf?: boolean;
   className?: string;
+  /** 未加入语音时不渲染（用于列表等紧凑场景，避免整排灰色图标噪音） */
+  hideIdle?: boolean;
 }
 
 function normalizeVoiceName(name: string): string {
   return name.trim().replace(/[^\p{L}\p{N}_ .-]/gu, '').slice(0, 32).toLocaleLowerCase();
 }
 
-export default function PlayerVoiceStatus({ playerId, playerName, isSelf = false, className }: PlayerVoiceStatusProps) {
+export default function PlayerVoiceStatus({ playerId, playerName, isSelf = false, className, hideIdle = false }: PlayerVoiceStatusProps) {
   const status = useGatewayStore((s) => s.status);
   const usersById = useGatewayStore((s) => s.usersById);
   const selfUserId = useGatewayStore((s) => s.selfUserId);
@@ -45,6 +47,8 @@ export default function PlayerVoiceStatus({ playerId, playerName, isSelf = false
   }
   const speaking = presenceAvailable ? presence.speaking : Boolean(voiceUser && speakingByUserId[voiceUser.id]);
   const forceMuted = presenceAvailable && presence.forceMuted;
+
+  if (hideIdle && !inVoice && !forceMuted) return null;
 
   return (
     <span className={cn('inline-flex items-center gap-0.5', className)} title={inVoice ? '语音状态' : '未加入语音'}>


### PR DESCRIPTION
本轮 UI 打磨，三块区域视觉/交互重构，功能逻辑零改动：

## 大厅右上角个人信息区
- **UserCapsule**：v0.11.0 token 化重构的漏网之鱼，硬编码 hex 全面换语义 token；下拉从两个裸菜单项升级为身份面板（头像+昵称+@用户名/临时用户），退出登录 destructive hover
- **hover 修复**：菜单项圆角与面板同心（28px 外圆角 − 10px 内边距 = 18px rounded-btn），修复高亮色块顶进面板圆弧的切角观感
- **ProfileModal**：尺寸 1110×820 → 900×620 消灭空旷；右栏加 Tab 头部行（当前 Tab 名 + ✕），修复悬浮关闭按钮叠压内容；三个全出血 58px 金渐变按钮降级为行内主按钮；删冗余标题与双关闭；移动端全面紧凑重排

## 对局玩家列表（PlayerListPanel 重写）
- 容器换 glass-panel-sm，当前回合三重指示：左侧金色指示条（高度动画）+ 行高亮 + 头像主色描边
- 手牌数改迷你卡片形徽记，剩 1 张红色发光告警（UNO 时刻）
- 语音图标闲置隐藏（PlayerVoiceStatus 新增 hideIdle 属性）；移交房主 hover 浮现；掉线红点改头像角标；「你」主色徽章
- 保留拖拽/折叠/Bot 难度配色/角色颜色/房主移交

## 结算板（ScoreBoard 重构）
- 表格 → 带头像排名列表：前三名奖牌色位次徽章，冠军行高亮 + 头像斜戴皇冠 + 金色分数（冠军皇冠与房主皇冠语义分离）
- 标题带轮次（第 N 轮结束）；已同意绿勾圆徽、踢人图标弱化
- 投票/冷却/五种按钮态逻辑一字未动

## 代码整理与修复
- 新增共享 `PlayerAvatar`（真实头像 > Bot 难度配色 > emoji 兜底），玩家列表与结算板统一使用；修复头像 img 未圆形裁切、flex/block 互斥类导致 Bot 图标偏移两个 bug
- 发现全局问题：`text-2xs` 工具类从未生成（token 命名 `--font-size-2xs` 不符合 Tailwind v4 `--text-*` 命名空间），对局页 46 处均在继承父级字号——本 PR 内改用显式字号规避，全局修复另行跟踪

## 验证
- client tsc + 生产构建 + shared 测试通过；拟人 e2e 回归通过
- 桌面/移动端逐 Tab 截图复核；「你」徽章计算字号、头像圆形裁切、Bot 居中经 DOM 实测验证
- 用户已在局域网实测确认

🤖 Generated with [Claude Code](https://claude.com/claude-code)