### PR TITLE
chore(client): 全部曲目署名改为完整的 Claude Opus 4.6

### DIFF
--- a/packages/client/src/shared/sound/songs/game-1.ts
+++ b/packages/client/src/shared/sound/songs/game-1.ts
@@ -45,7 +45,7 @@ const bF = bass([F2,F3],[G2,G3],[A2,A3],[C2,C3]);
 function join(...s: N[][]): N[] { return s.flat(); }
 
 const song: Song = {
-  name: 'UNO Bounce', meta: { 'author':'Claude', 'key':'C 大调', 'style':'弹跳琶音', 'wave':'方波' }, bpm: 138, stepsPerBeat: 2,
+  name: 'UNO Bounce', meta: { 'author':'Claude Opus 4.6', 'key':'C 大调', 'style':'弹跳琶音', 'wave':'方波' }, bpm: 138, stepsPerBeat: 2,
   tones: [
     { wave: 'square', gain: 0.15, dur: 0.1,
       notes: join(mA, mC, mB, mD, mE, mA, mB, mF) },

--- a/packages/client/src/shared/sound/songs/game-10.ts
+++ b/packages/client/src/shared/sound/songs/game-10.ts
@@ -41,7 +41,7 @@ const bE = bassHalf([F2,F3],[G2,G3],[C2,C3],[C2,C3]);
 function join(...s: N[][]): N[] { return s.flat(); }
 
 const song: Song = {
-  name: 'Minuet', meta: { 'author':'Claude', 'key':'C 大调', 'style':'巴洛克小步舞', 'wave':'三角波' }, bpm: 108, stepsPerBeat: 2,
+  name: 'Minuet', meta: { 'author':'Claude Opus 4.6', 'key':'C 大调', 'style':'巴洛克小步舞', 'wave':'三角波' }, bpm: 108, stepsPerBeat: 2,
   tones: [
     { wave: 'triangle', gain: 0.14, dur: 0.16,
       notes: join(mA, mB, mA, mC, mD, mA, mB, mE) },

--- a/packages/client/src/shared/sound/songs/game-2.ts
+++ b/packages/client/src/shared/sound/songs/game-2.ts
@@ -47,7 +47,7 @@ const bF = bass([C2,C3],[A2,A3],[F2,F3],[G2,G3]);
 function join(...s: N[][]): N[] { return s.flat(); }
 
 const song: Song = {
-  name: 'Reverse!', meta: { 'author':'Claude', 'key':'A 小调', 'style':'切分律动', 'wave':'方波' }, bpm: 128, stepsPerBeat: 2,
+  name: 'Reverse!', meta: { 'author':'Claude Opus 4.6', 'key':'A 小调', 'style':'切分律动', 'wave':'方波' }, bpm: 128, stepsPerBeat: 2,
   tones: [
     { wave: 'square', gain: 0.15, dur: 0.1,
       notes: join(mA, mB, mC, mD, mE, mA, mF, mD) },

--- a/packages/client/src/shared/sound/songs/game-3.ts
+++ b/packages/client/src/shared/sound/songs/game-3.ts
@@ -53,7 +53,7 @@ const bF = bass([A2,A3],[G2,G3],[F2,F3],[A2,A3]);
 function join(...s: N[][]): N[] { return s.flat(); }
 
 const song: Song = {
-  name: 'Draw Four!', meta: { 'author':'Claude', 'key':'A 小调', 'style':'高速连奏', 'wave':'方波' }, bpm: 144, stepsPerBeat: 2,
+  name: 'Draw Four!', meta: { 'author':'Claude Opus 4.6', 'key':'A 小调', 'style':'高速连奏', 'wave':'方波' }, bpm: 144, stepsPerBeat: 2,
   tones: [
     { wave: 'square', gain: 0.15, dur: 0.1,
       notes: join(mA, mB, mA, mC, mD, mE, mB, mF) },

--- a/packages/client/src/shared/sound/songs/game-4.ts
+++ b/packages/client/src/shared/sound/songs/game-4.ts
@@ -35,7 +35,7 @@ const bD = bass([D3,F3],[G2,G3],[C2,C3],[C2,C3]);
 function join(...s: N[][]): N[] { return s.flat(); }
 
 const song: Song = {
-  name: 'Color Wheel', meta: { 'author':'Claude', 'key':'C 大调', 'style':'回旋轮盘', 'wave':'方波' }, bpm: 120, stepsPerBeat: 2,
+  name: 'Color Wheel', meta: { 'author':'Claude Opus 4.6', 'key':'C 大调', 'style':'回旋轮盘', 'wave':'方波' }, bpm: 120, stepsPerBeat: 2,
   tones: [
     { wave: 'square', gain: 0.14, dur: 0.12,
       notes: join(mA, mB, mA, mC, mA, mB, mA, mD) },

--- a/packages/client/src/shared/sound/songs/game-5.ts
+++ b/packages/client/src/shared/sound/songs/game-5.ts
@@ -38,7 +38,7 @@ const bD = bass([A2,A3],[F2,F3],[G2,G3],[A2,A3]);
 function join(...s: N[][]): N[] { return s.flat(); }
 
 const song: Song = {
-  name: 'Wild Card', meta: { 'author':'Claude', 'key':'A 小调', 'style':'极速冲刺', 'wave':'方波' }, bpm: 148, stepsPerBeat: 2,
+  name: 'Wild Card', meta: { 'author':'Claude Opus 4.6', 'key':'A 小调', 'style':'极速冲刺', 'wave':'方波' }, bpm: 148, stepsPerBeat: 2,
   tones: [
     { wave: 'square', gain: 0.15, dur: 0.09,
       notes: join(mA, mA, mB, mB, mC, mC, mD, mD) },

--- a/packages/client/src/shared/sound/songs/game-6.ts
+++ b/packages/client/src/shared/sound/songs/game-6.ts
@@ -41,7 +41,7 @@ const bE = bass([E2,E3],[D2,D3],[C3,C4],[G2,G3]);
 function join(...s: N[][]): N[] { return s.flat(); }
 
 const song: Song = {
-  name: 'Blitz', meta: { 'author':'Claude', 'key':'G 大调', 'style':'进行曲', 'wave':'锯齿波' }, bpm: 135, stepsPerBeat: 2,
+  name: 'Blitz', meta: { 'author':'Claude Opus 4.6', 'key':'G 大调', 'style':'进行曲', 'wave':'锯齿波' }, bpm: 135, stepsPerBeat: 2,
   tones: [
     { wave: 'sawtooth', gain: 0.10, dur: 0.1,
       notes: join(mA, mB, mC, mA, mD, mA, mB, mE) },

--- a/packages/client/src/shared/sound/songs/game-7.ts
+++ b/packages/client/src/shared/sound/songs/game-7.ts
@@ -41,7 +41,7 @@ const bE = bass([D3,A3],[C2,C3],[Bb2,Bb3],[F2,F3]);
 function join(...s: N[][]): N[] { return s.flat(); }
 
 const song: Song = {
-  name: 'Carnival', meta: { 'author':'Claude', 'key':'F 大调', 'style':'拉丁嘉年华', 'wave':'正弦波' }, bpm: 132, stepsPerBeat: 2,
+  name: 'Carnival', meta: { 'author':'Claude Opus 4.6', 'key':'F 大调', 'style':'拉丁嘉年华', 'wave':'正弦波' }, bpm: 132, stepsPerBeat: 2,
   tones: [
     { wave: 'sine', gain: 0.18, dur: 0.12,
       notes: join(mA, mB, mA, mC, mD, mA, mB, mE) },

--- a/packages/client/src/shared/sound/songs/game-8.ts
+++ b/packages/client/src/shared/sound/songs/game-8.ts
@@ -41,7 +41,7 @@ const bE = bassHalf([G2,G3],[A2,A3],[Bb2,Bb3],[C2,C3]);
 function join(...s: N[][]): N[] { return s.flat(); }
 
 const song: Song = {
-  name: 'Midnight', meta: { 'author':'Claude', 'key':'D 小调', 'style':'暗夜氛围', 'wave':'方波' }, bpm: 116, stepsPerBeat: 2,
+  name: 'Midnight', meta: { 'author':'Claude Opus 4.6', 'key':'D 小调', 'style':'暗夜氛围', 'wave':'方波' }, bpm: 116, stepsPerBeat: 2,
   tones: [
     { wave: 'square', gain: 0.13, dur: 0.14,
       notes: join(mA, mB, mC, mA, mD, mE, mB, mD) },

--- a/packages/client/src/shared/sound/songs/game-9.ts
+++ b/packages/client/src/shared/sound/songs/game-9.ts
@@ -43,7 +43,7 @@ const bD: N[] = [
 function join(...s: N[][]): N[] { return s.flat(); }
 
 const song: Song = {
-  name: 'Pulse', meta: { 'author':'Claude', 'key':'A 小调', 'style':'纯节奏', 'wave':'方波' }, bpm: 140, stepsPerBeat: 2,
+  name: 'Pulse', meta: { 'author':'Claude Opus 4.6', 'key':'A 小调', 'style':'纯节奏', 'wave':'方波' }, bpm: 140, stepsPerBeat: 2,
   tones: [
     { wave: 'square', gain: 0.12, dur: 0.05,
       notes: join(mA, mB, mC, mD, mA, mB, mC, mE) },

--- a/packages/client/src/shared/sound/songs/lobby-1.ts
+++ b/packages/client/src/shared/sound/songs/lobby-1.ts
@@ -45,7 +45,7 @@ const bF = bassHalf([F2,F3],[G2,G3],[A2,A3],[C2,C3]);
 function join(...s: N[][]): N[] { return s.flat(); }
 
 const song: Song = {
-  name: 'Shuffle', meta: { 'author':'Claude', 'key':'C 大调', 'style':'轻快摇曳', 'wave':'方波' }, bpm: 96, stepsPerBeat: 2,
+  name: 'Shuffle', meta: { 'author':'Claude Opus 4.6', 'key':'C 大调', 'style':'轻快摇曳', 'wave':'方波' }, bpm: 96, stepsPerBeat: 2,
   tones: [
     { wave: 'square', gain: 0.10, dur: 0.18,
       notes: join(mA, mB, mC, mD, mE, mA, mB, mF) },

--- a/packages/client/src/shared/sound/songs/lobby-2.ts
+++ b/packages/client/src/shared/sound/songs/lobby-2.ts
@@ -39,7 +39,7 @@ const bD = bassHalf([F2,null],[G2,null],[C2,null],[C2,null]);
 function join(...s: N[][]): N[] { return s.flat(); }
 
 const song: Song = {
-  name: 'Daydream', meta: { 'author':'Claude', 'key':'C 大调', 'style':'空灵梦幻', 'wave':'方波' }, bpm: 88, stepsPerBeat: 2,
+  name: 'Daydream', meta: { 'author':'Claude Opus 4.6', 'key':'C 大调', 'style':'空灵梦幻', 'wave':'方波' }, bpm: 88, stepsPerBeat: 2,
   tones: [
     { wave: 'square', gain: 0.10, dur: 0.22,
       notes: join(mA, mB, mAp, mC, mA, mB, mAp, mD) },

--- a/packages/client/src/shared/sound/songs/lobby-3.ts
+++ b/packages/client/src/shared/sound/songs/lobby-3.ts
@@ -35,7 +35,7 @@ const bD = bassHalf([D3,F3],[G2,G3],[C2,C3],[C2,C3]);
 function join(...s: N[][]): N[] { return s.flat(); }
 
 const song: Song = {
-  name: 'Waiting Room', meta: { 'author':'Claude', 'key':'C 大调', 'style':'温暖柔和', 'wave':'方波' }, bpm: 92, stepsPerBeat: 2,
+  name: 'Waiting Room', meta: { 'author':'Claude Opus 4.6', 'key':'C 大调', 'style':'温暖柔和', 'wave':'方波' }, bpm: 92, stepsPerBeat: 2,
   tones: [
     { wave: 'square', gain: 0.10, dur: 0.18,
       notes: join(mA, mB, mC, mB, mA, mB, mC, mD) },

--- a/packages/client/src/shared/sound/songs/lobby-4.ts
+++ b/packages/client/src/shared/sound/songs/lobby-4.ts
@@ -35,7 +35,7 @@ const bD = bassHalf([C3,null],[D2,null],[G2,null],[G2,null]);
 function join(...s: N[][]): N[] { return s.flat(); }
 
 const song: Song = {
-  name: 'Breeze', meta: { 'author':'Claude', 'key':'G 大调', 'style':'田园清风', 'wave':'正弦波' }, bpm: 84, stepsPerBeat: 2,
+  name: 'Breeze', meta: { 'author':'Claude Opus 4.6', 'key':'G 大调', 'style':'田园清风', 'wave':'正弦波' }, bpm: 84, stepsPerBeat: 2,
   tones: [
     { wave: 'sine', gain: 0.12, dur: 0.25,
       notes: join(mA, mB, mA, mC, mA, mB, mA, mD) },

--- a/packages/client/src/shared/sound/songs/lobby-5.ts
+++ b/packages/client/src/shared/sound/songs/lobby-5.ts
@@ -41,7 +41,7 @@ const bE = bassHalf([Bb2,null],[C2,null],[F2,null],[F2,null]);
 function join(...s: N[][]): N[] { return s.flat(); }
 
 const song: Song = {
-  name: 'Sunset', meta: { 'author':'Claude', 'key':'F 大调', 'style':'日落音乐盒', 'wave':'三角波' }, bpm: 78, stepsPerBeat: 2,
+  name: 'Sunset', meta: { 'author':'Claude Opus 4.6', 'key':'F 大调', 'style':'日落音乐盒', 'wave':'三角波' }, bpm: 78, stepsPerBeat: 2,
   tones: [
     { wave: 'triangle', gain: 0.12, dur: 0.3,
       notes: join(mA, mB, mC, mA, mD, mB, mC, mE) },

--- a/packages/client/src/shared/sound/songs/lobby-6.ts
+++ b/packages/client/src/shared/sound/songs/lobby-6.ts
@@ -42,7 +42,7 @@ const bE = bassHalf([F2,F3],[G2,G3],[A2,A3],[A2,A3]);
 function join(...s: N[][]): N[] { return s.flat(); }
 
 const song: Song = {
-  name: 'Nocturne', meta: { 'author':'Claude', 'key':'Am/C', 'style':'浪漫夜曲', 'wave':'正弦波' }, bpm: 72, stepsPerBeat: 2,
+  name: 'Nocturne', meta: { 'author':'Claude Opus 4.6', 'key':'Am/C', 'style':'浪漫夜曲', 'wave':'正弦波' }, bpm: 72, stepsPerBeat: 2,
   tones: [
     { wave: 'sine', gain: 0.14, dur: 0.3,
       notes: join(mA, mB, mC, mA, mD, mB, mC, mE) },


### PR DESCRIPTION
16 首内置曲目的 meta.author 从 'Claude' 改为完整署名 'Claude Opus 4.6'（音乐厅与 BGM 提示均随 meta 展示）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)