### PR TITLE
fix: 修复淘汰制僵尸座位获得回合，改进人机策略逻辑

### DIFF
--- a/packages/server/src/ws/bot-uno-watcher.ts
+++ b/packages/server/src/ws/bot-uno-watcher.ts
@@ -160,6 +160,12 @@ export function checkBotJumpIn(
   );
   if (candidateBots.length === 0) return false;
 
+  // Shuffle so earlier-seated bots don't always win the race to jump in
+  for (let i = candidateBots.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [candidateBots[i], candidateBots[j]] = [candidateBots[j]!, candidateBots[i]!];
+  }
+
   // Find the first bot that can jump in
   for (const bot of candidateBots) {
     const actions = chooseBotJumpInAction(state, bot.id);

--- a/packages/shared/src/rules/bot/bot-strategy.ts
+++ b/packages/shared/src/rules/bot/bot-strategy.ts
@@ -3,10 +3,10 @@ import type { Color, Card } from '../../types/card.js';
 import type { BotConfig } from '../../types/bot.js';
 import { getPlayableCards, canPlayCard, isExactJumpInMatch, isValidWildDrawFour } from '../validation.js';
 import { isWildCard, isColoredCard, getEffectiveColor } from '../../types/card.js';
-import { getNextPlayerIndex, reverseDirection } from '../turn.js';
+import { getNextAliveIndex } from '../turn.js';
 import { DIFFICULTY_PARAMS } from './difficulty-params.js';
 import { PERSONALITY_WEIGHTS } from './personality-weights.js';
-import { evaluateCards, bestColorForHand, evaluateHandQuality, electLeadBot } from './card-evaluator.js';
+import { evaluateCards, bestColorsForHand, evaluateHandQuality, electLeadBot } from './card-evaluator.js';
 
 function isFinishBlocked(card: Card, hand: Card[], hr: { noWildFinish: boolean; noFunctionCardFinish: boolean }): boolean {
   if (hand.length !== 1) return false;
@@ -107,19 +107,18 @@ function chooseBestColor(state: GameState, botId: string, hand: Card[], playedCa
 
       let allyBonus = 0;
       let oppPenalty = 0;
-      let idx = getNextPlayerIndex(botIndex, state.players.length, state.direction);
+      // Walk alive seats in turn order; weight decays per acting player
+      let idx = getNextAliveIndex(state.players, botIndex, state.direction);
       let weight = 1.0;
-      for (let i = 0; i < state.players.length - 1; i++) {
+      for (let i = 0; i < state.players.length && idx !== botIndex; i++) {
         const p = state.players[idx]!;
-        if (!p.eliminated && p.id !== botId) {
-          const colorCount = p.hand.filter(c => isColoredCard(c) && c.color === color).length;
-          if (isAlly(p)) {
-            allyBonus += colorCount * weight;
-          } else {
-            oppPenalty += colorCount * weight;
-          }
+        const colorCount = p.hand.filter(c => isColoredCard(c) && c.color === color).length;
+        if (isAlly(p)) {
+          allyBonus += colorCount * weight;
+        } else {
+          oppPenalty += colorCount * weight;
         }
-        idx = getNextPlayerIndex(idx, state.players.length, state.direction);
+        idx = getNextAliveIndex(state.players, idx, state.direction);
         weight *= 0.5;
       }
 
@@ -140,8 +139,10 @@ function chooseBestColor(state: GameState, botId: string, hand: Card[], playedCa
     return scores.sort((a, b) => b.score - a.score)[0]!.color;
   }
 
-  // Normal/easy: pick best color for own hand (excluding the played card)
-  return bestColorForHand(hand, playedCardId);
+  // Normal/easy: pick best color for own hand (excluding the played card);
+  // random among ties so the choice can't be predicted from color order
+  const best = bestColorsForHand(hand, playedCardId);
+  return best[Math.floor(Math.random() * best.length)]!;
 }
 
 /**
@@ -236,12 +237,11 @@ function handleChallenging(state: GameState, playerId: string, config: BotConfig
     return [{ type: 'ACCEPT', playerId }];
   }
 
-  // Hard bot: peek at previous player's hand to determine if WD4 was valid
+  // Hard bot: peek at the WD4 player's hand to determine if the play was valid.
+  // During the challenging phase currentPlayerIndex is still the WD4 player
+  // (the engine resolves challenges the same way), which also covers jump-in WD4s.
   if (config.difficulty === 'hard' && params.infoAccess.canSeeOpponentHands) {
-    // Find the player who played the WD4 (the one before the current player in turn order)
-    const botIndex = state.players.findIndex(p => p.id === playerId);
-    const prevIndex = getNextPlayerIndex(botIndex, state.players.length, reverseDirection(state.direction));
-    const prevPlayer = state.players[prevIndex];
+    const prevPlayer = state.players[state.currentPlayerIndex];
 
     // Determine what color was active before the WD4 was played.
     // The second-to-last card in the discard pile tells us the color.
@@ -310,8 +310,6 @@ function handleChoosingSwapTarget(state: GameState, playerId: string, config: Bo
     };
 
     const myQuality = evaluateHandQuality(player.hand, state);
-    const allyBots = state.players.filter(p => p.isBot && !p.eliminated);
-    const lead = allyBots.length > 0 ? electLeadBot(allyBots, state) : null;
 
     let bestTarget: typeof targets[number] | null = null;
     let bestDelta = -Infinity;
@@ -326,8 +324,6 @@ function handleChoosingSwapTarget(state: GameState, playerId: string, config: Bo
         // Extra bonus if our hand is large (dumping junk on human)
         if (player.hand.length > t.hand.length + 2) delta += 4;
       }
-      // Bonus if this bot is the lead — swap to get even closer to winning
-      if (lead && lead.id === player.id) delta += 5;
       if (delta > bestDelta) { bestDelta = delta; bestTarget = t; }
     }
     if (bestTarget) {
@@ -346,8 +342,15 @@ function handleChoosingSwapTarget(state: GameState, playerId: string, config: Bo
 
 const ALL_COLORS: Color[] = ['red', 'blue', 'green', 'yellow'];
 
-function solveEndgame(hand: Card[], topCard: Card, currentColor: Color, hr: { noWildFinish: boolean; noFunctionCardFinish: boolean }): Card | null {
-  if (hand.length > 3 || hand.length === 0) return null;
+/**
+ * Endgame solver: return every card that starts at least one winning
+ * sequence, assuming the state does not change between the bot's plays.
+ * The caller ranks the returned candidates with the evaluator, so the
+ * strategically best line wins instead of whichever card happens to sit
+ * first in the hand.
+ */
+function solveEndgame(hand: Card[], topCard: Card, currentColor: Color, hr: { noWildFinish: boolean; noFunctionCardFinish: boolean }): Card[] {
+  if (hand.length > 3 || hand.length === 0) return [];
 
   function canWin(remaining: Card[], top: Card, color: Color): boolean {
     if (remaining.length === 0) return true;
@@ -368,24 +371,23 @@ function solveEndgame(hand: Card[], topCard: Card, currentColor: Color, hr: { no
     return false;
   }
 
+  const winningStarts: Card[] = [];
   for (let i = 0; i < hand.length; i++) {
     const card = hand[i]!;
     if (!canPlayCard(card, topCard, currentColor)) continue;
     const rest = hand.filter((_, j) => j !== i);
     if (rest.length === 0) {
-      if (isFinishBlocked(card, hand, hr)) continue;
-      return card;
+      if (!isFinishBlocked(card, hand, hr)) winningStarts.push(card);
+      continue;
     }
     if (isWildCard(card)) {
-      for (const c of ALL_COLORS) {
-        if (canWin(rest, card, c)) return card;
-      }
+      if (ALL_COLORS.some(c => canWin(rest, card, c))) winningStarts.push(card);
     } else {
       const nextColor = isColoredCard(card) ? card.color : currentColor;
-      if (canWin(rest, card, nextColor)) return card;
+      if (canWin(rest, card, nextColor)) winningStarts.push(card);
     }
   }
-  return null;
+  return winningStarts;
 }
 
 function handlePlaying(state: GameState, playerId: string, config: BotConfig): GameAction[] {
@@ -510,12 +512,16 @@ function handlePlaying(state: GameState, playerId: string, config: BotConfig): G
     return playCardActions(playerId, pick, color, false);
   }
 
-  // Hard bot endgame solver: enumerate winning sequences when hand is small
+  // Hard bot endgame solver: restrict candidates to cards that start a
+  // winning sequence, then let the evaluator pick the strongest of them
+  // (e.g. prefer a draw-two that guarantees the follow-up over a gamble).
   if (config.difficulty === 'hard' && player.hand.length <= 3 && topCard && state.currentColor) {
-    const winCard = solveEndgame(player.hand, topCard, state.currentColor, hr);
-    if (winCard) {
-      const color = chooseBestColor(state, playerId, player.hand, winCard.id, config);
-      return playCardActions(playerId, winCard, color, false);
+    const winningStarts = solveEndgame(player.hand, topCard, state.currentColor, hr);
+    if (winningStarts.length > 0) {
+      const scored = evaluateCards(player.hand, winningStarts, state, playerId, params, weights);
+      const pick = applyMistake(scored, params.mistakeRate);
+      const color = chooseBestColor(state, playerId, player.hand, pick.id, config);
+      return playCardActions(playerId, pick, color, false);
     }
   }
 
@@ -544,9 +550,19 @@ function handlePlaying(state: GameState, playerId: string, config: BotConfig): G
       } else {
         chainCount = Math.ceil(sameValue.length * params.specialCardAwareness);
       }
+      // Order the chain: dump scarce colors first and finish on the color
+      // the bot holds most of — the last card played sets the table color.
+      const restAfterChain = player.hand.filter(c =>
+        c.id !== pick.id && !sameValue.some(s => s.id === c.id));
+      const remainingColorCount = (card: Card): number =>
+        isColoredCard(card)
+          ? restAfterChain.filter(c => isColoredCard(c) && c.color === card.color).length
+          : 0;
+      const orderedSameValue = [...sameValue].sort((a, b) => remainingColorCount(a) - remainingColorCount(b));
+
       // Cap chain to avoid leaving a single finish-blocked card
       if (params.finishRestrictionAwareness && (hr.noWildFinish || hr.noFunctionCardFinish)) {
-        const playedIds = new Set([pick.id, ...sameValue.slice(0, chainCount).map(c => c.id)]);
+        const playedIds = new Set([pick.id, ...orderedSameValue.slice(0, chainCount).map(c => c.id)]);
         const afterChain = player.hand.filter(c => !playedIds.has(c.id));
         if (afterChain.length === 1 && isFinishBlocked(afterChain[0]!, afterChain, hr)) {
           chainCount = Math.max(0, chainCount - 1);
@@ -554,7 +570,7 @@ function handlePlaying(state: GameState, playerId: string, config: BotConfig): G
       }
       if (chainCount > 0) {
         for (let i = 0; i < chainCount; i++) {
-          actions.push({ type: 'PLAY_CARD', playerId, cardId: sameValue[i]!.id });
+          actions.push({ type: 'PLAY_CARD', playerId, cardId: orderedSameValue[i]!.id });
         }
         actions.push({ type: 'PASS', playerId });
       }
@@ -625,7 +641,7 @@ export function chooseBotJumpInAction(state: GameState, playerId: string): GameA
     // Close to winning — always worth it
     if (afterCount > 1) {
       const botIndex = state.players.findIndex(p => p.id === playerId);
-      const nextIdx = getNextPlayerIndex(botIndex, state.players.length, state.direction);
+      const nextIdx = getNextAliveIndex(state.players, botIndex, state.direction);
       const nextAfterJump = state.players[nextIdx];
       const hitsHuman = nextAfterJump && !nextAfterJump.isBot && !nextAfterJump.eliminated;
       const isOffensive = (card.type === 'draw_two' || card.type === 'skip') && hitsHuman;
@@ -643,7 +659,7 @@ export function chooseBotJumpInAction(state: GameState, playerId: string): GameA
   // and the card is just a number)
   if (params.botCoalition && !currentPlayer.isBot && card.type === 'number') {
     const botIndex = state.players.findIndex(p => p.id === playerId);
-    const nextIdx = getNextPlayerIndex(botIndex, state.players.length, state.direction);
+    const nextIdx = getNextAliveIndex(state.players, botIndex, state.direction);
     const nextAfterJump = state.players[nextIdx];
     if (nextAfterJump && !nextAfterJump.isBot && !nextAfterJump.eliminated && nextAfterJump.hand.length <= 2) {
       if (player.hand.length > 3) return [];

--- a/packages/shared/src/rules/bot/card-evaluator.ts
+++ b/packages/shared/src/rules/bot/card-evaluator.ts
@@ -3,8 +3,8 @@ import type { GameState, Player } from '../../types/game.js';
 import type { DifficultyParams } from './difficulty-params.js';
 import type { PersonalityWeights } from './personality-weights.js';
 import { isColoredCard, isWildCard } from '../../types/card.js';
-import { getPlayableCards } from '../validation.js';
-import { getNextPlayerIndex, reverseDirection } from '../turn.js';
+import { getPlayableCards, isValidWildDrawFour } from '../validation.js';
+import { getNextPlayerIndex, getNextAliveIndex, reverseDirection } from '../turn.js';
 
 interface EvalContext {
   botIndex: number;
@@ -28,6 +28,7 @@ export interface CardScoreFactors {
   cardConservation: number;
   globalThreat: number;
   coalitionTactics: number;
+  wildFourRisk: number;
 }
 
 export interface CardScore {
@@ -41,11 +42,20 @@ function countColorInHand(hand: Card[], color: Color, excludeId?: string): numbe
 }
 
 export function bestColorForHand(hand: Card[], excludeId?: string): Color {
+  return bestColorsForHand(hand, excludeId)[0]!;
+}
+
+/**
+ * All colors tied for the highest count in hand, in fixed color order.
+ * Callers that pick randomly among these avoid a predictable red bias.
+ */
+export function bestColorsForHand(hand: Card[], excludeId?: string): Color[] {
   const counts: Record<Color, number> = { red: 0, blue: 0, green: 0, yellow: 0 };
   for (const c of hand) {
     if (c.id !== excludeId && isColoredCard(c)) counts[c.color]++;
   }
-  return (Object.entries(counts).sort((a, b) => b[1] - a[1])[0]?.[0] ?? 'red') as Color;
+  const max = Math.max(counts.red, counts.blue, counts.green, counts.yellow);
+  return (Object.keys(counts) as Color[]).filter(color => counts[color] === max);
 }
 
 
@@ -192,9 +202,10 @@ export function evaluateWinProximity(hand: Card[], state: GameState): number {
 }
 
 /**
- * Elect the lead bot from a list of ally bots with hysteresis.
- * The bot with the lowest player-array index keeps leadership
- * unless another bot's proximity score exceeds it by HYSTERESIS.
+ * Elect the lead bot from a list of ally bots. Earlier-seated bots keep
+ * leadership unless a later bot's proximity score beats theirs by more
+ * than HYSTERESIS — a deterministic rule so every bot independently
+ * elects the same lead without shared state.
  */
 export function electLeadBot(allyBots: Player[], state: GameState): Player {
   const HYSTERESIS = 3;
@@ -202,12 +213,29 @@ export function electLeadBot(allyBots: Player[], state: GameState): Player {
   let bestBot = allyBots[0]!;
   for (const ab of allyBots) {
     const prox = evaluateWinProximity(ab.hand, state);
-    if (prox > bestScore + HYSTERESIS || (prox > bestScore && state.players.indexOf(ab) < state.players.indexOf(bestBot))) {
+    if (prox > bestScore + HYSTERESIS) {
       bestScore = prox;
       bestBot = ab;
     }
   }
   return bestBot;
+}
+
+/**
+ * Penalty for playing a WD4 that is challengeable (bot still holds the
+ * current color). Uses only the bot's own hand — no cheating involved.
+ * Applies only to normal plays: stacked WD4s never open a challenge window.
+ */
+function scoreWildFourRisk(card: Card, hand: Card[], state: GameState, params: DifficultyParams): number {
+  if (!params.wildFourLegalityAwareness) return 0;
+  if (card.type !== 'wild_draw_four') return 0;
+  if (state.phase !== 'playing' || state.drawStack > 0) return 0;
+  if (state.settings.houseRules.noChallengeWildFour) return 0;
+  if (!state.currentColor) return 0;
+  const handAfterPlay = hand.filter(c => c.id !== card.id);
+  if (isValidWildDrawFour(handAfterPlay, state.currentColor)) return 0;
+  // A successful challenge costs the bot 4 draws plus the wasted WD4
+  return -20;
 }
 
 function scoreCardConservation(card: Card, hand: Card[], playable: Card[], params: DifficultyParams, state: GameState): number {
@@ -224,13 +252,22 @@ function scoreCardConservation(card: Card, hand: Card[], playable: Card[], param
   return penalty;
 }
 
-function turnsUntilPlayer(fromIndex: number, toIndex: number, playerCount: number, direction: GameState['direction']): number {
+/**
+ * Number of turns until `toIndex` gets to act, counting only alive seats
+ * (eliminated seats are skipped by the engine and cost no turn).
+ */
+function turnsUntilPlayer(players: readonly Player[], fromIndex: number, toIndex: number, direction: GameState['direction']): number {
   if (fromIndex === toIndex) return 0;
+  const count = players.length;
   const step = direction === 'clockwise' ? 1 : -1;
-  for (let t = 1; t < playerCount; t++) {
-    if (((fromIndex + step * t) % playerCount + playerCount) % playerCount === toIndex) return t;
+  let turns = 0;
+  let idx = fromIndex;
+  for (let s = 0; s < count; s++) {
+    idx = ((idx + step) % count + count) % count;
+    if (!players[idx]!.eliminated) turns++;
+    if (idx === toIndex) return turns;
   }
-  return playerCount;
+  return count;
 }
 
 function scoreGlobalThreat(card: Card, state: GameState, botId: string, params: DifficultyParams, ctx: EvalContext): number {
@@ -251,13 +288,13 @@ function scoreGlobalThreat(card: Card, state: GameState, botId: string, params: 
   const leadNearWin = leadBot && leadBot.id !== botId && leadBot.hand.length <= 2;
 
   for (const { player: threat, index: threatIndex } of threats) {
-    const dist = turnsUntilPlayer(botIndex, threatIndex, state.players.length, state.direction);
+    const dist = turnsUntilPlayer(state.players, botIndex, threatIndex, state.direction);
     const urgency = (4 - threat.hand.length) * Math.max(1, 3 - dist);
 
     // Shield bonus: threat is right before the lead bot → extra urgency to neutralize
     let shieldMultiplier = 1.0;
     if (params.botCoalition && leadNearWin && leadIndex >= 0) {
-      const threatToLead = turnsUntilPlayer(threatIndex, leadIndex, state.players.length, state.direction);
+      const threatToLead = turnsUntilPlayer(state.players, threatIndex, leadIndex, state.direction);
       if (threatToLead === 1) {
         shieldMultiplier = 2.0;
       } else if (threatToLead === 2) {
@@ -271,12 +308,12 @@ function scoreGlobalThreat(card: Card, state: GameState, botId: string, params: 
 
     if (card.type === 'reverse') {
       const reversedDir = reverseDirection(state.direction);
-      const newDist = turnsUntilPlayer(botIndex, threatIndex, state.players.length, reversedDir);
+      const newDist = turnsUntilPlayer(state.players, botIndex, threatIndex, reversedDir);
       let reverseDelta = (newDist - dist) * urgency * 0.6;
       // Reversing to push a threat away from the lead bot is extra valuable
       if (params.botCoalition && leadNearWin && leadIndex >= 0) {
-        const threatToLeadBefore = turnsUntilPlayer(threatIndex, leadIndex, state.players.length, state.direction);
-        const threatToLeadAfter = turnsUntilPlayer(threatIndex, leadIndex, state.players.length, reversedDir);
+        const threatToLeadBefore = turnsUntilPlayer(state.players, threatIndex, leadIndex, state.direction);
+        const threatToLeadAfter = turnsUntilPlayer(state.players, threatIndex, leadIndex, reversedDir);
         if (threatToLeadAfter > threatToLeadBefore) reverseDelta += urgency * 0.8;
       }
       score += reverseDelta;
@@ -302,7 +339,7 @@ function scoreSpecialTiming(card: Card, hand: Card[], state: GameState, botId: s
   if (card.type === 'number' && (card as { value: number }).value === 0 && hr.zeroRotateHands) {
     if (params.infoAccess.canSeeOpponentHands) {
       const botIdx = state.players.findIndex(p => p.id === botId);
-      const giverIndex = getNextPlayerIndex(botIdx, state.players.length, reverseDirection(state.direction));
+      const giverIndex = getNextAliveIndex(state.players, botIdx, reverseDirection(state.direction));
       const giver = state.players[giverIndex];
       if (giver && !giver.eliminated) {
         const delta = evaluateHandQuality(giver.hand, state) - evaluateHandQuality(hand, state);
@@ -316,7 +353,7 @@ function scoreSpecialTiming(card: Card, hand: Card[], state: GameState, botId: s
         for (let i = 0; i < state.players.length; i++) {
           const receiver = state.players[i]!;
           if (receiver.eliminated) continue;
-          const gvrIdx = getNextPlayerIndex(i, state.players.length, reverseDirection(dir));
+          const gvrIdx = getNextAliveIndex(state.players, i, reverseDirection(dir));
           const gvr = state.players[gvrIdx];
           if (!gvr || gvr.eliminated) continue;
           const qBefore = evaluateHandQuality(receiver.hand, state);
@@ -387,7 +424,7 @@ function scoreCoalitionTactics(card: Card, _hand: Card[], state: GameState, botI
       if (getPlayableCards(h.hand, card, card.color).length === 0) {
         humansBlocked++;
         const hIdx = state.players.findIndex(p => p.id === h.id);
-        const dist = turnsUntilPlayer(botIndex, hIdx, state.players.length, state.direction);
+        const dist = turnsUntilPlayer(state.players, botIndex, hIdx, state.direction);
         starvationScore += Math.max(1, 4 - dist) * 2;
       }
     }
@@ -471,7 +508,7 @@ function scoreCoalitionTactics(card: Card, _hand: Card[], state: GameState, botI
   // --- 4. Reverse to redirect draw stack toward humans ---
   if (card.type === 'reverse' && state.drawStack > 0) {
     const reversedDir = reverseDirection(state.direction);
-    const afterReverseIdx = getNextPlayerIndex(botIndex, state.players.length, reversedDir);
+    const afterReverseIdx = getNextAliveIndex(state.players, botIndex, reversedDir);
     const afterReversePlayer = state.players[afterReverseIdx];
     if (afterReversePlayer && !afterReversePlayer.eliminated) {
       if (!isAlly(afterReversePlayer)) score += 10;
@@ -481,9 +518,10 @@ function scoreCoalitionTactics(card: Card, _hand: Card[], state: GameState, botI
 
   // --- 5. Skip human → give ally the next turn (extra if it's the lead bot) ---
   if (card.type === 'skip' && nextPlayer && !nextPlayer.eliminated && !isAlly(nextPlayer)) {
-    const afterSkipIdx = getNextPlayerIndex(
+    const afterSkipIdx = getNextAliveIndex(
+      state.players,
       state.players.findIndex(p => p.id === nextPlayer.id),
-      state.players.length, state.direction);
+      state.direction);
     const afterSkipPlayer = state.players[afterSkipIdx];
     if (afterSkipPlayer && !afterSkipPlayer.eliminated && isAlly(afterSkipPlayer)) {
       score += (leadBot && afterSkipPlayer.id === leadBot.id) ? 10 : 5;
@@ -493,7 +531,7 @@ function scoreCoalitionTactics(card: Card, _hand: Card[], state: GameState, botI
   // --- 6. Reverse to position human as next player (extra if lead bot follows) ---
   if (card.type === 'reverse' && state.drawStack === 0) {
     const reversedDir = reverseDirection(state.direction);
-    const afterReverseIdx = getNextPlayerIndex(botIndex, state.players.length, reversedDir);
+    const afterReverseIdx = getNextAliveIndex(state.players, botIndex, reversedDir);
     const afterReversePlayer = state.players[afterReverseIdx];
     if (afterReversePlayer && !afterReversePlayer.eliminated && !isAlly(afterReversePlayer)) {
       if (nextPlayer && isAlly(nextPlayer)) {
@@ -592,7 +630,7 @@ export function evaluateCards(
   weights: PersonalityWeights,
 ): CardScore[] {
   const botIndex = state.players.findIndex(p => p.id === botId);
-  const nextIndex = getNextPlayerIndex(botIndex, state.players.length, state.direction);
+  const nextIndex = getNextAliveIndex(state.players, botIndex, state.direction);
   const nextPlayer = state.players[nextIndex];
   const bot = state.players[botIndex];
 
@@ -601,6 +639,7 @@ export function evaluateCards(
   const avgHandSize = alivePlayers.length > 0 ? alivePlayers.reduce((sum, p) => sum + p.hand.length, 0) / alivePlayers.length : 0;
 
   const isAlly = (player: Player): boolean => {
+    if (player.eliminated) return false;
     if (params.botCoalition && player.isBot) return true;
     if (params.considerTeamStrategy && state.settings.houseRules.teamMode
       && bot?.teamId !== undefined && player.teamId === bot.teamId) return true;
@@ -624,6 +663,7 @@ export function evaluateCards(
       cardConservation: scoreCardConservation(card, hand, playable, params, state),
       globalThreat: scoreGlobalThreat(card, state, botId, params, ctx),
       coalitionTactics: scoreCoalitionTactics(card, hand, state, botId, params, ctx),
+      wildFourRisk: scoreWildFourRisk(card, hand, state, params),
     };
 
     let score =
@@ -636,7 +676,8 @@ export function evaluateCards(
       factors.targetPressure * weights.targetPressure +
       factors.cardConservation * weights.cardConservation +
       factors.globalThreat * weights.globalThreat +
-      factors.coalitionTactics * weights.coalitionTactics;
+      factors.coalitionTactics * weights.coalitionTactics +
+      factors.wildFourRisk * weights.wildFourRisk;
 
     if (params.scoreNoise > 0) {
       score += (Math.random() * 2 - 1) * params.scoreNoise;

--- a/packages/shared/src/rules/bot/difficulty-params.ts
+++ b/packages/shared/src/rules/bot/difficulty-params.ts
@@ -22,6 +22,8 @@ export interface DifficultyParams {
   challengeRate: number;
   specialCardAwareness: number;
   finishRestrictionAwareness: boolean;
+  /** Knows that playing a WD4 while holding the current color is challengeable */
+  wildFourLegalityAwareness: boolean;
   conserveSpecialCards: boolean;
   globalThreatAwareness: boolean;
   botCoalition: boolean;
@@ -41,6 +43,7 @@ export const DIFFICULTY_PARAMS: Record<BotDifficulty, DifficultyParams> = {
     challengeRate: 0.0,
     specialCardAwareness: 0.0,
     finishRestrictionAwareness: false,
+    wildFourLegalityAwareness: false,
     conserveSpecialCards: false,
     globalThreatAwareness: false,
     botCoalition: false,
@@ -58,6 +61,7 @@ export const DIFFICULTY_PARAMS: Record<BotDifficulty, DifficultyParams> = {
     challengeRate: 0.1,
     specialCardAwareness: 0.2,
     finishRestrictionAwareness: false,
+    wildFourLegalityAwareness: false,
     conserveSpecialCards: false,
     globalThreatAwareness: false,
     botCoalition: false,
@@ -75,6 +79,7 @@ export const DIFFICULTY_PARAMS: Record<BotDifficulty, DifficultyParams> = {
     challengeRate: 0.3,
     specialCardAwareness: 0.6,
     finishRestrictionAwareness: true,
+    wildFourLegalityAwareness: true,
     conserveSpecialCards: true,
     globalThreatAwareness: true,
     botCoalition: true,
@@ -92,6 +97,7 @@ export const DIFFICULTY_PARAMS: Record<BotDifficulty, DifficultyParams> = {
     challengeRate: -1,
     specialCardAwareness: 1.0,
     finishRestrictionAwareness: true,
+    wildFourLegalityAwareness: true,
     conserveSpecialCards: true,
     globalThreatAwareness: true,
     botCoalition: true,

--- a/packages/shared/src/rules/bot/personality-weights.ts
+++ b/packages/shared/src/rules/bot/personality-weights.ts
@@ -12,6 +12,7 @@ export interface PersonalityWeights {
   cardConservation: number;
   globalThreat: number;
   coalitionTactics: number;
+  wildFourRisk: number;
 }
 
 export const PERSONALITY_WEIGHTS: Record<BotPersonality, PersonalityWeights> = {
@@ -26,6 +27,7 @@ export const PERSONALITY_WEIGHTS: Record<BotPersonality, PersonalityWeights> = {
     cardConservation: 0.4,
     globalThreat: 1.4,
     coalitionTactics: 1.2,
+    wildFourRisk: 0.9,
   },
   defensive: {
     colorMatch: 1.5,
@@ -38,6 +40,7 @@ export const PERSONALITY_WEIGHTS: Record<BotPersonality, PersonalityWeights> = {
     cardConservation: 1.6,
     globalThreat: 0.8,
     coalitionTactics: 0.8,
+    wildFourRisk: 1.2,
   },
   chaotic: {
     colorMatch: 0.8,
@@ -50,6 +53,7 @@ export const PERSONALITY_WEIGHTS: Record<BotPersonality, PersonalityWeights> = {
     cardConservation: 0.3,
     globalThreat: 0.6,
     coalitionTactics: 0.5,
+    wildFourRisk: 0.5,
   },
   strategic: {
     colorMatch: 1.0,
@@ -62,6 +66,7 @@ export const PERSONALITY_WEIGHTS: Record<BotPersonality, PersonalityWeights> = {
     cardConservation: 1.5,
     globalThreat: 1.3,
     coalitionTactics: 1.4,
+    wildFourRisk: 1.2,
   },
   balanced: {
     colorMatch: 1.0,
@@ -74,5 +79,6 @@ export const PERSONALITY_WEIGHTS: Record<BotPersonality, PersonalityWeights> = {
     cardConservation: 1.0,
     globalThreat: 1.0,
     coalitionTactics: 1.0,
+    wildFourRisk: 1.0,
   },
 };

--- a/packages/shared/src/rules/game-engine.ts
+++ b/packages/shared/src/rules/game-engine.ts
@@ -2,7 +2,7 @@ import type { GameState, GameAction, DrawSide } from '../types/game.js';
 import type { Color } from '../types/card.js';
 import { reshuffleSideFromDiscard } from './deck.js';
 import { canPlayCard, isValidWildDrawFour, canRespondToDrawStack as canRespondToDrawStackPure } from './validation.js';
-import { getNextPlayerIndex, reverseDirection } from './turn.js';
+import { getNextAliveIndex, countAlivePlayers, reverseDirection } from './turn.js';
 import { calculateRoundScores } from './scoring.js';
 import { UNO_PENALTY_CARDS } from '../constants/scoring.js';
 
@@ -291,8 +291,6 @@ function handlePlayCard(
     lastAction: action,
   };
 
-  const playerCount = state.players.length;
-
   // Apply card-specific effects
   switch (card.type) {
     case 'number': {
@@ -300,7 +298,7 @@ function handlePlayCard(
       newState = {
         ...newState,
         currentColor: newColor,
-        currentPlayerIndex: getNextPlayerIndex(actingPlayerIdx, playerCount, state.direction),
+        currentPlayerIndex: getNextAliveIndex(state.players, actingPlayerIdx, state.direction),
       };
       break;
     }
@@ -309,15 +307,15 @@ function handlePlayCard(
       newState = {
         ...newState,
         currentColor: card.color,
-        // Skip next player: advance by 2 (skip=1 means advance by 1+1=2)
-        currentPlayerIndex: getNextPlayerIndex(actingPlayerIdx, playerCount, state.direction, 1),
+        // Skip next player: advance past 2 alive players (skip=1 means 1+1=2)
+        currentPlayerIndex: getNextAliveIndex(state.players, actingPlayerIdx, state.direction, 1),
       };
       break;
     }
 
     case 'reverse': {
       const newDirection = reverseDirection(state.direction);
-      if (playerCount === 2) {
+      if (countAlivePlayers(state.players) === 2) {
         // In 2-player, reverse acts as skip: current player keeps the turn
         newState = {
           ...newState,
@@ -331,20 +329,20 @@ function handlePlayCard(
           ...newState,
           currentColor: card.color,
           direction: newDirection,
-          currentPlayerIndex: getNextPlayerIndex(actingPlayerIdx, playerCount, newDirection),
+          currentPlayerIndex: getNextAliveIndex(state.players, actingPlayerIdx, newDirection),
         };
       }
       break;
     }
 
     case 'draw_two': {
-      const nextIdx = getNextPlayerIndex(actingPlayerIdx, playerCount, state.direction);
+      const nextIdx = getNextAliveIndex(state.players, actingPlayerIdx, state.direction);
       const nextPlayerId = state.players[nextIdx]!.id;
       newState = startPenaltyDraw(
         { ...newState, currentColor: card.color },
         nextPlayerId,
         2,
-        getNextPlayerIndex(actingPlayerIdx, playerCount, state.direction, 1),
+        getNextAliveIndex(state.players, actingPlayerIdx, state.direction, 1),
         actingPlayer.id,
       );
       break;
@@ -361,7 +359,7 @@ function handlePlayCard(
     }
 
     case 'wild_draw_four': {
-      const nextIdx = getNextPlayerIndex(actingPlayerIdx, playerCount, state.direction);
+      const nextIdx = getNextAliveIndex(state.players, actingPlayerIdx, state.direction);
       const nextPlayerId = state.players[nextIdx]!.id;
       newState = {
         ...newState,
@@ -413,9 +411,9 @@ function handlePass(
     }
   }
 
-  const newIndex = getNextPlayerIndex(
+  const newIndex = getNextAliveIndex(
+    state.players,
     state.currentPlayerIndex,
-    state.players.length,
     state.direction,
   );
   return {
@@ -444,9 +442,9 @@ function handleChooseColor(
       lastAction: action,
     };
   } else {
-    const newIndex = getNextPlayerIndex(
+    const newIndex = getNextAliveIndex(
+      colorState.players,
       colorState.currentPlayerIndex,
-      colorState.players.length,
       colorState.direction,
     );
     return drainPenaltyQueue({
@@ -473,7 +471,7 @@ function handleChallenge(
   const wd4WasLegal = isValidWildDrawFour(wd4Player.hand, prevColor);
 
   if (wd4WasLegal) {
-    const nextIdx = getNextPlayerIndex(challengerIdx, state.players.length, state.direction);
+    const nextIdx = getNextAliveIndex(state.players, challengerIdx, state.direction);
     return startPenaltyDraw({
       ...state,
       phase: 'playing',
@@ -482,7 +480,7 @@ function handleChallenge(
     }, action.playerId, 6, nextIdx, state.lastAction?.type === 'CHOOSE_COLOR' ? wd4Player.id : null);
   }
 
-  const nextIdx = getNextPlayerIndex(wd4PlayerIdx, state.players.length, state.direction);
+  const nextIdx = getNextAliveIndex(state.players, wd4PlayerIdx, state.direction);
   return startPenaltyDraw({
     ...state,
     phase: 'playing',
@@ -499,7 +497,7 @@ function handleAccept(
 
   const wd4PlayerId = currentPlayerId(state);
   const accepterIdx = playerIndex(state, action.playerId);
-  const nextIdx = getNextPlayerIndex(accepterIdx, state.players.length, state.direction);
+  const nextIdx = getNextAliveIndex(state.players, accepterIdx, state.direction);
   return startPenaltyDraw({
     ...state,
     phase: 'playing',

--- a/packages/shared/src/rules/house-rule-helpers.ts
+++ b/packages/shared/src/rules/house-rule-helpers.ts
@@ -3,7 +3,7 @@ import type { Card } from '../types/card.js';
 import type { Color } from '../types/card.js';
 import { isWildCard } from '../types/card.js';
 import { canPlayCard } from './validation.js';
-import { getNextPlayerIndex } from './turn.js';
+import { getNextPlayerIndex, getNextAliveIndex, countAlivePlayers, rotateHands } from './turn.js';
 import { applyAction, checkRoundEnd, startPenaltyDraw, drawCards } from './game-engine.js';
 import type { RuleContext } from './house-rule-types.js';
 
@@ -72,7 +72,7 @@ export function putAttackCardOnStack(
   const players = state.players.map((p, i) =>
     i === state.currentPlayerIndex ? { ...p, hand: newHand, calledUno: newHand.length === 1 ? p.calledUno : false, unoCaught: false } : p,
   );
-  const nextIdx = getNextPlayerIndex(state.currentPlayerIndex, players.length, state.direction);
+  const nextIdx = getNextAliveIndex(players, state.currentPlayerIndex, state.direction);
   const newColor = card.type === 'draw_two' ? card.color : (action.chosenColor ?? state.currentColor);
 
   return checkRoundEnd({
@@ -144,5 +144,8 @@ export function buildRuleContext(): RuleContext {
     applyDoubleScore,
     canPlayCard,
     getNextPlayerIndex,
+    getNextAliveIndex,
+    countAlivePlayers,
+    rotateHands,
   };
 }

--- a/packages/shared/src/rules/house-rule-types.ts
+++ b/packages/shared/src/rules/house-rule-types.ts
@@ -40,6 +40,9 @@ export interface RuleContext {
   applyDoubleScore: (before: GameState, after: GameState) => GameState;
   canPlayCard: (card: Card, topCard: Card, currentColor: Color) => boolean;
   getNextPlayerIndex: (current: number, total: number, direction: Direction, skip?: number) => number;
+  getNextAliveIndex: (players: readonly { eliminated?: boolean }[], current: number, direction: Direction, skip?: number) => number;
+  countAlivePlayers: (players: readonly { eliminated?: boolean }[]) => number;
+  rotateHands: <P extends { eliminated?: boolean; hand: unknown[] }>(players: readonly P[], direction: Direction) => P[];
 }
 
 export interface HouseRulePlugin {

--- a/packages/shared/src/rules/index.ts
+++ b/packages/shared/src/rules/index.ts
@@ -1,7 +1,7 @@
 export { createDeck, shuffleDeck, reshuffleDiscardIntoDeck, reshuffleSideFromDiscard, serializeDeck, serializeDecks, cardToIdentity } from './deck.js';
 export type { CardIdentity } from './deck.js';
 export { canPlayCard, getPlayableCards, isValidWildDrawFour, canRespondToDrawStack, isExactJumpInMatch } from './validation.js';
-export { getNextPlayerIndex, reverseDirection } from './turn.js';
+export { getNextPlayerIndex, getNextAliveIndex, countAlivePlayers, rotateHands, reverseDirection } from './turn.js';
 export { dealCards, handleFirstDiscard, initializeGame, initializeNextRound } from './setup.js';
 export type { DealResult, FirstCardEffect, FirstDiscardResult } from './setup.js';
 export { calculateRoundScore, calculateRoundScores } from './scoring.js';

--- a/packages/shared/src/rules/rules/deflection.ts
+++ b/packages/shared/src/rules/rules/deflection.ts
@@ -32,7 +32,7 @@ export const deflection: HouseRulePlugin = {
         );
         const wd4PlayerIdx = state.currentPlayerIndex;
         const wd4PlayerId = state.players[wd4PlayerIdx]!.id;
-        const afterPenaltyNextIdx = ctx.getNextPlayerIndex(wd4PlayerIdx, players.length, newDirection);
+        const afterPenaltyNextIdx = ctx.getNextAliveIndex(players, wd4PlayerIdx, newDirection);
         const baseState = checkRoundEnd({
           ...state,
           players,
@@ -54,9 +54,9 @@ export const deflection: HouseRulePlugin = {
         const players = state.players.map((p, i) =>
           i === playerIdx ? { ...p, hand: newHand } : p,
         );
-        const nextIdx = ctx.getNextPlayerIndex(playerIdx, players.length, state.direction);
+        const nextIdx = ctx.getNextAliveIndex(players, playerIdx, state.direction);
         const nextPlayerId = state.players[nextIdx]!.id;
-        const afterPenaltyNextIdx = ctx.getNextPlayerIndex(nextIdx, players.length, state.direction);
+        const afterPenaltyNextIdx = ctx.getNextAliveIndex(players, nextIdx, state.direction);
         const baseState = checkRoundEnd({
           ...state,
           players,
@@ -92,7 +92,7 @@ export const deflection: HouseRulePlugin = {
       const players = state.players.map((p, i) =>
         i === state.currentPlayerIndex ? { ...p, hand: newHand } : p,
       );
-      const nextIdx = ctx.getNextPlayerIndex(state.currentPlayerIndex, players.length, newDirection);
+      const nextIdx = ctx.getNextAliveIndex(players, state.currentPlayerIndex, newDirection);
       return {
         handled: true,
         state: checkRoundEnd({
@@ -112,7 +112,7 @@ export const deflection: HouseRulePlugin = {
       const players = state.players.map((p, i) =>
         i === state.currentPlayerIndex ? { ...p, hand: newHand } : p,
       );
-      const nextIdx = ctx.getNextPlayerIndex(state.currentPlayerIndex, players.length, state.direction);
+      const nextIdx = ctx.getNextAliveIndex(players, state.currentPlayerIndex, state.direction);
       return {
         handled: true,
         state: checkRoundEnd({

--- a/packages/shared/src/rules/rules/jump-in.ts
+++ b/packages/shared/src/rules/rules/jump-in.ts
@@ -32,7 +32,7 @@ export const jumpIn: HouseRulePlugin = {
       const players = state.players.map((p, i) =>
         i === jumperIdx ? { ...p, hand: newHand } : p,
       );
-      const nextIdx = ctx.getNextPlayerIndex(jumperIdx, players.length, state.direction);
+      const nextIdx = ctx.getNextAliveIndex(players, jumperIdx, state.direction);
       const baseState: GameState = {
         ...state,
         players,
@@ -48,16 +48,16 @@ export const jumpIn: HouseRulePlugin = {
             state: ctx.checkRoundEnd({
               ...baseState,
               currentColor: card.color,
-              currentPlayerIndex: ctx.getNextPlayerIndex(jumperIdx, players.length, state.direction, 1),
+              currentPlayerIndex: ctx.getNextAliveIndex(players, jumperIdx, state.direction, 1),
             }, action.playerId),
           };
         }
 
         case 'reverse': {
           const newDirection = reverseDirection(state.direction);
-          const newIdx = players.length === 2
+          const newIdx = ctx.countAlivePlayers(players) === 2
             ? jumperIdx
-            : ctx.getNextPlayerIndex(jumperIdx, players.length, newDirection);
+            : ctx.getNextAliveIndex(players, jumperIdx, newDirection);
           return {
             handled: true,
             state: ctx.checkRoundEnd({
@@ -72,7 +72,7 @@ export const jumpIn: HouseRulePlugin = {
         case 'draw_two': {
           const drawTarget = players[nextIdx]?.id;
           if (!drawTarget) break;
-          const skipNext = ctx.getNextPlayerIndex(jumperIdx, players.length, state.direction, 1);
+          const skipNext = ctx.getNextAliveIndex(players, jumperIdx, state.direction, 1);
           let penaltyState = ctx.startPenaltyDraw(
             { ...baseState, currentColor: card.color },
             drawTarget, 2, skipNext, action.playerId,
@@ -150,13 +150,7 @@ export const jumpIn: HouseRulePlugin = {
             };
           }
           if (hr.zeroRotateHands && card.value === 0) {
-            const hands = players.map(p => [...p.hand]);
-            const rotatedPlayers = players.map((p, i) => {
-              const sourceIdx = state.direction === 'clockwise'
-                ? (i - 1 + players.length) % players.length
-                : (i + 1) % players.length;
-              return { ...p, hand: hands[sourceIdx]! };
-            });
+            const rotatedPlayers = ctx.rotateHands(players, state.direction);
             return {
               handled: true,
               state: ctx.checkRoundEnd({

--- a/packages/shared/src/rules/rules/multi-play.ts
+++ b/packages/shared/src/rules/rules/multi-play.ts
@@ -19,7 +19,7 @@ export const multiPlayPass: HouseRulePlugin = {
     const topCard = state.discardPile[state.discardPile.length - 1];
     if (topCard?.type !== 'number') return { handled: false };
 
-    const nextIdx = ctx.getNextPlayerIndex(state.currentPlayerIndex, state.players.length, state.direction);
+    const nextIdx = ctx.getNextAliveIndex(state.players, state.currentPlayerIndex, state.direction);
     let result: GameState = { ...state, currentPlayerIndex: nextIdx, lastAction: action };
 
     if (hr.bombCard) {
@@ -32,7 +32,7 @@ export const multiPlayPass: HouseRulePlugin = {
       }
       if (bombCount >= 3) {
         for (const p of result.players) {
-          if (p.id !== player.id) {
+          if (p.id !== player.id && !p.eliminated) {
             result = ctx.startPenaltyDraw(result, p.id, 1, nextIdx);
           }
         }

--- a/packages/shared/src/rules/rules/no-challenge-wild-four.ts
+++ b/packages/shared/src/rules/rules/no-challenge-wild-four.ts
@@ -28,9 +28,9 @@ export const noChallengeWildFour: HouseRulePlugin = {
       const penaltyPlayerIndex = afterColor.players.findIndex(p => p.id === penaltyPlayerId);
       if (penaltyPlayerIndex === -1) return { handled: true, state: afterColor };
 
-      const nextPlayerIndex = ctx.getNextPlayerIndex(
+      const nextPlayerIndex = ctx.getNextAliveIndex(
+        afterColor.players,
         penaltyPlayerIndex,
-        afterColor.players.length,
         afterColor.direction,
       );
 

--- a/packages/shared/src/rules/rules/revenge-mode.ts
+++ b/packages/shared/src/rules/rules/revenge-mode.ts
@@ -19,7 +19,7 @@ export const revengeMode: HouseRulePlugin = {
     if (!prevTopCard || (prevTopCard.type !== 'draw_two' && prevTopCard.type !== 'wild_draw_four')) return after;
 
     if (playedCard.type === 'draw_two') {
-      const victimIdx = ctx.getNextPlayerIndex(before.currentPlayerIndex, before.players.length, before.direction);
+      const victimIdx = ctx.getNextAliveIndex(before.players, before.currentPlayerIndex, before.direction);
       const victimId = before.players[victimIdx]!.id;
       return ctx.startPenaltyDraw(after, victimId, 2, after.pendingPenaltyNextPlayerIndex ?? after.currentPlayerIndex);
     } else {

--- a/packages/shared/src/rules/rules/seven-swap.ts
+++ b/packages/shared/src/rules/rules/seven-swap.ts
@@ -35,6 +35,7 @@ export const sevenSwapTarget: HouseRulePlugin = {
     if (!currentPlayer || currentPlayer.id !== action.playerId) return { handled: true, state };
     const targetIdx = state.players.findIndex(p => p.id === action.targetId);
     if (targetIdx === -1 || targetIdx === state.currentPlayerIndex) return { handled: true, state };
+    if (state.players[targetIdx]!.eliminated) return { handled: true, state };
     const currentHand = [...state.players[state.currentPlayerIndex]!.hand];
     const targetHand = [...state.players[targetIdx]!.hand];
     const players = state.players.map((p, i) => {
@@ -42,7 +43,7 @@ export const sevenSwapTarget: HouseRulePlugin = {
       if (i === targetIdx) return { ...p, hand: currentHand, calledUno: currentHand.length === 1, unoCaught: false };
       return p;
     });
-    const nextIdx = ctx.getNextPlayerIndex(state.currentPlayerIndex, players.length, state.direction);
+    const nextIdx = ctx.getNextAliveIndex(players, state.currentPlayerIndex, state.direction);
     return { handled: true, state: { ...state, players, phase: 'playing', currentPlayerIndex: nextIdx, lastAction: action } };
   },
 };

--- a/packages/shared/src/rules/rules/stacking.ts
+++ b/packages/shared/src/rules/rules/stacking.ts
@@ -93,7 +93,7 @@ export const stacking: HouseRulePlugin = {
       if ((state.pendingPenaltyDraws ?? 0) > 0) return { handled: false };
       const player = state.players[state.currentPlayerIndex];
       if (!player || player.id !== action.playerId) return { handled: true, state };
-      const nextIdx = ctx.getNextPlayerIndex(state.currentPlayerIndex, state.players.length, state.direction);
+      const nextIdx = ctx.getNextAliveIndex(state.players, state.currentPlayerIndex, state.direction);
       const pendingState = ctx.startPenaltyDraw(
         { ...state, drawStack: 0, lastAction: action },
         action.playerId,

--- a/packages/shared/src/rules/rules/zero-rotate.ts
+++ b/packages/shared/src/rules/rules/zero-rotate.ts
@@ -10,19 +10,12 @@ export const zeroRotate: HouseRulePlugin = {
     description: '打出 0 时所有人按方向传递手牌',
   },
   isEnabled: (hr) => hr.zeroRotateHands,
-  postProcess: (before: GameState, after: GameState, action: GameAction, _ctx: RuleContext): GameState => {
+  postProcess: (before: GameState, after: GameState, action: GameAction, ctx: RuleContext): GameState => {
     if (action.type !== 'PLAY_CARD') return after;
     if (after === before) return after;
     const playedCard = before.players[before.currentPlayerIndex]?.hand.find(c => c.id === action.cardId);
     if (playedCard?.type !== 'number' || playedCard.value !== 0) return after;
 
-    const hands = after.players.map(p => [...p.hand]);
-    const rotated = after.players.map((p, i) => {
-      const sourceIdx = after.direction === 'clockwise'
-        ? (i - 1 + after.players.length) % after.players.length
-        : (i + 1) % after.players.length;
-      return { ...p, hand: hands[sourceIdx]! };
-    });
-    return { ...after, players: rotated };
+    return { ...after, players: ctx.rotateHands(after.players, after.direction) };
   },
 };

--- a/packages/shared/src/rules/setup.ts
+++ b/packages/shared/src/rules/setup.ts
@@ -5,7 +5,7 @@ import type { UserRole } from '../types/role.js';
 import type { BotConfig } from '../types/bot.js';
 import { isColoredCard } from '../types/card.js';
 import { createDeck, shuffleDeck } from './deck.js';
-import { getNextPlayerIndex, reverseDirection } from './turn.js';
+import { getNextAliveIndex, reverseDirection } from './turn.js';
 import { INITIAL_HAND_SIZE } from '../constants/deck.js';
 import { DEFAULT_TARGET_SCORE, DEFAULT_TURN_TIME_LIMIT } from '../constants/scoring.js';
 import { DEFAULT_HOUSE_RULES } from '../types/house-rules.js';
@@ -103,7 +103,7 @@ function applyFirstDiscardEffect(
 
   switch (effect.type) {
     case 'skip':
-      currentPlayerIndex = getNextPlayerIndex(currentPlayerIndex, players.length, direction);
+      currentPlayerIndex = getNextAliveIndex(players, currentPlayerIndex, direction);
       break;
     case 'reverse':
       direction = reverseDirection(direction);
@@ -114,7 +114,7 @@ function applyFirstDiscardEffect(
         const drawn = deckAfterDiscard.splice(0, 2);
         targetPlayer.hand.push(...drawn);
       }
-      currentPlayerIndex = getNextPlayerIndex(currentPlayerIndex, players.length, direction);
+      currentPlayerIndex = getNextAliveIndex(players, currentPlayerIndex, direction);
       break;
     }
     case 'choose_color':
@@ -207,7 +207,10 @@ export function initializeNextRound(prevState: GameState): GameState {
   }
 
   const currentColor: Color | null = isColoredCard(topCard) ? topCard.color : null;
-  const startIdx = players.length > 0 ? prevState.currentPlayerIndex % players.length : 0;
+  let startIdx = players.length > 0 ? prevState.currentPlayerIndex % players.length : 0;
+  if (players[startIdx]?.eliminated) {
+    startIdx = getNextAliveIndex(players, startIdx, 'clockwise');
+  }
   const applied = applyFirstDiscardEffect(effect, players, startIdx, 'clockwise', deckAfterDiscard);
 
   return {

--- a/packages/shared/src/rules/turn.ts
+++ b/packages/shared/src/rules/turn.ts
@@ -14,3 +14,55 @@ export function getNextPlayerIndex(
 export function reverseDirection(direction: Direction): Direction {
   return direction === 'clockwise' ? 'counter_clockwise' : 'clockwise';
 }
+
+interface Seat {
+  eliminated?: boolean;
+}
+
+/**
+ * Next non-eliminated seat in turn order. `skip` counts alive players to
+ * skip over (skip=1 → the seat after the next alive player), mirroring
+ * getNextPlayerIndex semantics. Identical to getNextPlayerIndex when no
+ * seat is eliminated; falls back to it if no alive seat exists.
+ */
+export function getNextAliveIndex(
+  players: readonly Seat[],
+  currentIndex: number,
+  direction: Direction,
+  skip: number = 0,
+): number {
+  const count = players.length;
+  if (count === 0) return currentIndex;
+  const step = direction === 'clockwise' ? 1 : -1;
+  let remaining = 1 + skip;
+  let idx = currentIndex;
+  const maxSteps = count * (1 + skip) + count;
+  for (let i = 0; i < maxSteps; i++) {
+    idx = ((idx + step) % count + count) % count;
+    if (!players[idx]!.eliminated) {
+      remaining--;
+      if (remaining === 0) return idx;
+    }
+  }
+  return getNextPlayerIndex(currentIndex, count, direction, skip);
+}
+
+export function countAlivePlayers(players: readonly Seat[]): number {
+  return players.reduce((n, p) => n + (p.eliminated ? 0 : 1), 0);
+}
+
+/**
+ * Rotate hands one seat along the play direction, passing only between
+ * alive players. Eliminated seats keep their (empty) hands.
+ */
+export function rotateHands<P extends Seat & { hand: unknown[] }>(
+  players: readonly P[],
+  direction: Direction,
+): P[] {
+  const hands = players.map(p => [...p.hand]);
+  return players.map((p, i) => {
+    if (p.eliminated) return { ...p };
+    const sourceIdx = getNextAliveIndex(players, i, reverseDirection(direction));
+    return { ...p, hand: hands[sourceIdx]! };
+  });
+}

--- a/packages/shared/tests/bot/bot-improvements.test.ts
+++ b/packages/shared/tests/bot/bot-improvements.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from 'vitest';
+import type { Card, Color } from '../../src/types/card';
+import type { GameState, Player } from '../../src/types/game';
+import type { BotConfig } from '../../src/types/bot';
+import { DEFAULT_HOUSE_RULES } from '../../src/types/house-rules';
+import { chooseBotAction } from '../../src/rules/bot/bot-strategy';
+import { bestColorsForHand } from '../../src/rules/bot/card-evaluator';
+import { makeState, makeCard } from '../helpers/test-utils';
+
+function n(id: string, color: Color, value: number): Card {
+  return { id, type: 'number', color, value };
+}
+
+function makePlayer(id: string, hand: Card[], botConfig?: BotConfig, extra: Partial<Player> = {}): Player {
+  return {
+    id,
+    name: id,
+    hand,
+    score: 0,
+    connected: true,
+    autopilot: false,
+    calledUno: false,
+    isBot: botConfig !== undefined,
+    botConfig,
+    ...extra,
+  };
+}
+
+const hardBot: BotConfig = { difficulty: 'hard', personality: 'balanced' };
+const normalBot: BotConfig = { difficulty: 'normal', personality: 'balanced' };
+
+describe('WD4 legality self-check', () => {
+  it('normal bot avoids a challengeable WD4 when a safe alternative exists', () => {
+    // Bot holds a red card while red is the current color → WD4 would be invalid.
+    const wd4 = makeCard('wild_draw_four', null, { id: 'wd4' });
+    const botHand = [wd4, n('r3', 'red', 3), n('g9', 'green', 9)];
+    const state = makeState({
+      players: [
+        makePlayer('bot', botHand, normalBot),
+        makePlayer('h1', [n('x1', 'blue', 1), n('x2', 'blue', 2), n('x3', 'green', 5)]),
+      ],
+      discardPile: [n('top', 'red', 7)],
+      currentColor: 'red',
+      currentPlayerIndex: 0,
+    });
+
+    // Normal bots have small score noise/mistake rates — sample repeatedly
+    let wd4Plays = 0;
+    for (let i = 0; i < 60; i++) {
+      const actions = chooseBotAction(state, 'bot');
+      if (actions[0]?.type === 'PLAY_CARD' && actions[0].cardId === 'wd4') wd4Plays++;
+    }
+    // Without the self-check the WD4 (actionValue 10) wins most of the time;
+    // with the -20 risk penalty it should be rare (noise-only).
+    expect(wd4Plays).toBeLessThan(10);
+  });
+
+  it('hard bot plays WD4 freely when it holds no card of the current color', () => {
+    const wd4 = makeCard('wild_draw_four', null, { id: 'wd4' });
+    // No red in hand and no playable colored card → WD4 is legal AND the only playable card
+    const botHand = [wd4, n('g9', 'green', 9)];
+    const state = makeState({
+      players: [
+        makePlayer('bot', botHand, hardBot),
+        makePlayer('h1', [n('x1', 'blue', 1), n('x2', 'blue', 2), n('x3', 'green', 5)]),
+      ],
+      discardPile: [n('top', 'red', 7)],
+      currentColor: 'red',
+      currentPlayerIndex: 0,
+    });
+    const actions = chooseBotAction(state, 'bot');
+    expect(actions[0]).toMatchObject({ type: 'PLAY_CARD', cardId: 'wd4' });
+  });
+});
+
+describe('endgame solver ranks winning starts with the evaluator', () => {
+  it('prefers the draw_two line over the gamble line in a 2-player endgame', () => {
+    // Hand: [red5, red draw_two]. Both start a "winning" sequence on paper,
+    // but draw_two first is strictly better (opponent draws 2 and is skipped,
+    // guaranteeing the follow-up red5 win in 2-player).
+    const red5 = n('r5', 'red', 5);
+    const redD2 = makeCard('draw_two', 'red', { id: 'rd2' });
+    const state = makeState({
+      players: [
+        makePlayer('bot', [red5, redD2], hardBot),
+        makePlayer('h1', [n('x1', 'blue', 1), n('x2', 'green', 2)]),
+      ],
+      discardPile: [n('top', 'red', 7)],
+      currentColor: 'red',
+      currentPlayerIndex: 0,
+    });
+    const actions = chooseBotAction(state, 'bot');
+    expect(actions[0]).toMatchObject({ type: 'PLAY_CARD', cardId: 'rd2' });
+  });
+
+  it('still finds the only winning start', () => {
+    // Hand: [red5, blue skip]. Only red5 → blue? no. red5 leaves blue skip
+    // unplayable; blue skip is unplayable now. Only red5 is playable at all.
+    const state = makeState({
+      players: [
+        makePlayer('bot', [n('r5', 'red', 5), makeCard('skip', 'blue', { id: 'bsk' })], hardBot),
+        makePlayer('h1', [n('x1', 'blue', 1)]),
+      ],
+      discardPile: [n('top', 'red', 7)],
+      currentColor: 'red',
+      currentPlayerIndex: 0,
+    });
+    const actions = chooseBotAction(state, 'bot');
+    expect(actions[0]!.type).toBe('PLAY_CARD');
+  });
+});
+
+describe('multi-play chain ordering', () => {
+  it('ends the chain on the color the bot holds most of', () => {
+    // Hand: three 5s (red, blue, green) + two extra yellow… no — extras are
+    // blue so blue is the dominant remaining color; chain must end on blue-5? No:
+    // blue-5 is chained too. Remaining after chain: two blue cards → the LAST
+    // chained 5 should be the one whose color matches remaining (blue).
+    const r5 = n('r5', 'red', 5);
+    const b5 = n('b5', 'blue', 5);
+    const g5 = n('g5', 'green', 5);
+    const b1 = n('b1', 'blue', 1);
+    const b2 = n('b2', 'blue', 2);
+    const state = makeState({
+      players: [
+        makePlayer('bot', [r5, b5, g5, b1, b2], hardBot),
+        makePlayer('h1', [n('x1', 'yellow', 9), n('x2', 'yellow', 8), n('x3', 'green', 7)]),
+      ],
+      discardPile: [n('top', 'red', 7)],
+      currentColor: 'red',
+      currentPlayerIndex: 0,
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        allowSpectators: true,
+        spectatorMode: 'hidden',
+        houseRules: { ...DEFAULT_HOUSE_RULES, multiplePlaySameNumber: true },
+      },
+    });
+
+    const actions = chooseBotAction(state, 'bot');
+    const plays = actions.filter(a => a.type === 'PLAY_CARD');
+    // Hard bot (specialCardAwareness=1) chains all three 5s
+    expect(plays.length).toBe(3);
+    const lastPlay = plays[plays.length - 1] as { cardId: string };
+    // Last chained card must be the blue 5 (bot's remaining hand is blue-heavy).
+    // The first play is the evaluator's pick; regardless of which 5 starts,
+    // blue must come last among the chained cards.
+    expect(lastPlay.cardId).toBe('b5');
+  });
+});
+
+describe('bestColorsForHand', () => {
+  it('returns all tied colors', () => {
+    const hand = [n('r1', 'red', 1), n('b1', 'blue', 1)];
+    expect(new Set(bestColorsForHand(hand))).toEqual(new Set(['red', 'blue']));
+  });
+
+  it('returns the single dominant color when there is one', () => {
+    const hand = [n('r1', 'red', 1), n('r2', 'red', 2), n('b1', 'blue', 1)];
+    expect(bestColorsForHand(hand)).toEqual(['red']);
+  });
+});
+
+describe('elimination-aware targeting', () => {
+  it('hard bot draw_two pressure targets the alive next player', () => {
+    // Seat order: bot, eliminated seat, human with 1 card (the real next player).
+    // globalThreat should still see the human as dist=1 and favor draw_two.
+    const d2 = makeCard('draw_two', 'red', { id: 'rd2' });
+    const state = makeState({
+      players: [
+        makePlayer('bot', [d2, n('g9', 'green', 9), n('g8', 'green', 8), n('g7', 'green', 3), n('b9', 'blue', 9)], hardBot),
+        makePlayer('gone', [], undefined, { eliminated: true }),
+        makePlayer('h1', [n('x1', 'red', 1)]),
+        makePlayer('h2', [n('y1', 'blue', 1), n('y2', 'blue', 2), n('y3', 'green', 5), n('y4', 'yellow', 6)]),
+      ],
+      discardPile: [n('top', 'red', 7)],
+      currentColor: 'red',
+      currentPlayerIndex: 0,
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        allowSpectators: true,
+        spectatorMode: 'hidden',
+        houseRules: { ...DEFAULT_HOUSE_RULES, elimination: true },
+      },
+    });
+    const actions = chooseBotAction(state, 'bot');
+    // The one-card human right after the zombie seat must be hit with the +2
+    expect(actions[0]).toMatchObject({ type: 'PLAY_CARD', cardId: 'rd2' });
+  });
+});

--- a/packages/shared/tests/bot/bot-simulation.test.ts
+++ b/packages/shared/tests/bot/bot-simulation.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import type { GameState } from '../../src/types/game';
+import type { HouseRules } from '../../src/types/house-rules';
+import type { BotConfig } from '../../src/types/bot';
+import { DEFAULT_HOUSE_RULES } from '../../src/types/house-rules';
+import { initializeGame, initializeNextRound } from '../../src/rules/setup';
+import { applyActionWithHouseRules } from '../../src/rules/house-rules-engine';
+import { chooseBotAction } from '../../src/rules/bot/bot-strategy';
+
+/**
+ * Full-game smoke test: four bots play unattended from deal to game_over.
+ * Catches livelocks, crashes, and rules/bot interactions that stall a game.
+ */
+
+const BOTS: { id: string; config: BotConfig }[] = [
+  { id: 'b1', config: { difficulty: 'novice', personality: 'chaotic' } },
+  { id: 'b2', config: { difficulty: 'easy', personality: 'defensive' } },
+  { id: 'b3', config: { difficulty: 'normal', personality: 'aggressive' } },
+  { id: 'b4', config: { difficulty: 'hard', personality: 'strategic' } },
+];
+
+function fingerprint(s: GameState): string {
+  const handTotal = s.players.reduce((n, p) => n + p.hand.length, 0);
+  return [
+    s.phase, s.currentPlayerIndex, s.currentColor, s.direction,
+    handTotal, s.discardPile.length, s.drawStack,
+    s.pendingPenaltyDraws ?? 0, s.pendingDrawPlayerId ?? '',
+    s.lastAction?.type ?? '',
+  ].join('|');
+}
+
+function simulateGame(houseRules: HouseRules, maxTurns = 8000): { state: GameState; turns: number } {
+  let state = initializeGame(
+    BOTS.map(b => ({ id: b.id, name: b.id, isBot: true, botConfig: b.config })),
+    houseRules,
+  );
+  state = { ...state, settings: { ...state.settings, targetScore: 100 } };
+
+  let stuck = 0;
+  for (let turn = 0; turn < maxTurns; turn++) {
+    if (state.phase === 'game_over') return { state, turns: turn };
+    if (state.phase === 'round_end') {
+      state = initializeNextRound(state);
+      continue;
+    }
+
+    const actorId = state.phase === 'challenging'
+      ? state.pendingDrawPlayerId
+      : state.players[state.currentPlayerIndex]?.id;
+    expect(actorId, `no actor in phase ${state.phase}`).toBeTruthy();
+    const actor = state.players.find(p => p.id === actorId)!;
+    expect(actor.eliminated, `eliminated player ${actorId} got a turn (phase ${state.phase})`).not.toBe(true);
+
+    const actions = chooseBotAction(state, actorId!);
+    expect(actions.length, `bot ${actorId} returned no actions in phase ${state.phase}`).toBeGreaterThan(0);
+
+    const before = fingerprint(state);
+    for (const action of actions) {
+      state = applyActionWithHouseRules(state, action);
+    }
+    if (fingerprint(state) === before) {
+      stuck++;
+      expect(stuck, `game stalled: bot ${actorId} actions had no effect in phase ${state.phase}`).toBeLessThan(4);
+    } else {
+      stuck = 0;
+    }
+  }
+  throw new Error(`game did not finish within ${maxTurns} turns (phase ${state.phase})`);
+}
+
+const RULESETS: { name: string; hr: HouseRules }[] = [
+  { name: 'classic', hr: { ...DEFAULT_HOUSE_RULES } },
+  {
+    name: 'party',
+    hr: {
+      ...DEFAULT_HOUSE_RULES,
+      stackDrawTwo: true, stackDrawFour: true, zeroRotateHands: true,
+      sevenSwapHands: true, jumpIn: true, drawUntilPlayable: true,
+    },
+  },
+  {
+    name: 'attack-heavy',
+    hr: {
+      ...DEFAULT_HOUSE_RULES,
+      stackDrawTwo: true, stackDrawFour: true, crossStack: true,
+      reverseDeflectDrawTwo: true, reverseDeflectDrawFour: true, skipDeflect: true,
+      revengeMode: true, noChallengeWildFour: true,
+    },
+  },
+  {
+    name: 'elimination-multiplay',
+    hr: {
+      ...DEFAULT_HOUSE_RULES,
+      elimination: true, multiplePlaySameNumber: true, bombCard: true,
+      noWildFinish: true, noFunctionCardFinish: true,
+      sevenSwapHands: true, zeroRotateHands: true,
+    },
+  },
+  {
+    name: 'team-limits',
+    hr: {
+      ...DEFAULT_HOUSE_RULES,
+      teamMode: true, handLimit: 15, forcedPlay: true, forcedPlayAfterDraw: true,
+      strictUnoCall: true, wildFirstTurn: true,
+    },
+  },
+];
+
+describe('bot full-game simulation', () => {
+  for (const { name, hr } of RULESETS) {
+    it(`4 bots finish a full game under "${name}" rules`, () => {
+      for (let run = 0; run < 3; run++) {
+        const { state } = simulateGame(hr);
+        expect(state.phase).toBe('game_over');
+        expect(state.winnerId).toBeTruthy();
+      }
+    });
+  }
+});

--- a/packages/shared/tests/bot/bot-strategy.test.ts
+++ b/packages/shared/tests/bot/bot-strategy.test.ts
@@ -134,7 +134,9 @@ describe('chooseBotAction — challenging phase', () => {
 
     const state = makeState({
       phase: 'challenging',
-      currentPlayerIndex: 1, // bot's turn in the challenging phase
+      // Engine convention: during challenging, currentPlayerIndex stays on
+      // the WD4 player (p2); the challenger is pendingDrawPlayerId.
+      currentPlayerIndex: 0,
       pendingDrawPlayerId: 'bot',
       players: [
         makePlayer('p2', 'Human', prevPlayerHand), // previous player who played WD4

--- a/packages/shared/tests/turn-alive.test.ts
+++ b/packages/shared/tests/turn-alive.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect } from 'vitest';
+import { getNextPlayerIndex, getNextAliveIndex, countAlivePlayers, rotateHands } from '../src/rules/turn';
+import { applyActionWithHouseRules } from '../src/rules/house-rules-engine';
+import { initializeGame, initializeNextRound } from '../src/rules/setup';
+import { DEFAULT_HOUSE_RULES } from '../src/types/house-rules';
+import { makeState, makeCard } from './helpers/test-utils';
+import type { Card } from '../src/types/card';
+import type { GameState, Player } from '../src/types/game';
+
+const seat = (eliminated: boolean) => ({ eliminated });
+
+describe('getNextAliveIndex', () => {
+  const alive = [seat(false), seat(false), seat(false), seat(false)];
+
+  it('matches getNextPlayerIndex when nobody is eliminated', () => {
+    for (let from = 0; from < 4; from++) {
+      for (const dir of ['clockwise', 'counter_clockwise'] as const) {
+        for (const skip of [0, 1]) {
+          expect(getNextAliveIndex(alive, from, dir, skip))
+            .toBe(getNextPlayerIndex(from, 4, dir, skip));
+        }
+      }
+    }
+  });
+
+  it('skips eliminated seats', () => {
+    const players = [seat(false), seat(true), seat(false), seat(false)];
+    expect(getNextAliveIndex(players, 0, 'clockwise')).toBe(2);
+    expect(getNextAliveIndex(players, 2, 'counter_clockwise')).toBe(0);
+  });
+
+  it('skip=1 skips over an alive player, not an eliminated seat', () => {
+    const players = [seat(false), seat(true), seat(false), seat(false)];
+    // From 0: next alive is 2, skipping them lands on 3
+    expect(getNextAliveIndex(players, 0, 'clockwise', 1)).toBe(3);
+  });
+
+  it('wraps around eliminated seats at the boundary', () => {
+    const players = [seat(true), seat(false), seat(false), seat(true)];
+    expect(getNextAliveIndex(players, 2, 'clockwise')).toBe(1);
+  });
+
+  it('countAlivePlayers counts non-eliminated seats', () => {
+    expect(countAlivePlayers([seat(false), seat(true), seat(false)])).toBe(2);
+  });
+});
+
+describe('rotateHands', () => {
+  it('passes hands only between alive players', () => {
+    const players = [
+      { eliminated: false, hand: ['a'] },
+      { eliminated: true, hand: [] },
+      { eliminated: false, hand: ['c'] },
+      { eliminated: false, hand: ['d'] },
+    ];
+    const rotated = rotateHands(players, 'clockwise');
+    // clockwise: each alive player receives from the previous alive seat
+    expect(rotated[0]!.hand).toEqual(['d']);
+    expect(rotated[1]!.hand).toEqual([]); // eliminated seat keeps empty hand
+    expect(rotated[2]!.hand).toEqual(['a']);
+    expect(rotated[3]!.hand).toEqual(['c']);
+  });
+});
+
+// ─── Engine integration: eliminated seats never act ───────────────────────────
+
+function elimPlayers(hands: (Card[] | null)[]): Player[] {
+  return hands.map((hand, i) => ({
+    id: `p${i + 1}`,
+    name: `P${i + 1}`,
+    hand: hand ?? [],
+    score: 0,
+    connected: true,
+    autopilot: false,
+    calledUno: false,
+    eliminated: hand === null,
+  }));
+}
+
+const n = (id: string, color: 'red' | 'blue' | 'green' | 'yellow', value: number): Card =>
+  ({ id, type: 'number', color, value });
+
+function elimState(overrides: Partial<GameState>): GameState {
+  return makeState({
+    settings: {
+      turnTimeLimit: 30,
+      targetScore: 500,
+      allowSpectators: true,
+      spectatorMode: 'hidden',
+      houseRules: { ...DEFAULT_HOUSE_RULES, elimination: true },
+    },
+    ...overrides,
+  });
+}
+
+describe('engine skips eliminated seats', () => {
+  it('number card passes the turn over an eliminated seat', () => {
+    const state = elimState({
+      players: elimPlayers([[n('a1', 'red', 3), n('a2', 'blue', 1)], null, [n('c1', 'green', 2)]]),
+      discardPile: [n('top', 'red', 7)],
+      currentColor: 'red',
+      currentPlayerIndex: 0,
+    });
+    const after = applyActionWithHouseRules(state, { type: 'PLAY_CARD', playerId: 'p1', cardId: 'a1' });
+    expect(after.currentPlayerIndex).toBe(2);
+  });
+
+  it('skip card skips an alive player, not an eliminated seat', () => {
+    const skipCard = makeCard('skip', 'red', { id: 'sk1' });
+    const state = elimState({
+      players: elimPlayers([[skipCard, n('a2', 'blue', 1)], null, [n('c1', 'green', 2)], [n('d1', 'yellow', 4)]]),
+      discardPile: [n('top', 'red', 7)],
+      currentColor: 'red',
+      currentPlayerIndex: 0,
+    });
+    const after = applyActionWithHouseRules(state, { type: 'PLAY_CARD', playerId: 'p1', cardId: 'sk1' });
+    // p2 eliminated; skip passes over alive p3, lands on p4
+    expect(after.currentPlayerIndex).toBe(3);
+  });
+
+  it('draw_two penalizes the next ALIVE player', () => {
+    const d2 = makeCard('draw_two', 'red', { id: 'd2' });
+    const state = elimState({
+      players: elimPlayers([[d2, n('a2', 'blue', 1)], null, [n('c1', 'green', 2)], [n('d1', 'yellow', 4)]]),
+      discardPile: [n('top', 'red', 7)],
+      currentColor: 'red',
+      currentPlayerIndex: 0,
+    });
+    const after = applyActionWithHouseRules(state, { type: 'PLAY_CARD', playerId: 'p1', cardId: 'd2' });
+    // Victim must be p3 (p2 is eliminated) — it becomes the current player with pending draws
+    expect(after.currentPlayerIndex).toBe(2);
+    expect(after.pendingPenaltyDraws).toBe(2);
+  });
+
+  it('eliminated player cannot draw a card', () => {
+    const state = elimState({
+      players: elimPlayers([[n('a1', 'red', 3)], null, [n('c1', 'green', 2)]]),
+      discardPile: [n('top', 'red', 7)],
+      currentColor: 'red',
+      currentPlayerIndex: 0,
+    });
+    // Even if a stale client sends an action for the eliminated player, it's not their turn
+    const after = applyActionWithHouseRules(state, { type: 'DRAW_CARD', playerId: 'p2', side: 'left' });
+    expect(after.players[1]!.hand.length).toBe(0);
+  });
+
+  it('next round never starts on an eliminated seat', () => {
+    const state = initializeGame(
+      [{ id: 'p1', name: 'A' }, { id: 'p2', name: 'B' }, { id: 'p3', name: 'C' }],
+      { ...DEFAULT_HOUSE_RULES, elimination: true },
+    );
+    state.players[1]!.eliminated = true;
+    state.phase = 'round_end';
+    state.currentPlayerIndex = 1; // round ended while pointing at the now-eliminated seat
+
+    const next = initializeNextRound(state);
+    expect(next.players[next.currentPlayerIndex]!.eliminated).not.toBe(true);
+  });
+
+  it('full flow: elimination at round end, then round 2 turns skip the zombie seat', () => {
+    let state = initializeGame(
+      [{ id: 'p1', name: 'A' }, { id: 'p2', name: 'B' }, { id: 'p3', name: 'C' }],
+      { ...DEFAULT_HOUSE_RULES, elimination: true },
+    );
+    state.players[0]!.hand = [n('a1', 'red', 5)];
+    state.players[0]!.calledUno = true;
+    state.players[1]!.hand = [n('b1', 'blue', 1), n('b2', 'blue', 2), n('b3', 'blue', 3)];
+    state.players[2]!.hand = [n('c1', 'green', 1)];
+    state.discardPile = [n('top', 'red', 7)];
+    state.currentColor = 'red';
+    state.currentPlayerIndex = 0;
+    state.phase = 'playing';
+
+    state = applyActionWithHouseRules(state, { type: 'PLAY_CARD', playerId: 'p1', cardId: 'a1' });
+    expect(state.phase).toBe('round_end');
+    expect(state.players[1]!.eliminated).toBe(true);
+
+    let round2 = initializeNextRound(state);
+    round2 = {
+      ...round2,
+      phase: 'playing',
+      currentPlayerIndex: 0,
+      direction: 'clockwise',
+      discardPile: [n('t2', 'red', 7)],
+      currentColor: 'red',
+      drawStack: 0,
+      pendingPenaltyDraws: 0,
+    };
+    round2.players[0]!.hand = [n('a2', 'red', 3), n('a3', 'blue', 4)];
+
+    const after = applyActionWithHouseRules(round2, { type: 'PLAY_CARD', playerId: 'p1', cardId: 'a2' });
+    expect(after.players[after.currentPlayerIndex]!.id).toBe('p3');
+  });
+
+  it('zero-rotate keeps eliminated hands empty', () => {
+    const zero = n('z0', 'red', 0);
+    const state = elimState({
+      players: elimPlayers([[zero, n('a2', 'blue', 1)], null, [n('c1', 'green', 2), n('c2', 'green', 3)]]),
+      discardPile: [n('top', 'red', 7)],
+      currentColor: 'red',
+      currentPlayerIndex: 0,
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        allowSpectators: true,
+        spectatorMode: 'hidden',
+        houseRules: { ...DEFAULT_HOUSE_RULES, elimination: true, zeroRotateHands: true },
+      },
+    });
+    const after = applyActionWithHouseRules(state, { type: 'PLAY_CARD', playerId: 'p1', cardId: 'z0' });
+    expect(after.players[1]!.hand.length).toBe(0);
+    // p1's remaining hand (1 card) went to p3; p3's 2 cards went to p1
+    expect(after.players[0]!.hand.length).toBe(2);
+    expect(after.players[2]!.hand.length).toBe(1);
+  });
+
+  it('seven-swap rejects an eliminated target', () => {
+    const state = elimState({
+      phase: 'choosing_swap_target',
+      players: elimPlayers([[n('a1', 'red', 1)], null, [n('c1', 'green', 2)]]),
+      currentPlayerIndex: 0,
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        allowSpectators: true,
+        spectatorMode: 'hidden',
+        houseRules: { ...DEFAULT_HOUSE_RULES, elimination: true, sevenSwapHands: true },
+      },
+    });
+    const after = applyActionWithHouseRules(state, { type: 'CHOOSE_SWAP_TARGET', playerId: 'p1', targetId: 'p2' });
+    // Swap must be rejected: state unchanged apart from being handled
+    expect(after.phase).toBe('choosing_swap_target');
+    expect(after.players[0]!.hand.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## 背景

审查人机逻辑时发现一个引擎级 bug 和多处策略缺陷，逐项验证后修复。

## 引擎修复（淘汰制）

淘汰模式第 2 轮起，已淘汰座位仍会获得回合并摸牌/行动（已用真实流程复现）。整条 `getNextPlayerIndex` 调用链不感知淘汰状态。

- 新增 `getNextAliveIndex` / `countAlivePlayers` / `rotateHands`（`turn.ts`），无人淘汰时与原逻辑逐位等价，非淘汰房间零影响
- 替换 game-engine、全部房规插件、setup 中约 30 处回合指派：轮转、skip/+2/+4 目标、下一轮起始座位只落在存活玩家
- 连锁修复：0 牌轮转不再把手牌传进僵尸座位、bomb 不惩罚已淘汰玩家、七换手拒绝已淘汰目标、剩 2 名存活玩家时 reverse 按 2 人规则处理

## 人机策略改进

- **WD4 合法性自查**（normal/hard）：出 +4 前检查自己是否持有当前颜色（自家手牌信息，不算作弊），可被必胜挑战时重罚评分。A/B 实测：可挑战 WD4 占比 **57.5% → 2%**；novice/easy 保留该失误作为拟人化
- **残局求解器**：改为返回全部胜线起手牌、评估器在集合内择优。修复了按手牌顺序返回首个胜线、放弃必胜线去赌非必胜线的问题（如 `[红5, 红+2]` 残局现在正确先出 +2）
- **挑战判定**：hard 改用 `currentPlayerIndex` 定位 WD4 出牌者（与引擎结算一致），修复 jump-in WD4 场景反推错人
- **淘汰配套**：`turnsUntilPlayer`、下家、盟友判断全部按存活座位计算
- **连打排序**：同数字连打稀缺色先甩、主色收尾（最后一张定场上颜色）
- **公平性**：选色平局随机化（消除红色偏好）、跳入候选洗牌（消除前排座位优势）
- **清理**：删除换手目标 lead 加分（对所有候选统一 +5，不影响排序）和 lead 选举的恒假条件两处死代码

## 测试

- 新增 27 个测试：`turn-alive`（淘汰轮转不变量 + 引擎集成）、`bot-improvements`（策略行为断言）、`bot-simulation`（4 bot × 5 套房规组合全自动对局至 game_over，断言已淘汰玩家永不获得回合）
- 全仓 405 测试绿，三包 tsc + shared 构建干净
- 强度抽查：hard 对 3 novice 胜率 37.5%（基线 25%），难度梯度健康
- 已局域网实测确认

🤖 Generated with [Claude Code](https://claude.com/claude-code)