### PR TITLE
fix(game): 修复牌堆耗尽与自动操作死循环

### DIFF
--- a/packages/client/src/features/game/components/GameActions.tsx
+++ b/packages/client/src/features/game/components/GameActions.tsx
@@ -43,7 +43,12 @@ export default function GameActions({ onCallUno, onCatchUno, onChallenge, onAcce
   const noCardsAvailable = deckLeftCount === 0 && deckRightCount === 0 && discardPileLength <= 1;
   const mustDrawUntilPlayable = Boolean(settings?.houseRules?.drawUntilPlayable);
   const canPassAfterDraw = pendingPenaltyDraws === 0 && drawStack === 0 && hasDrawnThisTurn && (!mustDrawUntilPlayable || playableIds.size > 0);
-  const canPass = canPassAfterDraw || noCardsAvailable;
+  // handLimit blocks drawing at/above the limit; with nothing playable, PASS
+  // is the only legal move and the engine accepts it without a prior draw.
+  const handLimit = settings?.houseRules?.handLimit ?? null;
+  const stuckAtHandLimit = handLimit !== null && ownHandCount >= handLimit &&
+    playableIds.size === 0 && pendingPenaltyDraws === 0 && drawStack === 0;
+  const canPass = canPassAfterDraw || noCardsAvailable || stuckAtHandLimit;
 
   return (
     <div className="relative z-actions flex justify-center gap-2.5 py-2 pointer-events-auto">

--- a/packages/mcp/src/tools/room.ts
+++ b/packages/mcp/src/tools/room.ts
@@ -52,7 +52,7 @@ export function registerRoomTools(server: McpUnoServer): void {
       turnTimeLimit: z.union([z.literal(15), z.literal(30), z.literal(60)]).optional().describe('每回合时间限制（秒）'),
       targetScore: z.union([z.literal(200), z.literal(300), z.literal(500), z.literal(1000)]).optional().describe('目标分数'),
       allowSpectators: z.boolean().optional().describe('是否允许观战'),
-      houseRules: z.record(z.unknown()).optional().describe('村规设置，如 {"stackDrawTwo":true}'),
+      houseRules: z.record(z.string(), z.unknown()).optional().describe('村规设置，如 {"stackDrawTwo":true}'),
     },
     (args) => wrapTool(() => {
       const settings = Object.fromEntries(Object.entries(args).filter(([, v]) => v !== undefined));

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",
+    "types": ["node"],
     "noUnusedLocals": false,
     "noUnusedParameters": false
   },

--- a/packages/server/src/plugins/core/game/session.ts
+++ b/packages/server/src/plugins/core/game/session.ts
@@ -1,5 +1,9 @@
 import { createHash } from 'node:crypto';
-import { initializeGame, applyActionWithHouseRules } from '@uno-online/shared';
+import {
+  AutomationCycleGuard,
+  initializeGame,
+  applyActionWithHouseRules,
+} from '@uno-online/shared';
 import { initializeNextRound, serializeDecks } from '@uno-online/shared';
 import type { GameState, GameAction, RoomSettings, UserRole, BotConfig } from '@uno-online/shared';
 import type { Card } from '@uno-online/shared';
@@ -18,6 +22,7 @@ export class GameSession {
   private state: GameState;
   private initialDeckSerialized: string = '';
   private _spectatorMode: 'full' | 'hidden' = 'hidden';
+  private readonly automationCycleGuard = new AutomationCycleGuard();
 
   get spectatorMode(): 'full' | 'hidden' {
     return this._spectatorMode;
@@ -57,6 +62,17 @@ export class GameSession {
 
   getFullState(): GameState {
     return this.state;
+  }
+
+  getAutomationCycleGuard(): AutomationCycleGuard {
+    return this.automationCycleGuard;
+  }
+
+  recordAutomatedTransition(
+    before: GameState,
+    plan: readonly GameAction[],
+  ): void {
+    this.automationCycleGuard.recordTransition(before, plan, this.state);
   }
 
   private static readonly DISCARD_TRUNCATE = 10;
@@ -287,6 +303,7 @@ export class GameSession {
     this.state = initializeNextRound(this.state);
     this.state = { ...this.state, deckHash: GameSession.computeDeckHash(this.state), gameStartedAt, turnStartedAt: Date.now() };
     this.initialDeckSerialized = serializeDecks(this.state.deckLeft, this.state.deckRight);
+    this.automationCycleGuard.reset();
   }
 
   resetForRematch(): void {
@@ -297,6 +314,7 @@ export class GameSession {
     const now = Date.now();
     this.state = { ...fresh, settings, deckHash, chatHistory: [], gameStartedAt: now, turnStartedAt: now };
     this.initialDeckSerialized = serializeDecks(fresh.deckLeft, fresh.deckRight);
+    this.automationCycleGuard.reset();
   }
 
   addChatMessage(message: ChatMessage): void {

--- a/packages/server/src/ws/bot-uno-watcher.ts
+++ b/packages/server/src/ws/bot-uno-watcher.ts
@@ -3,6 +3,7 @@ import type { KvStore } from '../kv/types.js';
 import type { GameSession } from '../plugins/core/game/session.js';
 import type { GameStatePersister } from '../plugins/core/game/state-store.js';
 import { DIFFICULTY_PARAMS, chooseBotJumpInAction } from '@uno-online/shared';
+import type { GameAction } from '@uno-online/shared';
 
 // Map from roomCode to list of pending catch timers
 const botTimers = new Map<string, ReturnType<typeof setTimeout>[]>();
@@ -168,7 +169,8 @@ export function checkBotJumpIn(
 
   // Find the first bot that can jump in
   for (const bot of candidateBots) {
-    const actions = chooseBotJumpInAction(state, bot.id);
+    const cycleGuard = session.getAutomationCycleGuard();
+    const actions = chooseBotJumpInAction(state, bot.id, cycleGuard);
     if (actions.length === 0) continue;
 
     // Delay scaled by difficulty
@@ -189,15 +191,20 @@ export function checkBotJumpIn(
       // Re-read current state to avoid stale closure
       const currentState = session.getFullState();
       if (currentState.phase === 'game_over' || currentState.phase === 'round_end') return;
-      const freshActions = chooseBotJumpInAction(currentState, bot.id);
+      const freshActions = chooseBotJumpInAction(currentState, bot.id, cycleGuard);
       if (freshActions.length === 0) { onTurnChange(); return; }
 
       let acted = false;
+      const appliedActions: GameAction[] = [];
       for (const action of freshActions) {
         const result = session.applyAction(action);
-        if (result.success) acted = true;
+        if (result.success) {
+          acted = true;
+          appliedActions.push(action);
+        }
       }
       if (!acted) { onTurnChange(); return; }
+      session.recordAutomatedTransition(currentState, appliedActions);
 
       // Bot UNO call after jump-in
       const afterState = session.getFullState();

--- a/packages/server/src/ws/room-events.ts
+++ b/packages/server/src/ws/room-events.ts
@@ -684,14 +684,16 @@ export async function executeAutopilot(
   let lastActionTime = 0;
   for (let round = 0; round < 5; round++) {
     const st = session.getFullState();
+    const cycleGuard = session.getAutomationCycleGuard();
     let actions: GameAction[];
     if (canAutopilotActForPlayer(session, playerId)) {
-      actions = chooseAutopilotAction(st, playerId);
+      actions = chooseAutopilotAction(st, playerId, cycleGuard);
     } else {
-      actions = chooseJumpInAction(st, playerId);
+      actions = chooseJumpInAction(st, playerId, cycleGuard);
     }
     if (actions.length === 0) break;
     let anySuccess = false;
+    const appliedActions: GameAction[] = [];
     for (const action of actions) {
       if (lastActionTime > 0) {
         const elapsed = Date.now() - lastActionTime;
@@ -701,11 +703,15 @@ export async function executeAutopilot(
       }
       const result = session.applyAction(action);
       if (result.success) {
+        appliedActions.push(action);
         lastActionTime = Date.now();
         anySuccess = true;
         await onActionSuccess?.(action);
         await onPenaltyPause?.();
       }
+    }
+    if (appliedActions.length > 0) {
+      session.recordAutomatedTransition(st, appliedActions);
     }
     if (!anySuccess) break;
     acted = true;
@@ -783,16 +789,22 @@ export function startTurnTimer(
         return;
       }
       let actions: GameAction[];
+      const cycleGuard = s.getAutomationCycleGuard();
       if (botPlayer?.isBot && botPlayer.botConfig) {
-        actions = chooseBotAction(fullState, pid);
+        actions = chooseBotAction(fullState, pid, cycleGuard);
       } else {
-        actions = chooseAutopilotAction(fullState, pid);
+        actions = chooseAutopilotAction(fullState, pid, cycleGuard);
       }
 
+      const appliedActions: GameAction[] = [];
       for (const action of actions) {
         const result = s.applyAction(action);
         if (!result.success) break;
+        appliedActions.push(action);
         notifyAutopilotAction(roomCode, s, action);
+      }
+      if (appliedActions.length > 0) {
+        s.recordAutomatedTransition(fullState, appliedActions);
       }
 
       // Bot UNO call

--- a/packages/shared/src/rules/autopilot-strategy.ts
+++ b/packages/shared/src/rules/autopilot-strategy.ts
@@ -1,6 +1,8 @@
 import type { GameState, GameAction, DrawSide } from '../types/game.js';
 import type { Color, Card } from '../types/card.js';
 import { getPlayableCards, isExactJumpInMatch } from './validation.js';
+import type { AutomationCycleGuard } from './bot/automation-cycle-guard.js';
+import { enumerateLegalActionPlans } from './bot/legal-action-plans.js';
 
 function bestColor(hand: Card[], excludeId?: string): Color {
   const counts: Record<Color, number> = { red: 0, blue: 0, green: 0, yellow: 0 };
@@ -45,7 +47,7 @@ export function canJumpIn(state: GameState, playerId: string): boolean {
   return player.hand.some(c => isExactJumpInMatch(c, topCard));
 }
 
-export function chooseJumpInAction(state: GameState, playerId: string): GameAction[] {
+function chooseJumpInActionUnchecked(state: GameState, playerId: string): GameAction[] {
   if (!state.settings.houseRules.jumpIn || state.phase !== 'playing') return [];
   if ((state.pendingPenaltyDraws ?? 0) > 0 || state.drawStack > 0) return [];
   const currentPlayer = state.players[state.currentPlayerIndex];
@@ -58,13 +60,34 @@ export function chooseJumpInAction(state: GameState, playerId: string): GameActi
   return playCardActions(playerId, card, player.hand);
 }
 
-export function chooseAutopilotJumpInAction(state: GameState, playerId: string): GameAction[] {
-  const player = state.players.find(p => p.id === playerId);
-  if (!player?.autopilot) return [];
-  return chooseJumpInAction(state, playerId);
+export function chooseJumpInAction(
+  state: GameState,
+  playerId: string,
+  cycleGuard?: AutomationCycleGuard,
+): GameAction[] {
+  const preferred = chooseJumpInActionUnchecked(state, playerId);
+  if (!cycleGuard || preferred.length === 0) return preferred;
+  const player = state.players.find(candidate => candidate.id === playerId);
+  const topCard = state.discardPile[state.discardPile.length - 1];
+  const card = topCard
+    ? player?.hand.find(candidate => isExactJumpInMatch(candidate, topCard))
+    : undefined;
+  if (!card) return preferred;
+  const legal = enumerateLegalActionPlans(state, playerId, { kind: 'jumpin', card });
+  return cycleGuard.selectPlan(state, preferred, legal);
 }
 
-export function chooseAutopilotAction(state: GameState, playerId: string): GameAction[] {
+export function chooseAutopilotJumpInAction(
+  state: GameState,
+  playerId: string,
+  cycleGuard?: AutomationCycleGuard,
+): GameAction[] {
+  const player = state.players.find(p => p.id === playerId);
+  if (!player?.autopilot) return [];
+  return chooseJumpInAction(state, playerId, cycleGuard);
+}
+
+function chooseAutopilotActionUnchecked(state: GameState, playerId: string): GameAction[] {
   const player = state.players.find(p => p.id === playerId);
   if (!player) return [];
 
@@ -120,6 +143,8 @@ export function chooseAutopilotAction(state: GameState, playerId: string): GameA
   if (!currentPlayer || currentPlayer.id !== playerId) return [];
 
   const noCards = state.deckLeft.length === 0 && state.deckRight.length === 0 && state.discardPile.length <= 1;
+  // handLimit rejects non-obligation draws at/above the limit; PASS instead.
+  const atHandLimit = hr.handLimit !== null && player.hand.length >= hr.handLimit;
 
   if ((state.pendingPenaltyDraws ?? 0) > 0) {
     if (noCards) return [{ type: 'PASS', playerId }];
@@ -128,7 +153,7 @@ export function chooseAutopilotAction(state: GameState, playerId: string): GameA
 
   const topCard = state.discardPile[state.discardPile.length - 1];
   if (!topCard || !state.currentColor) {
-    if (noCards) return [{ type: 'PASS', playerId }];
+    if (noCards || atHandLimit) return [{ type: 'PASS', playerId }];
     return [{ type: 'DRAW_CARD', playerId, side: autopilotSide }];
   }
 
@@ -139,7 +164,7 @@ export function chooseAutopilotAction(state: GameState, playerId: string): GameA
   if (hasDrawnThisTurn && state.drawStack === 0) {
     const playableAfterDraw = getPlayableCards(player.hand, topCard, state.currentColor);
     if (playableAfterDraw.length === 0) {
-      if (!noCards && state.settings.houseRules.drawUntilPlayable) {
+      if (!noCards && !atHandLimit && state.settings.houseRules.drawUntilPlayable) {
         return [{ type: 'DRAW_CARD', playerId, side: autopilotSide }];
       }
       return [{ type: 'PASS', playerId }];
@@ -185,11 +210,22 @@ export function chooseAutopilotAction(state: GameState, playerId: string): GameA
 
   const playable = getPlayableCards(player.hand, topCard, state.currentColor);
   if (playable.length === 0) {
-    if (noCards) return [{ type: 'PASS', playerId }];
+    if (noCards || atHandLimit) return [{ type: 'PASS', playerId }];
     return [{ type: 'DRAW_CARD', playerId, side: autopilotSide }];
   }
 
   const pick = pickPlayableCard(playable, state.currentColor);
   const needsColorOnPlay = pick.type === 'wild_draw_four' && state.drawStack > 0 && (hr.stackDrawFour || hr.crossStack);
   return playCardActions(playerId, pick, player.hand, needsColorOnPlay);
+}
+
+export function chooseAutopilotAction(
+  state: GameState,
+  playerId: string,
+  cycleGuard?: AutomationCycleGuard,
+): GameAction[] {
+  const preferred = chooseAutopilotActionUnchecked(state, playerId);
+  if (!cycleGuard || preferred.length === 0) return preferred;
+  const legal = enumerateLegalActionPlans(state, playerId, { kind: 'turn' });
+  return cycleGuard.selectPlan(state, preferred, legal);
 }

--- a/packages/shared/src/rules/bot/automation-cycle-guard.ts
+++ b/packages/shared/src/rules/bot/automation-cycle-guard.ts
@@ -1,0 +1,299 @@
+import type { GameAction, GameState } from '../../types/game.js';
+import { applyActionWithHouseRules } from '../house-rules-engine.js';
+
+interface LegalActionSet {
+  plans: GameAction[][];
+}
+
+interface TransitionBucket {
+  afterVisits: Map<string, number>;
+}
+
+export interface AutomationCycleGuardOptions {
+  /**
+   * Permit this many identical observed transitions before avoiding the plan.
+   * Two visits preserve an initial tactic and one legitimate recurrence while
+   * still breaking a deterministic loop promptly.
+   */
+  repeatLimit?: number;
+  /** Bound memory for long rounds and persistent server sessions. */
+  maxTransitions?: number;
+}
+
+const DEFAULT_REPEAT_LIMIT = 2;
+const DEFAULT_MAX_TRANSITIONS = 8_192;
+
+function hashExactState(value: unknown): string {
+  const text = JSON.stringify(value);
+  let h1 = 0x811c9dc5;
+  let h2 = 0x9e3779b9;
+  let h3 = 0x85ebca6b;
+  let h4 = 0xc2b2ae35;
+  for (let index = 0; index < text.length; index++) {
+    const code = text.charCodeAt(index);
+    h1 = Math.imul(h1 ^ code, 0x01000193);
+    h2 = Math.imul(h2 ^ code, 0x27d4eb2d);
+    h3 = Math.imul(h3 ^ code, 0x165667b1);
+    h4 = Math.imul(h4 ^ code, 0x9e3779b1);
+  }
+  return [h1, h2, h3, h4]
+    .map(hash => (hash >>> 0).toString(16).padStart(8, '0'))
+    .join('');
+}
+
+/**
+ * Deterministic 128-bit fingerprint of the rule-relevant exact game state.
+ *
+ * House rules and player configuration are constant during a round, so they
+ * do not need to be duplicated in every transition key.
+ */
+export function automationStateFingerprint(state: GameState): string {
+  return hashExactState({
+    phase: state.phase,
+    players: state.players.map(player => ({
+      id: player.id,
+      hand: player.hand.map(card => card.id),
+      score: player.score,
+      calledUno: player.calledUno,
+      eliminated: player.eliminated ?? false,
+      teamId: player.teamId ?? null,
+    })),
+    currentPlayerIndex: state.currentPlayerIndex,
+    direction: state.direction,
+    deckLeft: state.deckLeft.map(card => card.id),
+    deckRight: state.deckRight.map(card => card.id),
+    discardPile: state.discardPile.map(card => card.id),
+    currentColor: state.currentColor,
+    drawStack: state.drawStack,
+    pendingDrawPlayerId: state.pendingDrawPlayerId,
+    pendingPenaltyDraws: state.pendingPenaltyDraws ?? 0,
+    pendingPenaltyNextPlayerIndex: state.pendingPenaltyNextPlayerIndex ?? null,
+    pendingPenaltySourcePlayerId: state.pendingPenaltySourcePlayerId ?? null,
+    pendingPenaltyQueue: state.pendingPenaltyQueue ?? [],
+    pendingRevengeDraws: state.pendingRevengeDraws ?? 0,
+    lastAction: state.lastAction,
+  });
+}
+
+function actionSignature(action: GameAction): unknown {
+  switch (action.type) {
+    case 'PLAY_CARD':
+      return [
+        action.type,
+        action.playerId,
+        action.cardId,
+        action.chosenColor ?? null,
+        action.isJumpIn ?? false,
+      ];
+    case 'DRAW_CARD':
+      return [action.type, action.playerId, action.side];
+    case 'PASS':
+    case 'CALL_UNO':
+    case 'CHALLENGE':
+    case 'ACCEPT':
+      return [action.type, action.playerId];
+    case 'CATCH_UNO':
+      return [action.type, action.catcherId, action.targetId];
+    case 'CHOOSE_COLOR':
+      return [action.type, action.playerId, action.color];
+    case 'CHOOSE_SWAP_TARGET':
+      return [action.type, action.playerId, action.targetId];
+  }
+}
+
+function planSignature(plan: readonly GameAction[]): string {
+  return JSON.stringify(plan.map(actionSignature));
+}
+
+/**
+ * A bounded, automation-only cycle guard.
+ *
+ * It never changes engine legality. A plan is avoided only after either its
+ * exact transition edge or its predicted exact after-state has already been
+ * observed `repeatLimit` times in the current round. Tracking the destination
+ * independently matters when several predecessor states converge into the
+ * same deterministic loop. First-use tactics remain legal, including
+ * immediately replaying a recycled action card.
+ */
+export class AutomationCycleGuard {
+  private readonly repeatLimit: number;
+  private readonly maxTransitions: number;
+  private readonly transitions = new Map<string, TransitionBucket>();
+  private readonly stateVisits = new Map<string, number>();
+  private roundNumber: number | null = null;
+  private lastAfterFingerprint: string | null = null;
+
+  constructor(options: AutomationCycleGuardOptions = {}) {
+    this.repeatLimit = Math.max(1, options.repeatLimit ?? DEFAULT_REPEAT_LIMIT);
+    this.maxTransitions = Math.max(1, options.maxTransitions ?? DEFAULT_MAX_TRANSITIONS);
+  }
+
+  reset(): void {
+    this.transitions.clear();
+    this.stateVisits.clear();
+    this.roundNumber = null;
+    this.lastAfterFingerprint = null;
+  }
+
+  private syncRound(state: GameState): void {
+    if (this.roundNumber === null) {
+      this.roundNumber = state.roundNumber;
+      return;
+    }
+    if (this.roundNumber !== state.roundNumber) {
+      this.transitions.clear();
+      this.stateVisits.clear();
+      this.roundNumber = state.roundNumber;
+      this.lastAfterFingerprint = null;
+    }
+  }
+
+  private key(state: GameState, plan: readonly GameAction[]): string {
+    return `${automationStateFingerprint(state)}:${planSignature(plan)}`;
+  }
+
+  private planAfterFingerprint(
+    state: GameState,
+    plan: readonly GameAction[],
+  ): string | null {
+    let after = state;
+    for (const action of plan) {
+      const next = applyActionWithHouseRules(after, action);
+      if (next === after) return null;
+      after = next;
+    }
+    return automationStateFingerprint(after);
+  }
+
+  private boundedIncrement(visits: Map<string, number>, fingerprint: string): void {
+    const next = (visits.get(fingerprint) ?? 0) + 1;
+    // Refresh insertion order so the bounded map represents recent states,
+    // not merely the first states observed in a very long round.
+    visits.delete(fingerprint);
+    if (visits.size >= this.maxTransitions) {
+      const oldest = visits.keys().next().value as string | undefined;
+      if (oldest !== undefined) visits.delete(oldest);
+    }
+    visits.set(fingerprint, next);
+  }
+
+  private repeatCountForAfter(
+    state: GameState,
+    plan: readonly GameAction[],
+    afterFingerprint: string | null,
+  ): number {
+    if (plan.length === 0) return 0;
+    this.syncRound(state);
+    const bucket = this.transitions.get(this.key(state, plan));
+    let edgeMax = 0;
+    if (bucket) {
+      for (const visits of bucket.afterVisits.values()) {
+        edgeMax = Math.max(edgeMax, visits);
+      }
+    }
+    const stateCount = afterFingerprint === null
+      ? 0
+      : (this.stateVisits.get(afterFingerprint) ?? 0);
+    return Math.max(edgeMax, stateCount);
+  }
+
+  repeatCount(state: GameState, plan: readonly GameAction[]): number {
+    return this.repeatCountForAfter(
+      state,
+      plan,
+      this.planAfterFingerprint(state, plan),
+    );
+  }
+
+  shouldAvoidPlan(state: GameState, plan: readonly GameAction[]): boolean {
+    return this.repeatCount(state, plan) >= this.repeatLimit;
+  }
+
+  recordTransition(
+    before: GameState,
+    plan: readonly GameAction[],
+    after: GameState,
+  ): void {
+    if (plan.length === 0) return;
+    this.syncRound(before);
+    if (after.roundNumber !== before.roundNumber) {
+      this.transitions.clear();
+      this.stateVisits.clear();
+      this.roundNumber = after.roundNumber;
+      this.lastAfterFingerprint = null;
+      return;
+    }
+
+    const beforeFingerprint = automationStateFingerprint(before);
+    if (beforeFingerprint !== this.lastAfterFingerprint) {
+      this.boundedIncrement(this.stateVisits, beforeFingerprint);
+    }
+
+    const key = this.key(before, plan);
+    let bucket = this.transitions.get(key);
+    if (!bucket) {
+      if (this.transitions.size >= this.maxTransitions) {
+        const oldestKey = this.transitions.keys().next().value as string | undefined;
+        if (oldestKey !== undefined) this.transitions.delete(oldestKey);
+      }
+      bucket = { afterVisits: new Map<string, number>() };
+      this.transitions.set(key, bucket);
+    }
+    const afterFingerprint = automationStateFingerprint(after);
+    bucket.afterVisits.set(
+      afterFingerprint,
+      (bucket.afterVisits.get(afterFingerprint) ?? 0) + 1,
+    );
+    this.boundedIncrement(this.stateVisits, afterFingerprint);
+    this.lastAfterFingerprint = afterFingerprint;
+  }
+
+  /**
+   * Remove only plans with demonstrated repeated transitions. If every legal
+   * plan is repeated, preserve the original set so callers never receive an
+   * artificial zero-action state.
+   */
+  filterLegalActions<T extends LegalActionSet>(state: GameState, legal: T): T {
+    const avoid = legal.plans.map(plan => {
+      const afterFingerprint = this.planAfterFingerprint(state, plan);
+      return this.repeatCountForAfter(state, plan, afterFingerprint)
+        >= this.repeatLimit;
+    });
+    const hasAllowedPlan = legal.plans.some((_, index) => !avoid[index]);
+    if (!hasAllowedPlan || !avoid.some(Boolean)) return legal;
+    return {
+      ...legal,
+      plans: legal.plans.filter((_, index) => !avoid[index]),
+    };
+  }
+
+  /**
+   * Keep a chooser's preferred plan unless it has demonstrated recurrence.
+   * On intervention, choose the least-repeated remaining engine-legal plan.
+   */
+  selectPlan<T extends LegalActionSet>(
+    state: GameState,
+    preferred: GameAction[],
+    legal: T,
+  ): GameAction[] {
+    if (
+      preferred.length === 0
+      || !this.shouldAvoidPlan(state, preferred)
+    ) {
+      return preferred;
+    }
+
+    const filtered = this.filterLegalActions(state, legal);
+    let selected: GameAction[] | null = null;
+    let selectedCount = Number.POSITIVE_INFINITY;
+    for (const plan of filtered.plans) {
+      const afterFingerprint = this.planAfterFingerprint(state, plan);
+      const count = this.repeatCountForAfter(state, plan, afterFingerprint);
+      if (count < selectedCount) {
+        selected = plan;
+        selectedCount = count;
+      }
+    }
+    return selected ?? preferred;
+  }
+}

--- a/packages/shared/src/rules/bot/bot-strategy.ts
+++ b/packages/shared/src/rules/bot/bot-strategy.ts
@@ -7,6 +7,8 @@ import { getNextAliveIndex } from '../turn.js';
 import { DIFFICULTY_PARAMS } from './difficulty-params.js';
 import { PERSONALITY_WEIGHTS } from './personality-weights.js';
 import { evaluateCards, bestColorsForHand, evaluateHandQuality, electLeadBot } from './card-evaluator.js';
+import type { AutomationCycleGuard } from './automation-cycle-guard.js';
+import { enumerateLegalActionPlans } from './legal-action-plans.js';
 
 function isFinishBlocked(card: Card, hand: Card[], hr: { noWildFinish: boolean; noFunctionCardFinish: boolean }): boolean {
   if (hand.length !== 1) return false;
@@ -406,6 +408,8 @@ function handlePlaying(state: GameState, playerId: string, config: BotConfig): G
     state.deckLeft.length === 0 &&
     state.deckRight.length === 0 &&
     state.discardPile.length <= 1;
+  // handLimit rejects non-obligation draws at/above the limit; PASS instead.
+  const atHandLimit = hr.handLimit !== null && player.hand.length >= hr.handLimit;
 
   // Pending penalty draws (from misplay or uno catch)
   if ((state.pendingPenaltyDraws ?? 0) > 0) {
@@ -415,7 +419,7 @@ function handlePlaying(state: GameState, playerId: string, config: BotConfig): G
 
   const topCard = state.discardPile[state.discardPile.length - 1];
   if (!topCard || !state.currentColor) {
-    if (noCards) return [{ type: 'PASS', playerId }];
+    if (noCards || atHandLimit) return [{ type: 'PASS', playerId }];
     return [{ type: 'DRAW_CARD', playerId, side: drawSide }];
   }
 
@@ -430,7 +434,7 @@ function handlePlaying(state: GameState, playerId: string, config: BotConfig): G
       playableAfterDraw = playableAfterDraw.filter(c => !isFinishBlocked(c, player.hand, hr));
     }
     if (playableAfterDraw.length === 0) {
-      if (!noCards && hr.drawUntilPlayable) {
+      if (!noCards && !atHandLimit && hr.drawUntilPlayable) {
         return [{ type: 'DRAW_CARD', playerId, side: drawSide }];
       }
       return [{ type: 'PASS', playerId }];
@@ -501,7 +505,7 @@ function handlePlaying(state: GameState, playerId: string, config: BotConfig): G
     playable = playable.filter(c => !isFinishBlocked(c, player.hand, hr));
   }
   if (playable.length === 0) {
-    if (noCards) return [{ type: 'PASS', playerId }];
+    if (noCards || atHandLimit) return [{ type: 'PASS', playerId }];
     return [{ type: 'DRAW_CARD', playerId, side: drawSide }];
   }
 
@@ -586,12 +590,14 @@ function handlePlaying(state: GameState, playerId: string, config: BotConfig): G
  * Main bot action chooser. Dispatches to the appropriate phase handler.
  * Returns an array of actions to be applied sequentially.
  */
-export function chooseBotAction(state: GameState, playerId: string): GameAction[] {
+function chooseBotActionUnchecked(
+  state: GameState,
+  playerId: string,
+): GameAction[] {
   const player = state.players.find(p => p.id === playerId);
   if (!player) return [];
 
   const config: BotConfig = player.botConfig ?? DEFAULT_BOT_CONFIG;
-
   switch (state.phase) {
     case 'challenging':
       return handleChallenging(state, playerId, config);
@@ -606,11 +612,25 @@ export function chooseBotAction(state: GameState, playerId: string): GameAction[
   }
 }
 
+export function chooseBotAction(
+  state: GameState,
+  playerId: string,
+  cycleGuard?: AutomationCycleGuard,
+): GameAction[] {
+  const preferred = chooseBotActionUnchecked(state, playerId);
+  if (!cycleGuard || preferred.length === 0) return preferred;
+  const legal = enumerateLegalActionPlans(state, playerId, { kind: 'turn' });
+  return cycleGuard.selectPlan(state, preferred, legal);
+}
+
 /**
  * Bot jump-in check. Called asynchronously while it's another player's turn.
  * Uses `specialCardAwareness` as the probability to attempt a jump-in.
  */
-export function chooseBotJumpInAction(state: GameState, playerId: string): GameAction[] {
+function chooseBotJumpInActionUnchecked(
+  state: GameState,
+  playerId: string,
+): GameAction[] {
   if (!state.settings.houseRules.jumpIn) return [];
   if (state.phase !== 'playing') return [];
 
@@ -628,6 +648,9 @@ export function chooseBotJumpInAction(state: GameState, playerId: string): GameA
 
   const config: BotConfig = player.botConfig ?? DEFAULT_BOT_CONFIG;
   const params = DIFFICULTY_PARAMS[config.difficulty];
+
+  const jumpInCard = player.hand.find(c => isExactJumpInMatch(c, topCard));
+  if (!jumpInCard) return [];
 
   // specialCardAwareness controls jump-in probability
   if (Math.random() >= params.specialCardAwareness) return [];
@@ -668,4 +691,21 @@ export function chooseBotJumpInAction(state: GameState, playerId: string): GameA
 
   const color = chooseBestColor(state, playerId, player.hand, card.id, config);
   return playCardActions(playerId, card, color);
+}
+
+export function chooseBotJumpInAction(
+  state: GameState,
+  playerId: string,
+  cycleGuard?: AutomationCycleGuard,
+): GameAction[] {
+  const preferred = chooseBotJumpInActionUnchecked(state, playerId);
+  if (!cycleGuard || preferred.length === 0) return preferred;
+  const player = state.players.find(candidate => candidate.id === playerId);
+  const topCard = state.discardPile[state.discardPile.length - 1];
+  const card = topCard
+    ? player?.hand.find(candidate => isExactJumpInMatch(candidate, topCard))
+    : undefined;
+  if (!card) return preferred;
+  const legal = enumerateLegalActionPlans(state, playerId, { kind: 'jumpin', card });
+  return cycleGuard.selectPlan(state, preferred, legal);
 }

--- a/packages/shared/src/rules/bot/legal-action-plans.ts
+++ b/packages/shared/src/rules/bot/legal-action-plans.ts
@@ -1,0 +1,165 @@
+import type { Card, Color } from '../../types/card.js';
+import type { GameAction, GameState } from '../../types/game.js';
+import { applyActionWithHouseRules } from '../house-rules-engine.js';
+
+const COLORS: readonly Color[] = ['red', 'blue', 'green', 'yellow'];
+
+export type AutomatedDecisionContext =
+  | { kind: 'turn' }
+  | { kind: 'jumpin'; card: Card };
+
+export interface LegalActionPlans {
+  plans: GameAction[][];
+}
+
+function isLegalPlan(state: GameState, plan: readonly GameAction[]): boolean {
+  let current = state;
+  for (const action of plan) {
+    const next = applyActionWithHouseRules(current, action);
+    if (next === current) return false;
+    current = next;
+  }
+  return plan.length > 0;
+}
+
+function validationStateForPlay(state: GameState): GameState {
+  const houseRules = state.settings.houseRules;
+  if (!houseRules.misplayPenalty) return state;
+  return {
+    ...state,
+    settings: {
+      ...state.settings,
+      houseRules: { ...houseRules, misplayPenalty: false },
+    },
+  };
+}
+
+function cardPlans(
+  state: GameState,
+  playerId: string,
+  card: Card,
+  options: { jumpIn: boolean },
+): GameAction[][] {
+  const { jumpIn } = options;
+  if (card.type !== 'wild' && card.type !== 'wild_draw_four') {
+    return [[{
+      type: 'PLAY_CARD',
+      playerId,
+      cardId: card.id,
+      ...(jumpIn ? { isJumpIn: true } : {}),
+    }]];
+  }
+
+  const inlineOnly = jumpIn
+    || (card.type === 'wild_draw_four'
+      && (state.phase === 'challenging' || state.drawStack > 0));
+  return COLORS.flatMap(color => {
+    const inline: GameAction[] = [{
+      type: 'PLAY_CARD',
+      playerId,
+      cardId: card.id,
+      chosenColor: color,
+      ...(jumpIn ? { isJumpIn: true } : {}),
+    }];
+    if (inlineOnly) return [inline];
+    return [
+      [
+        { type: 'PLAY_CARD', playerId, cardId: card.id },
+        { type: 'CHOOSE_COLOR', playerId, color },
+      ],
+      inline,
+    ];
+  });
+}
+
+function addLegal(
+  output: GameAction[][],
+  state: GameState,
+  candidates: readonly GameAction[][],
+): void {
+  for (const candidate of candidates) {
+    if (isLegalPlan(state, candidate)) output.push(candidate);
+  }
+}
+
+/**
+ * Enumerate concrete engine-legal plans for automated cycle recovery.
+ *
+ * This deliberately has no model action indices, masks, observations, or
+ * training metadata. Product automation only needs alternative rule-engine
+ * transitions when its preferred deterministic plan is known to repeat.
+ */
+export function enumerateLegalActionPlans(
+  state: GameState,
+  playerId: string,
+  context: AutomatedDecisionContext = { kind: 'turn' },
+): LegalActionPlans {
+  const output: GameAction[][] = [];
+  const player = state.players.find(candidate => candidate.id === playerId);
+  if (!player) return { plans: output };
+
+  if (context.kind === 'jumpin') {
+    addLegal(
+      output,
+      validationStateForPlay(state),
+      cardPlans(state, playerId, context.card, { jumpIn: true }),
+    );
+    return { plans: output };
+  }
+
+  const actorId = state.phase === 'challenging'
+    ? state.pendingDrawPlayerId
+    : state.players[state.currentPlayerIndex]?.id;
+  if (actorId !== playerId) return { plans: output };
+
+  if (state.phase === 'choosing_color') {
+    addLegal(
+      output,
+      state,
+      COLORS.map(color => [{ type: 'CHOOSE_COLOR', playerId, color }]),
+    );
+    return { plans: output };
+  }
+
+  if (state.phase === 'choosing_swap_target') {
+    addLegal(
+      output,
+      state,
+      state.players
+        .filter(target => target.id !== playerId && !target.eliminated)
+        .map(target => [{
+          type: 'CHOOSE_SWAP_TARGET' as const,
+          playerId,
+          targetId: target.id,
+        }]),
+    );
+    return { plans: output };
+  }
+
+  if (state.phase === 'challenging') {
+    addLegal(output, state, [
+      [{ type: 'CHALLENGE', playerId }],
+      [{ type: 'ACCEPT', playerId }],
+    ]);
+  } else if (state.phase !== 'playing') {
+    return { plans: output };
+  }
+
+  const playState = validationStateForPlay(state);
+  for (const card of player.hand) {
+    addLegal(
+      output,
+      playState,
+      cardPlans(state, playerId, card, { jumpIn: false }),
+    );
+  }
+
+  if (state.phase === 'playing') {
+    addLegal(output, state, [
+      [{ type: 'DRAW_CARD', playerId, side: 'left' }],
+      [{ type: 'DRAW_CARD', playerId, side: 'right' }],
+      [{ type: 'PASS', playerId }],
+    ]);
+  }
+  return { plans: output };
+}

--- a/packages/shared/src/rules/game-engine.ts
+++ b/packages/shared/src/rules/game-engine.ts
@@ -11,6 +11,7 @@ export const PENALTY_STATE_DEFAULTS = {
   pendingPenaltyNextPlayerIndex: null,
   pendingPenaltySourcePlayerId: null,
   pendingPenaltyQueue: [] as { playerId: string; count: number; nextPlayerIndex: number; sourcePlayerId: string | null }[],
+  pendingRevengeDraws: 0,
   pendingDrawPlayerId: null,
   drawStack: 0,
 } as const;
@@ -19,8 +20,90 @@ export const PENALTY_STATE_DEFAULTS = {
 // Helpers
 // -----------------------------------------------------------------------------
 
-function hasCardsAvailable(state: GameState): boolean {
+export function hasCardsAvailable(state: GameState): boolean {
   return state.deckLeft.length > 0 || state.deckRight.length > 0 || state.discardPile.length > 1;
+}
+
+/**
+ * The handLimit house rule rejects DRAW_CARD at/above the limit. When the
+ * current player additionally has nothing playable, PASS is the only way the
+ * turn can advance — handlePass and the drawUntilPlayable plugin both wave
+ * PASS through in exactly that situation to avoid a deadlock.
+ */
+export function isStuckAtHandLimit(state: GameState): boolean {
+  const limit = state.settings.houseRules.handLimit;
+  if (limit === null) return false;
+  const player = state.players[state.currentPlayerIndex];
+  if (!player || player.hand.length < limit) return false;
+  const topCard = state.discardPile[state.discardPile.length - 1];
+  if (!topCard || !state.currentColor) return true;
+  return !player.hand.some(card => canPlayCard(card, topCard, state.currentColor!));
+}
+
+/**
+ * A PASS would make no progress when every active player lacks a playable
+ * card and nobody can draw. End such a round as a draw instead of rotating
+ * the exact same state forever.
+ *
+ * Drawing can be unavailable either because every physical draw source is
+ * exhausted or because the hand-limit rule blocks every active player.
+ */
+function isPassStalemate(state: GameState): boolean {
+  if (state.phase !== 'playing') return false;
+  if ((state.pendingPenaltyDraws ?? 0) > 0 || state.drawStack > 0) return false;
+  // A successful draw followed by PASS still advances the turn and therefore
+  // makes progress, even when that draw happened to exhaust the final source.
+  if (
+    state.lastAction?.type === 'DRAW_CARD' &&
+    state.lastAction.playerId === state.players[state.currentPlayerIndex]?.id
+  ) {
+    return false;
+  }
+
+  const topCard = state.discardPile[state.discardPile.length - 1];
+  if (!topCard || !state.currentColor) return false;
+
+  const activePlayers = state.players.filter(player => !player.eliminated);
+  if (activePlayers.length < 2) return false;
+  if (
+    activePlayers.some(player =>
+      player.hand.some(card =>
+        canPlayCard(card, topCard, state.currentColor!) &&
+        !isFinishRestrictedLastCard(state, player, card)
+      )
+    )
+  ) {
+    return false;
+  }
+
+  if (!hasCardsAvailable(state)) return true;
+
+  const limit = state.settings.houseRules.handLimit;
+  return limit !== null && activePlayers.every(player => player.hand.length >= limit);
+}
+
+function isFinishRestrictedLastCard(
+  state: GameState,
+  player: GameState['players'][number],
+  card: GameState['players'][number]['hand'][number],
+): boolean {
+  if (player.hand.length !== 1) return false;
+  const hr = state.settings.houseRules;
+  return (
+    (hr.noWildFinish && (card.type === 'wild' || card.type === 'wild_draw_four')) ||
+    (hr.noFunctionCardFinish && (card.type === 'draw_two' || card.type === 'wild_draw_four'))
+  );
+}
+
+function currentPlayerHasPlayableCard(state: GameState): boolean {
+  const player = state.players[state.currentPlayerIndex];
+  const topCard = state.discardPile[state.discardPile.length - 1];
+  if (!player || !topCard || !state.currentColor) return false;
+
+  return player.hand.some(card =>
+    canPlayCard(card, topCard, state.currentColor!) &&
+    !isFinishRestrictedLastCard(state, player, card)
+  );
 }
 
 /**
@@ -161,7 +244,12 @@ function finishPenaltyDrawIfNeeded(state: GameState, lastAction: GameAction): Ga
   const remaining = state.pendingPenaltyDraws ?? 0;
   if (remaining <= 0) return state;
 
-  const nextRemaining = Math.max(remaining - 1, 0);
+  // One draw action settles the unavailable remainder when every source is
+  // exhausted. Requiring one no-op click per missing penalty card makes large
+  // stacks consume thousands of fake turns without changing any cards.
+  const nextRemaining = hasCardsAvailable(state)
+    ? Math.max(remaining - 1, 0)
+    : 0;
   if (nextRemaining > 0) {
     return { ...state, pendingPenaltyDraws: nextRemaining, lastAction };
   }
@@ -204,7 +292,17 @@ function finishPenaltyDrawIfNeeded(state: GameState, lastAction: GameAction): Ga
 
 export function drainPenaltyQueue(state: GameState): GameState {
   const queue = state.pendingPenaltyQueue ?? [];
-  if (queue.length === 0 || state.phase !== 'playing') return state;
+  // A queued penalty must wait for the active penalty to be paid. Otherwise a
+  // house-rule pre-check that deliberately returns the unchanged state (for
+  // example drawUntilPlayable rejecting PASS) can pop and immediately requeue
+  // the next penalty, producing a new-but-equivalent state forever.
+  if (
+    queue.length === 0 ||
+    state.phase !== 'playing' ||
+    (state.pendingPenaltyDraws ?? 0) > 0
+  ) {
+    return state;
+  }
   const [next, ...rest] = queue;
   return startPenaltyDraw(
     { ...state, pendingPenaltyQueue: rest },
@@ -381,6 +479,7 @@ function handleDrawCard(
 ): GameState {
   if (state.phase !== 'playing') return state;
   if (action.playerId !== currentPlayerId(state)) return state;
+  if (!hasCardsAvailable(state) && (state.pendingPenaltyDraws ?? 0) === 0) return state;
 
   const newState = drawCards(state, action.playerId, 1, action.side);
   if ((state.pendingPenaltyDraws ?? 0) > 0) {
@@ -397,18 +496,40 @@ function handlePass(
   if (action.playerId !== currentPlayerId(state)) return state;
 
   const noCards = !hasCardsAvailable(state);
+  const completedDraw =
+    state.lastAction?.type === 'DRAW_CARD' &&
+    state.lastAction.playerId === action.playerId;
 
   if (!noCards) {
     if ((state.pendingPenaltyDraws ?? 0) > 0 || state.drawStack > 0) return state;
 
-    // Can only pass after drawing
+    // Can only pass after drawing — unless the hand limit blocks drawing and
+    // nothing is playable, in which case PASS is the only legal move left.
     if (
-      !state.lastAction ||
-      state.lastAction.type !== 'DRAW_CARD' ||
-      state.lastAction.playerId !== action.playerId
+      !isStuckAtHandLimit(state) &&
+      (!state.lastAction ||
+        state.lastAction.type !== 'DRAW_CARD' ||
+        state.lastAction.playerId !== action.playerId)
     ) {
       return state;
     }
+  } else if (
+    (state.pendingPenaltyDraws ?? 0) === 0 &&
+    state.drawStack === 0 &&
+    !completedDraw &&
+    currentPlayerHasPlayableCard(state)
+  ) {
+    return state;
+  }
+
+  if (isPassStalemate(state)) {
+    return {
+      ...state,
+      phase: 'round_end',
+      winnerId: null,
+      lastAction: action,
+      ...PENALTY_STATE_DEFAULTS,
+    };
   }
 
   const newIndex = getNextAliveIndex(
@@ -469,24 +590,36 @@ function handleChallenge(
   const challengerIdx = playerIndex(state, action.playerId);
   const prevColor = getWildDrawFourChallengeColor(state);
   const wd4WasLegal = isValidWildDrawFour(wd4Player.hand, prevColor);
+  const revengeBonus = state.pendingRevengeDraws ?? 0;
+  const settledState = { ...state, pendingRevengeDraws: 0 };
 
   if (wd4WasLegal) {
     const nextIdx = getNextAliveIndex(state.players, challengerIdx, state.direction);
     return startPenaltyDraw({
-      ...state,
+      ...settledState,
       phase: 'playing',
       pendingDrawPlayerId: null,
-      lastAction: { ...action, succeeded: false, penaltyPlayerId: action.playerId, penaltyCount: 6 },
-    }, action.playerId, 6, nextIdx, state.lastAction?.type === 'CHOOSE_COLOR' ? wd4Player.id : null);
+      lastAction: {
+        ...action,
+        succeeded: false,
+        penaltyPlayerId: action.playerId,
+        penaltyCount: 6 + revengeBonus,
+      },
+    }, action.playerId, 6 + revengeBonus, nextIdx, state.lastAction?.type === 'CHOOSE_COLOR' ? wd4Player.id : null);
   }
 
   const nextIdx = getNextAliveIndex(state.players, wd4PlayerIdx, state.direction);
   return startPenaltyDraw({
-    ...state,
+    ...settledState,
     phase: 'playing',
     pendingDrawPlayerId: null,
-    lastAction: { ...action, succeeded: true, penaltyPlayerId: wd4Player.id, penaltyCount: 4 },
-  }, wd4Player.id, 4, nextIdx);
+    lastAction: {
+      ...action,
+      succeeded: true,
+      penaltyPlayerId: wd4Player.id,
+      penaltyCount: 4 + revengeBonus,
+    },
+  }, wd4Player.id, 4 + revengeBonus, nextIdx);
 }
 function handleAccept(
   state: GameState,
@@ -498,12 +631,19 @@ function handleAccept(
   const wd4PlayerId = currentPlayerId(state);
   const accepterIdx = playerIndex(state, action.playerId);
   const nextIdx = getNextAliveIndex(state.players, accepterIdx, state.direction);
+  const revengeBonus = state.pendingRevengeDraws ?? 0;
   return startPenaltyDraw({
     ...state,
+    pendingRevengeDraws: 0,
     phase: 'playing',
     pendingDrawPlayerId: null,
-    lastAction: action,
-  }, action.playerId, 4, nextIdx, state.lastAction?.type === 'CHOOSE_COLOR' ? wd4PlayerId : null);
+    lastAction: {
+      ...action,
+      ...(revengeBonus > 0
+        ? { penaltyPlayerId: action.playerId, penaltyCount: 4 + revengeBonus }
+        : {}),
+    },
+  }, action.playerId, 4 + revengeBonus, nextIdx, state.lastAction?.type === 'CHOOSE_COLOR' ? wd4PlayerId : null);
 }
 function handleCallUno(
   state: GameState,

--- a/packages/shared/src/rules/house-rules-engine.ts
+++ b/packages/shared/src/rules/house-rules-engine.ts
@@ -19,6 +19,14 @@ const TERMINAL_PHASES = new Set(['round_end', 'game_over']);
 export function applyActionWithHouseRules(state: GameState, action: GameAction): GameState {
   const hr = state.settings.houseRules;
 
+  // Paying an already-resolved penalty is an exclusive phase of the turn:
+  // the affected player must finish drawing before any card can be played.
+  // Keep this invariant ahead of every plugin so a pre-check cannot bypass
+  // the core engine's identical guard (for example by starting a new stack).
+  if (action.type === 'PLAY_CARD' && (state.pendingPenaltyDraws ?? 0) > 0) {
+    return state;
+  }
+
   for (const plugin of PRE_CHECK_PLUGINS) {
     if (!plugin.isEnabled(hr)) continue;
     if (!plugin.preCheck) continue;

--- a/packages/shared/src/rules/index.ts
+++ b/packages/shared/src/rules/index.ts
@@ -15,6 +15,11 @@ export { chooseAutopilotAction, chooseAutopilotJumpInAction, canJumpIn, chooseJu
 export { HOUSE_RULE_DESCRIPTIONS } from './rule-descriptions.js';
 export { BOT_NAMES, pickBotName } from './bot/bot-names.js';
 export { chooseBotAction, chooseBotJumpInAction } from './bot/bot-strategy.js';
+export {
+  AutomationCycleGuard,
+  automationStateFingerprint,
+} from './bot/automation-cycle-guard.js';
+export type { AutomationCycleGuardOptions } from './bot/automation-cycle-guard.js';
 export { DIFFICULTY_PARAMS } from './bot/difficulty-params.js';
 export type { DifficultyParams, DelayConfig } from './bot/difficulty-params.js';
 export { PERSONALITY_WEIGHTS } from './bot/personality-weights.js';

--- a/packages/shared/src/rules/rules/deflection.ts
+++ b/packages/shared/src/rules/rules/deflection.ts
@@ -33,6 +33,7 @@ export const deflection: HouseRulePlugin = {
         const wd4PlayerIdx = state.currentPlayerIndex;
         const wd4PlayerId = state.players[wd4PlayerIdx]!.id;
         const afterPenaltyNextIdx = ctx.getNextAliveIndex(players, wd4PlayerIdx, newDirection);
+        const revengeBonus = state.pendingRevengeDraws ?? 0;
         const baseState = checkRoundEnd({
           ...state,
           players,
@@ -41,11 +42,18 @@ export const deflection: HouseRulePlugin = {
           direction: newDirection,
           phase: 'playing',
           pendingDrawPlayerId: null,
+          pendingRevengeDraws: 0,
           lastAction: action,
         }, action.playerId);
         return {
           handled: true,
-          state: ctx.startPenaltyDraw(baseState, wd4PlayerId, 4, afterPenaltyNextIdx, action.playerId),
+          state: ctx.startPenaltyDraw(
+            baseState,
+            wd4PlayerId,
+            4 + revengeBonus,
+            afterPenaltyNextIdx,
+            action.playerId,
+          ),
         };
       }
 
@@ -57,6 +65,7 @@ export const deflection: HouseRulePlugin = {
         const nextIdx = ctx.getNextAliveIndex(players, playerIdx, state.direction);
         const nextPlayerId = state.players[nextIdx]!.id;
         const afterPenaltyNextIdx = ctx.getNextAliveIndex(players, nextIdx, state.direction);
+        const revengeBonus = state.pendingRevengeDraws ?? 0;
         const baseState = checkRoundEnd({
           ...state,
           players,
@@ -64,11 +73,18 @@ export const deflection: HouseRulePlugin = {
           currentColor: card.color ?? state.currentColor,
           phase: 'playing',
           pendingDrawPlayerId: null,
+          pendingRevengeDraws: 0,
           lastAction: action,
         }, action.playerId);
         return {
           handled: true,
-          state: ctx.startPenaltyDraw(baseState, nextPlayerId, 4, afterPenaltyNextIdx, action.playerId),
+          state: ctx.startPenaltyDraw(
+            baseState,
+            nextPlayerId,
+            4 + revengeBonus,
+            afterPenaltyNextIdx,
+            action.playerId,
+          ),
         };
       }
 

--- a/packages/shared/src/rules/rules/draw-until-playable.ts
+++ b/packages/shared/src/rules/rules/draw-until-playable.ts
@@ -2,6 +2,7 @@ import type { HouseRulePlugin } from '../house-rule-types.js';
 import type { GameState, GameAction } from '../../types/game.js';
 import type { RuleContext, PreCheckResult } from '../house-rule-types.js';
 import { hasPendingDrawObligation, hasPlayableCard } from '../house-rule-helpers.js';
+import { hasCardsAvailable, isStuckAtHandLimit } from '../game-engine.js';
 
 export const drawUntilPlayable: HouseRulePlugin = {
   meta: {
@@ -17,6 +18,9 @@ export const drawUntilPlayable: HouseRulePlugin = {
       if (state.phase !== 'playing') return { handled: false };
       const player = state.players[state.currentPlayerIndex];
       if (player?.id !== action.playerId) return { handled: false };
+      // A one-card discard pile and two empty side decks cannot yield a card.
+      // Reject the no-op draw so PASS can advance this otherwise deadlocked turn.
+      if (!hasCardsAvailable(state)) return { handled: true, state };
       const topCard = state.discardPile[state.discardPile.length - 1];
       if (topCard && state.currentColor && hasPlayableCard(player.hand, topCard, state.currentColor, ctx.canPlayCard)) {
         return { handled: true, state };
@@ -27,8 +31,13 @@ export const drawUntilPlayable: HouseRulePlugin = {
     if (state.phase !== 'playing') return { handled: false };
     const player = state.players[state.currentPlayerIndex];
     if (player?.id !== action.playerId) return { handled: false };
+    if (!hasCardsAvailable(state)) return { handled: false };
     const topCard = state.discardPile[state.discardPile.length - 1];
     if (topCard && state.currentColor && !hasPlayableCard(player.hand, topCard, state.currentColor, ctx.canPlayCard)) {
+      // Normally "nothing playable" means keep drawing, so PASS is rejected —
+      // but when the hand limit blocks drawing, defer to the base engine,
+      // which allows PASS in exactly that stuck situation.
+      if (isStuckAtHandLimit(state)) return { handled: false };
       return { handled: true, state };
     }
     return { handled: false };

--- a/packages/shared/src/rules/rules/finish-restrictions.ts
+++ b/packages/shared/src/rules/rules/finish-restrictions.ts
@@ -13,7 +13,8 @@ export const finishRestrictions: HouseRulePlugin = {
   preCheck: (state: GameState, action: GameAction, ctx: RuleContext): PreCheckResult => {
     if (action.type !== 'PLAY_CARD') return { handled: false };
     const player = state.players.find(p => p.id === action.playerId);
-    const card = player?.hand.find(c => c.id === action.cardId);
+    if (!player) return { handled: false };
+    const card = player.hand.find(c => c.id === action.cardId);
     if (!card) return { handled: false };
     const hr = state.settings.houseRules;
     const isLast = ctx.isLastCard(state, action.playerId, action.cardId);
@@ -25,9 +26,20 @@ export const finishRestrictions: HouseRulePlugin = {
       if (!isCurrentPlayer || state.drawStack > 0) {
         return { handled: true, state };
       }
+      const penalized = ctx.drawCardsFromDeck(state, action.playerId, 1);
+      const penalizedPlayer = penalized.players.find(p => p.id === action.playerId);
+      if ((penalizedPlayer?.hand.length ?? player.hand.length) === player.hand.length) {
+        // The prohibited last card stays in hand. If no penalty card exists,
+        // forfeit this turn instead of reporting a state-changing no-op that
+        // can be selected forever by policy or timeout play.
+        return {
+          handled: true,
+          state: ctx.applyAction(state, { type: 'PASS', playerId: action.playerId }),
+        };
+      }
       return {
         handled: true,
-        state: ctx.drawCardsFromDeck(state, action.playerId, 1),
+        state: penalized,
       };
     }
     return { handled: false };

--- a/packages/shared/src/rules/rules/no-challenge-wild-four.ts
+++ b/packages/shared/src/rules/rules/no-challenge-wild-four.ts
@@ -33,6 +33,7 @@ export const noChallengeWildFour: HouseRulePlugin = {
         penaltyPlayerIndex,
         afterColor.direction,
       );
+      const revengeBonus = afterColor.pendingRevengeDraws ?? 0;
 
       return {
         handled: true,
@@ -41,9 +42,10 @@ export const noChallengeWildFour: HouseRulePlugin = {
             ...afterColor,
             phase: 'playing',
             pendingDrawPlayerId: null,
+            pendingRevengeDraws: 0,
           },
           penaltyPlayerId,
-          4,
+          4 + revengeBonus,
           nextPlayerIndex,
           wd4Player.id,
         ),

--- a/packages/shared/src/rules/rules/revenge-mode.ts
+++ b/packages/shared/src/rules/rules/revenge-mode.ts
@@ -13,17 +13,27 @@ export const revengeMode: HouseRulePlugin = {
   postProcess: (before: GameState, after: GameState, action: GameAction, ctx: RuleContext): GameState => {
     if (action.type !== 'PLAY_CARD') return after;
     if (after === before) return after;
+    if (after.phase === 'round_end' || after.phase === 'game_over') return after;
     const playedCard = before.players[before.currentPlayerIndex]?.hand.find(c => c.id === action.cardId);
     if (!playedCard || (playedCard.type !== 'draw_two' && playedCard.type !== 'wild_draw_four')) return after;
     const prevTopCard = before.discardPile[before.discardPile.length - 1];
     if (!prevTopCard || (prevTopCard.type !== 'draw_two' && prevTopCard.type !== 'wild_draw_four')) return after;
+
+    const bonus = ctx.getCardDrawPenalty(playedCard);
 
     if (playedCard.type === 'draw_two') {
       const victimIdx = ctx.getNextAliveIndex(before.players, before.currentPlayerIndex, before.direction);
       const victimId = before.players[victimIdx]!.id;
       return ctx.startPenaltyDraw(after, victimId, 2, after.pendingPenaltyNextPlayerIndex ?? after.currentPlayerIndex);
     } else {
-      return { ...after, drawStack: after.drawStack + 4 };
+      // WD4 does not have a final penalty target until accept/challenge (or a
+      // challenge-bypass/deflection rule) resolves. Keep this conditional
+      // bonus separate from drawStack so it cannot affect normal-turn
+      // legality.
+      return {
+        ...after,
+        pendingRevengeDraws: (after.pendingRevengeDraws ?? 0) + bonus,
+      };
     }
   },
 };

--- a/packages/shared/src/rules/rules/stacking.ts
+++ b/packages/shared/src/rules/rules/stacking.ts
@@ -30,22 +30,19 @@ export const stacking: HouseRulePlugin = {
         (hr.crossStack && (card.type === 'draw_two' || card.type === 'wild_draw_four'));
       if (!canStack) return { handled: false };
 
+      // A counter-stacked WD4 must declare its color atomically. Moving to
+      // choosing_color here without first removing the card lets CHOOSE_COLOR
+      // return to the exact same challenge and creates a repeatable no-op.
       if (card.type === 'wild_draw_four' && !action.chosenColor) {
-        return {
-          handled: true,
-          state: {
-            ...state,
-            phase: 'choosing_color',
-            currentPlayerIndex: playerIdx,
-          },
-        };
+        return { handled: true, state };
       }
 
       const baseState: GameState = {
         ...state,
         phase: 'playing',
         pendingDrawPlayerId: null,
-        drawStack: 4,
+        drawStack: 4 + (state.pendingRevengeDraws ?? 0),
+        pendingRevengeDraws: 0,
         currentPlayerIndex: playerIdx,
       };
       return { handled: true, state: ctx.putAttackCardOnStack(baseState, action, card, ctx.getCardDrawPenalty(card)) };

--- a/packages/shared/src/rules/setup.ts
+++ b/packages/shared/src/rules/setup.ts
@@ -133,7 +133,8 @@ export function initializeGame(
 
   const playerIds = playerData.map(p => p.id);
   const { hands, remainingDeck: deckAfterDeal } = dealCards(deck, playerIds, INITIAL_HAND_SIZE);
-  const skipWild = houseRules ? !houseRules.wildFirstTurn : false;
+  const effectiveHouseRules = houseRules ?? DEFAULT_HOUSE_RULES;
+  const skipWild = !effectiveHouseRules.wildFirstTurn;
   const { topCard, remainingDeck: deckAfterDiscard, effect } = handleFirstDiscard(deckAfterDeal, skipWild);
 
   const players: Player[] = playerData.map((p, i) => ({
@@ -173,7 +174,7 @@ export function initializeGame(
     settings: {
       turnTimeLimit: DEFAULT_TURN_TIME_LIMIT as 30,
       targetScore: DEFAULT_TARGET_SCORE as 1000,
-      houseRules: houseRules ?? DEFAULT_HOUSE_RULES,
+      houseRules: effectiveHouseRules,
       allowSpectators: true,
       spectatorMode: 'hidden' as const,
     },

--- a/packages/shared/src/types/game.ts
+++ b/packages/shared/src/types/game.ts
@@ -61,6 +61,13 @@ export interface GameState {
   pendingPenaltyNextPlayerIndex?: number | null;
   pendingPenaltySourcePlayerId?: string | null;
   pendingPenaltyQueue?: PendingPenaltyDraw[];
+  /**
+   * Extra Wild Draw Four damage produced by revengeMode while the challenge
+   * flow is unresolved. This must not share drawStack: drawStack participates
+   * in stacking/deflection legality, whereas this value is only consumed when
+   * the WD4 penalty target is known.
+   */
+  pendingRevengeDraws?: number;
   lastAction: GameAction | null;
   roundNumber: number;
   winnerId: string | null;

--- a/packages/shared/tests/autopilot-strategy.test.ts
+++ b/packages/shared/tests/autopilot-strategy.test.ts
@@ -3,6 +3,52 @@ import { DEFAULT_HOUSE_RULES, chooseAutopilotAction, chooseAutopilotJumpInAction
 import { makeCard, makeState } from './helpers/test-utils';
 
 describe('chooseAutopilotAction after drawing', () => {
+  it('draws from the populated side instead of recycling an empty side', () => {
+    const state = makeState({
+      currentPlayerIndex: 0,
+      currentColor: 'red',
+      deckLeft: [makeCard('number', 'blue', { value: 9, id: 'physical_draw' })],
+      deckRight: [],
+      deckLeftInitialCount: 1,
+      deckRightInitialCount: 1,
+      discardPile: [
+        makeCard('number', 'green', { value: 0, id: 'recycled_zero' }),
+        makeCard('number', 'red', { value: 0, id: 'top_zero' }),
+      ],
+      players: [
+        {
+          id: 'p1',
+          name: 'Alice',
+          hand: [makeCard('number', 'yellow', { value: 4, id: 'yellow_4' })],
+          score: 0,
+          connected: true,
+          autopilot: true,
+          calledUno: false,
+        },
+        {
+          id: 'p2',
+          name: 'Bob',
+          hand: [makeCard('number', 'blue', { value: 4, id: 'blue_4' })],
+          score: 0,
+          connected: true,
+          autopilot: false,
+          calledUno: false,
+        },
+      ],
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        allowSpectators: true,
+        spectatorMode: 'hidden',
+        houseRules: { ...DEFAULT_HOUSE_RULES, zeroRotateHands: true },
+      },
+    });
+
+    expect(chooseAutopilotAction(state, 'p1')).toEqual([
+      { type: 'DRAW_CARD', playerId: 'p1', side: 'left' },
+    ]);
+  });
+
   it('plays a playable drawn card instead of passing', () => {
     const drawn = makeCard('number', 'red', { value: 9, id: 'drawn_red_9' });
     const state = makeState({
@@ -15,6 +61,42 @@ describe('chooseAutopilotAction after drawing', () => {
 
     expect(chooseAutopilotAction(state, 'p1')).toEqual([
       { type: 'PLAY_CARD', playerId: 'p1', cardId: 'drawn_red_9' },
+    ]);
+  });
+
+  it('may play the final recycled card before recurrence is observed', () => {
+    const recycledReverse = makeCard('reverse', 'blue', { id: 'recycled_reverse' });
+    const state = makeState({
+      players: [
+        {
+          id: 'p1',
+          name: 'Alice',
+          hand: [makeCard('number', 'green', { value: 2, id: 'other' }), recycledReverse],
+          score: 0,
+          connected: true,
+          autopilot: true,
+          calledUno: false,
+        },
+        { id: 'p2', name: 'Bob', hand: [], score: 0, connected: true, autopilot: false, calledUno: false },
+      ],
+      currentColor: 'red',
+      deckLeft: [],
+      deckRight: [],
+      discardPile: [makeCard('reverse', 'red', { id: 'top_reverse' })],
+      lastAction: { type: 'DRAW_CARD', playerId: 'p1', side: 'left' },
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        houseRules: {
+          ...DEFAULT_HOUSE_RULES,
+          drawUntilPlayable: true,
+          forcedPlayAfterDraw: true,
+        },
+      },
+    });
+
+    expect(chooseAutopilotAction(state, 'p1')).toEqual([
+      { type: 'PLAY_CARD', playerId: 'p1', cardId: 'recycled_reverse' },
     ]);
   });
 

--- a/packages/shared/tests/bot/automation-cycle-guard.test.ts
+++ b/packages/shared/tests/bot/automation-cycle-guard.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_HOUSE_RULES } from '../../src/types/house-rules.js';
+import { chooseAutopilotAction } from '../../src/rules/autopilot-strategy.js';
+import { AutomationCycleGuard } from '../../src/rules/bot/automation-cycle-guard.js';
+import { enumerateLegalActionPlans } from '../../src/rules/bot/legal-action-plans.js';
+import { applyActionWithHouseRules } from '../../src/rules/house-rules-engine.js';
+import { makeCard, makeState } from '../helpers/test-utils.js';
+
+function recycledActionCardState() {
+  const recycledSkip = makeCard('skip', 'red', { id: 'recycled-skip' });
+  return {
+    recycledSkip,
+    state: makeState({
+      currentPlayerIndex: 0,
+      currentColor: 'red',
+      deckLeft: [],
+      deckRight: [],
+      discardPile: [makeCard('number', 'red', { value: 5, id: 'top-red-5' })],
+      lastAction: { type: 'DRAW_CARD', playerId: 'p1', side: 'left' },
+      players: [
+        {
+          id: 'p1',
+          name: 'Alice',
+          hand: [
+            recycledSkip,
+            makeCard('number', 'red', { value: 7, id: 'red-7' }),
+            makeCard('number', 'green', { value: 2, id: 'green-2' }),
+          ],
+          score: 0,
+          connected: true,
+          autopilot: true,
+          calledUno: false,
+        },
+        {
+          id: 'p2',
+          name: 'Bob',
+          hand: [makeCard('number', 'yellow', { value: 4, id: 'yellow-4' })],
+          score: 0,
+          connected: true,
+          autopilot: false,
+          calledUno: false,
+        },
+      ],
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        allowSpectators: true,
+        spectatorMode: 'hidden',
+        houseRules: {
+          ...DEFAULT_HOUSE_RULES,
+          drawUntilPlayable: true,
+        },
+      },
+    }),
+  };
+}
+
+describe('AutomationCycleGuard', () => {
+  it('allows two identical tactics and avoids only the demonstrated third transition', () => {
+    const { state, recycledSkip } = recycledActionCardState();
+    const guard = new AutomationCycleGuard();
+    const preferred = [{
+      type: 'PLAY_CARD' as const,
+      playerId: 'p1',
+      cardId: recycledSkip.id,
+    }];
+    const after = applyActionWithHouseRules(state, preferred[0]!);
+
+    expect(after).not.toBe(state);
+    expect(guard.shouldAvoidPlan(state, preferred)).toBe(false);
+    expect(chooseAutopilotAction(state, 'p1', guard)).toEqual(preferred);
+
+    guard.recordTransition(state, preferred, after);
+    expect(guard.shouldAvoidPlan(state, preferred)).toBe(false);
+    expect(chooseAutopilotAction(state, 'p1', guard)).toEqual(preferred);
+
+    guard.recordTransition(state, preferred, after);
+    expect(guard.shouldAvoidPlan(state, preferred)).toBe(true);
+
+    const legal = enumerateLegalActionPlans(state, 'p1', { kind: 'turn' });
+    const filtered = guard.filterLegalActions(state, legal);
+    expect(filtered.plans).not.toContainEqual(preferred);
+    expect(filtered.plans).toContainEqual([{
+      type: 'PLAY_CARD',
+      playerId: 'p1',
+      cardId: state.players[0]!.hand[1]!.id,
+    }]);
+    expect(filtered.plans).toContainEqual([{ type: 'PASS', playerId: 'p1' }]);
+
+    const guardedChoice = chooseAutopilotAction(state, 'p1', guard);
+    expect(guardedChoice).not.toEqual(preferred);
+    expect(guardedChoice.length).toBeGreaterThan(0);
+
+    // The rules engine and therefore a human player retain the original move.
+    expect(applyActionWithHouseRules(state, preferred[0]!)).not.toBe(state);
+  });
+
+  it('avoids convergence to a repeated after-state from a different before-state', () => {
+    const { state, recycledSkip } = recycledActionCardState();
+    const guard = new AutomationCycleGuard();
+    const plan = [{
+      type: 'PLAY_CARD' as const,
+      playerId: 'p1',
+      cardId: recycledSkip.id,
+    }];
+    const secondBefore = {
+      ...state,
+      lastAction: { type: 'DRAW_CARD' as const, playerId: 'p1', side: 'right' as const },
+    };
+    const firstAfter = applyActionWithHouseRules(state, plan[0]!);
+    const secondAfter = applyActionWithHouseRules(secondBefore, plan[0]!);
+    expect(firstAfter).toEqual(secondAfter);
+
+    // Neither exact edge repeats: two distinct predecessor states converge on
+    // one destination, matching the production low-deck failure geometry.
+    guard.recordTransition(state, plan, firstAfter);
+    expect(guard.shouldAvoidPlan(secondBefore, plan)).toBe(false);
+    guard.recordTransition(secondBefore, plan, secondAfter);
+
+    const thirdBefore = {
+      ...state,
+      lastAction: { type: 'PASS' as const, playerId: 'p2' },
+    };
+    expect(applyActionWithHouseRules(thirdBefore, plan[0]!)).toEqual(firstAfter);
+    expect(guard.shouldAvoidPlan(thirdBefore, plan)).toBe(true);
+    expect(chooseAutopilotAction(thirdBefore, 'p1', guard)).not.toEqual(plan);
+
+    const differentAfterState = {
+      ...thirdBefore,
+      players: thirdBefore.players.map((player, index) => (
+        index === 1 ? { ...player, calledUno: true } : player
+      )),
+    };
+    expect(guard.shouldAvoidPlan(differentAfterState, plan)).toBe(false);
+    expect(chooseAutopilotAction(differentAfterState, 'p1', guard)).toEqual(plan);
+  });
+
+  it('resets bounded history when the round number changes', () => {
+    const { state, recycledSkip } = recycledActionCardState();
+    const guard = new AutomationCycleGuard();
+    const plan = [{
+      type: 'PLAY_CARD' as const,
+      playerId: 'p1',
+      cardId: recycledSkip.id,
+    }];
+    const after = applyActionWithHouseRules(state, plan[0]!);
+    guard.recordTransition(state, plan, after);
+    guard.recordTransition(state, plan, after);
+    expect(guard.shouldAvoidPlan(state, plan)).toBe(true);
+
+    const nextRoundState = { ...state, roundNumber: state.roundNumber + 1 };
+    expect(guard.shouldAvoidPlan(nextRoundState, plan)).toBe(false);
+  });
+});

--- a/packages/shared/tests/bot/bot-improvements.test.ts
+++ b/packages/shared/tests/bot/bot-improvements.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import type { Card, Color } from '../../src/types/card';
 import type { GameState, Player } from '../../src/types/game';
 import type { BotConfig } from '../../src/types/bot';
@@ -28,6 +28,7 @@ function makePlayer(id: string, hand: Card[], botConfig?: BotConfig, extra: Part
 
 const hardBot: BotConfig = { difficulty: 'hard', personality: 'balanced' };
 const normalBot: BotConfig = { difficulty: 'normal', personality: 'balanced' };
+const chaoticHardBot: BotConfig = { difficulty: 'hard', personality: 'chaotic' };
 
 describe('WD4 legality self-check', () => {
   it('normal bot avoids a challengeable WD4 when a safe alternative exists', () => {
@@ -44,15 +45,15 @@ describe('WD4 legality self-check', () => {
       currentPlayerIndex: 0,
     });
 
-    // Normal bots have small score noise/mistake rates — sample repeatedly
-    let wd4Plays = 0;
-    for (let i = 0; i < 60; i++) {
+    // Keep noise and the mistake roll deterministic so this regression does
+    // not occasionally fail at the edge of a probabilistic sample.
+    const random = vi.spyOn(Math, 'random').mockReturnValue(0.99);
+    try {
       const actions = chooseBotAction(state, 'bot');
-      if (actions[0]?.type === 'PLAY_CARD' && actions[0].cardId === 'wd4') wd4Plays++;
+      expect(actions[0]).toMatchObject({ type: 'PLAY_CARD', cardId: 'r3' });
+    } finally {
+      random.mockRestore();
     }
-    // Without the self-check the WD4 (actionValue 10) wins most of the time;
-    // with the -20 risk penalty it should be rare (noise-only).
-    expect(wd4Plays).toBeLessThan(10);
   });
 
   it('hard bot plays WD4 freely when it holds no card of the current color', () => {
@@ -70,6 +71,73 @@ describe('WD4 legality self-check', () => {
     });
     const actions = chooseBotAction(state, 'bot');
     expect(actions[0]).toMatchObject({ type: 'PLAY_CARD', cardId: 'wd4' });
+  });
+
+  it('hard chaotic bot may use a challengeable WD4 before recurrence is observed', () => {
+    const wd4a = makeCard('wild_draw_four', null, { id: 'wd4-a' });
+    const wd4b = makeCard('wild_draw_four', null, { id: 'wd4-b' });
+    const safeRed = n('safe-red', 'red', 6);
+    const state = makeState({
+      players: [
+        makePlayer('bot', [
+          wd4a, safeRed, wd4b, n('red-9', 'red', 9),
+          n('yellow-2', 'yellow', 2), n('green-4', 'green', 4),
+        ], chaoticHardBot),
+        makePlayer('human-close', [n('human-green', 'green', 5)]),
+        makePlayer('ally', [
+          n('ally-yellow-6a', 'yellow', 6), n('ally-yellow-4a', 'yellow', 4),
+          n('ally-green-8', 'green', 8), n('ally-yellow-4b', 'yellow', 4),
+          n('ally-red-0', 'red', 0), n('ally-yellow-8', 'yellow', 8),
+          n('ally-yellow-6b', 'yellow', 6), n('ally-blue-9', 'blue', 9),
+          n('ally-red-1', 'red', 1), n('ally-red-8', 'red', 8),
+          n('ally-blue-5', 'blue', 5),
+        ], normalBot),
+        makePlayer('human-last', [n('human-red', 'red', 8)]),
+      ],
+      deckLeft: [],
+      deckRight: [],
+      discardPile: [n('top', 'red', 7)],
+      currentColor: 'red',
+      currentPlayerIndex: 0,
+    });
+
+    expect(chooseBotAction(state, 'bot')[0]).toMatchObject({
+      type: 'PLAY_CARD',
+      cardId: wd4a.id,
+    });
+  });
+
+  it('hard bot may still play a challengeable WD4 when cards remain to resolve the risk', () => {
+    const wd4a = makeCard('wild_draw_four', null, { id: 'wd4-a' });
+    const wd4b = makeCard('wild_draw_four', null, { id: 'wd4-b' });
+    const state = makeState({
+      players: [
+        makePlayer('bot', [
+          wd4a, n('safe-red', 'red', 6), wd4b, n('red-9', 'red', 9),
+          n('yellow-2', 'yellow', 2), n('green-4', 'green', 4),
+        ], chaoticHardBot),
+        makePlayer('human-close', [n('human-green', 'green', 5)]),
+        makePlayer('ally', [
+          n('ally-yellow-6a', 'yellow', 6), n('ally-yellow-4a', 'yellow', 4),
+          n('ally-green-8', 'green', 8), n('ally-yellow-4b', 'yellow', 4),
+          n('ally-red-0', 'red', 0), n('ally-yellow-8', 'yellow', 8),
+          n('ally-yellow-6b', 'yellow', 6), n('ally-blue-9', 'blue', 9),
+          n('ally-red-1', 'red', 1), n('ally-red-8', 'red', 8),
+          n('ally-blue-5', 'blue', 5),
+        ], normalBot),
+        makePlayer('human-last', [n('human-red', 'red', 8)]),
+      ],
+      discardPile: [n('top', 'red', 7)],
+      currentColor: 'red',
+      currentPlayerIndex: 0,
+    });
+
+    // This policy guard is specifically a no-progress safeguard; the normal
+    // score-based bluff/risk trade-off remains available while cards exist.
+    expect(chooseBotAction(state, 'bot')[0]).toMatchObject({
+      type: 'PLAY_CARD',
+      cardId: wd4a.id,
+    });
   });
 });
 

--- a/packages/shared/tests/bot/bot-strategy.test.ts
+++ b/packages/shared/tests/bot/bot-strategy.test.ts
@@ -430,4 +430,73 @@ describe('chooseBotAction — edge cases', () => {
     expect(actions.length).toBe(1);
     expect(actions[0]).toMatchObject({ type: 'PASS', playerId: 'bot' });
   });
+
+  it('may play the final recycled card before recurrence is observed', () => {
+    const recycledReverse = makeCard('reverse', 'blue', { id: 'recycled_reverse' });
+    const state = makeState({
+      currentPlayerIndex: 0,
+      currentColor: 'red',
+      deckLeft: [],
+      deckRight: [],
+      discardPile: [makeCard('reverse', 'red', { id: 'top_reverse' })],
+      lastAction: { type: 'DRAW_CARD', playerId: 'bot', side: 'left' },
+      players: [
+        makePlayer('bot', 'Bot', [
+          makeNumberCard('other', 'green', 2),
+          recycledReverse,
+        ], hardBot),
+        makePlayer('p2', 'Human', [makeNumberCard('p2', 'yellow', 4)]),
+      ],
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        houseRules: {
+          ...DEFAULT_HOUSE_RULES,
+          drawUntilPlayable: true,
+          forcedPlayAfterDraw: true,
+        },
+      },
+    });
+
+    expect(chooseBotAction(state, 'bot')).toEqual([
+      { type: 'PLAY_CARD', playerId: 'bot', cardId: 'recycled_reverse' },
+    ]);
+  });
+
+  it('keeps the bot draw-side preference separate from cycle protection', () => {
+    const state = makeState({
+      currentPlayerIndex: 0,
+      currentColor: 'red',
+      deckLeft: [makeNumberCard('physical-draw', 'blue', 9)],
+      deckRight: [],
+      deckLeftInitialCount: 1,
+      deckRightInitialCount: 1,
+      discardPile: [
+        makeNumberCard('recycled-zero', 'green', 0),
+        makeNumberCard('top-zero', 'red', 0),
+      ],
+      players: [
+        makePlayer('bot', 'Bot', [makeNumberCard('bot-card', 'yellow', 4)], {
+          difficulty: 'novice',
+          personality: 'balanced',
+        }),
+        makePlayer('p2', 'Human', [makeNumberCard('p2-card', 'blue', 6)]),
+      ],
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        houseRules: { ...DEFAULT_HOUSE_RULES, zeroRotateHands: true },
+      },
+    });
+
+    const plan = chooseBotAction(state, 'bot');
+    expect(plan).toHaveLength(1);
+    expect(plan[0]).toMatchObject({
+      type: 'DRAW_CARD',
+      playerId: 'bot',
+    });
+    expect(['left', 'right']).toContain(
+      plan[0]?.type === 'DRAW_CARD' ? plan[0].side : null,
+    );
+  });
 });

--- a/packages/shared/tests/helpers/test-utils.ts
+++ b/packages/shared/tests/helpers/test-utils.ts
@@ -43,6 +43,7 @@ export function makeState(overrides: Partial<GameState> = {}): GameState {
     pendingPenaltyNextPlayerIndex: null,
     pendingPenaltySourcePlayerId: null,
     pendingPenaltyQueue: [],
+    pendingRevengeDraws: 0,
     lastAction: null,
     roundNumber: 1,
     winnerId: null,

--- a/packages/shared/tests/house-rules-batch1.test.ts
+++ b/packages/shared/tests/house-rules-batch1.test.ts
@@ -129,9 +129,442 @@ describe('revengeMode', () => {
       },
     });
     const next = applyActionWithHouseRules(state, { type: 'PLAY_CARD', playerId: 'p1', cardId: 'wd4_play', chosenColor: 'blue' });
-    // wild_draw_four goes to choosing_color phase; revengeMode adds 4 to drawStack
-    expect(next.drawStack).toBe(4);
+    // The revenge bonus waits for the WD4 challenge flow to determine who pays.
+    expect(next.drawStack).toBe(0);
+    expect(next.pendingRevengeDraws).toBe(4);
     expect(next).not.toStrictEqual(state);
+  });
+
+  it('consumes the revenge WD4 bonus during accept without using drawStack', () => {
+    const wd4 = makeCard('wild_draw_four', null, { id: 'wd4_play' });
+    const deck = Array.from(
+      { length: 12 },
+      (_, i) => makeCard('number', 'green', { value: i % 10, id: `revenge-deck-${i}` }),
+    );
+    const state = makeState({
+      players: [
+        {
+          id: 'p1', name: 'Alice',
+          hand: [wd4, makeCard('number', 'red', { value: 1, id: 'extra' })],
+          score: 0, connected: true, calledUno: false,
+        },
+        { id: 'p2', name: 'Bob', hand: [makeCard('number', 'blue', { value: 1, id: 'p2c' })], score: 0, connected: true, calledUno: false },
+        { id: 'p3', name: 'Carol', hand: [makeCard('number', 'green', { value: 2, id: 'p3c' })], score: 0, connected: true, calledUno: false },
+      ],
+      discardPile: [makeCard('draw_two', 'red', { id: 'prev_d2' })],
+      currentColor: 'red',
+      deckLeft: deck,
+      deckRight: [],
+      deckLeftInitialCount: deck.length,
+      deckRightInitialCount: 0,
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        houseRules: { ...DEFAULT_HOUSE_RULES, revengeMode: true },
+      },
+    });
+
+    const played = applyActionWithHouseRules(state, {
+      type: 'PLAY_CARD', playerId: 'p1', cardId: 'wd4_play',
+    });
+    expect(played.drawStack).toBe(0);
+    expect(played.pendingRevengeDraws).toBe(4);
+    const colored = applyActionWithHouseRules(played, {
+      type: 'CHOOSE_COLOR', playerId: 'p1', color: 'blue',
+    });
+    const accepted = applyActionWithHouseRules(colored, { type: 'ACCEPT', playerId: 'p2' });
+
+    expect(accepted.drawStack).toBe(0);
+    expect(accepted.pendingRevengeDraws).toBe(0);
+    expect(accepted.pendingPenaltyDraws).toBe(8);
+    const paid = drawPendingPenalty(accepted);
+    expect(paid.drawStack).toBe(0);
+    expect(paid.players[1]!.hand).toHaveLength(9);
+    expect(paid.currentPlayerIndex).toBe(2);
+  });
+
+  it('applies the revenge WD4 bonus when challenges are disabled', () => {
+    const wd4 = makeCard('wild_draw_four', null, { id: 'wd4-no-challenge' });
+    const state = makeState({
+      players: [
+        {
+          id: 'p1', name: 'Alice',
+          hand: [wd4, makeCard('number', 'red', { value: 1, id: 'p1-extra' })],
+          score: 0, connected: true, calledUno: false,
+        },
+        { id: 'p2', name: 'Bob', hand: [makeCard('number', 'blue', { value: 1, id: 'p2-card' })], score: 0, connected: true, calledUno: false },
+        { id: 'p3', name: 'Carol', hand: [makeCard('number', 'green', { value: 2, id: 'p3-card' })], score: 0, connected: true, calledUno: false },
+      ],
+      discardPile: [makeCard('draw_two', 'red', { id: 'previous-attack' })],
+      currentColor: 'red',
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        houseRules: {
+          ...DEFAULT_HOUSE_RULES,
+          revengeMode: true,
+          noChallengeWildFour: true,
+        },
+      },
+    });
+
+    const played = applyActionWithHouseRules(state, {
+      type: 'PLAY_CARD', playerId: 'p1', cardId: wd4.id,
+    });
+    const colored = applyActionWithHouseRules(played, {
+      type: 'CHOOSE_COLOR', playerId: 'p1', color: 'blue',
+    });
+
+    expect(colored.phase).toBe('playing');
+    expect(colored.drawStack).toBe(0);
+    expect(colored.pendingRevengeDraws).toBe(0);
+    expect(colored.pendingPenaltyDraws).toBe(8);
+    expect(colored.players[colored.currentPlayerIndex]!.id).toBe('p2');
+  });
+
+  it('applies the revenge WD4 bonus when a reverse deflects the challenge', () => {
+    const wd4 = makeCard('wild_draw_four', null, { id: 'wd4-deflect' });
+    const reverse = makeCard('reverse', 'blue', { id: 'reverse-deflect' });
+    const state = makeState({
+      players: [
+        {
+          id: 'p1', name: 'Alice',
+          hand: [wd4, makeCard('number', 'red', { value: 1, id: 'p1-extra' })],
+          score: 0, connected: true, calledUno: false,
+        },
+        {
+          id: 'p2', name: 'Bob',
+          hand: [reverse, makeCard('number', 'yellow', { value: 1, id: 'p2-extra' })],
+          score: 0, connected: true, calledUno: false,
+        },
+        { id: 'p3', name: 'Carol', hand: [makeCard('number', 'green', { value: 2, id: 'p3-card' })], score: 0, connected: true, calledUno: false },
+      ],
+      discardPile: [makeCard('draw_two', 'red', { id: 'previous-attack' })],
+      currentColor: 'red',
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        houseRules: {
+          ...DEFAULT_HOUSE_RULES,
+          revengeMode: true,
+          reverseDeflectDrawFour: true,
+        },
+      },
+    });
+
+    const played = applyActionWithHouseRules(state, {
+      type: 'PLAY_CARD', playerId: 'p1', cardId: wd4.id,
+    });
+    const colored = applyActionWithHouseRules(played, {
+      type: 'CHOOSE_COLOR', playerId: 'p1', color: 'blue',
+    });
+    const deflected = applyActionWithHouseRules(colored, {
+      type: 'PLAY_CARD', playerId: 'p2', cardId: reverse.id,
+    });
+
+    expect(deflected.phase).toBe('playing');
+    expect(deflected.drawStack).toBe(0);
+    expect(deflected.pendingRevengeDraws).toBe(0);
+    expect(deflected.pendingPenaltyDraws).toBe(8);
+    expect(deflected.players[deflected.currentPlayerIndex]!.id).toBe('p1');
+    expect(deflected.discardPile.at(-1)?.type).toBe('reverse');
+  });
+
+  it('applies the revenge WD4 bonus when a skip deflects the challenge', () => {
+    const wd4 = makeCard('wild_draw_four', null, { id: 'wd4-skip-deflect' });
+    const skip = makeCard('skip', 'blue', { id: 'skip-deflect' });
+    const state = makeState({
+      players: [
+        {
+          id: 'p1', name: 'Alice',
+          hand: [wd4, makeCard('number', 'red', { value: 1, id: 'p1-extra' })],
+          score: 0, connected: true, calledUno: false,
+        },
+        {
+          id: 'p2', name: 'Bob',
+          hand: [skip, makeCard('number', 'yellow', { value: 1, id: 'p2-extra' })],
+          score: 0, connected: true, calledUno: false,
+        },
+        { id: 'p3', name: 'Carol', hand: [makeCard('number', 'green', { value: 2, id: 'p3-card' })], score: 0, connected: true, calledUno: false },
+      ],
+      discardPile: [makeCard('draw_two', 'red', { id: 'previous-attack' })],
+      currentColor: 'red',
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        houseRules: {
+          ...DEFAULT_HOUSE_RULES,
+          revengeMode: true,
+          skipDeflect: true,
+        },
+      },
+    });
+
+    const played = applyActionWithHouseRules(state, {
+      type: 'PLAY_CARD', playerId: 'p1', cardId: wd4.id,
+    });
+    const colored = applyActionWithHouseRules(played, {
+      type: 'CHOOSE_COLOR', playerId: 'p1', color: 'blue',
+    });
+    const deflected = applyActionWithHouseRules(colored, {
+      type: 'PLAY_CARD', playerId: 'p2', cardId: skip.id,
+    });
+
+    expect(deflected.phase).toBe('playing');
+    expect(deflected.drawStack).toBe(0);
+    expect(deflected.pendingRevengeDraws).toBe(0);
+    expect(deflected.pendingPenaltyDraws).toBe(8);
+    expect(deflected.players[deflected.currentPlayerIndex]!.id).toBe('p3');
+    expect(deflected.pendingPenaltyNextPlayerIndex).toBe(0);
+  });
+
+  it('adds the revenge bonus to a successful challenge penalty', () => {
+    const wd4 = makeCard('wild_draw_four', null, { id: 'wd4-illegal' });
+    const state = makeState({
+      players: [
+        {
+          id: 'p1', name: 'Alice',
+          hand: [wd4, makeCard('number', 'red', { value: 1, id: 'matching-color' })],
+          score: 0, connected: true, calledUno: false,
+        },
+        { id: 'p2', name: 'Bob', hand: [makeCard('number', 'blue', { value: 1, id: 'p2-card' })], score: 0, connected: true, calledUno: false },
+        { id: 'p3', name: 'Carol', hand: [makeCard('number', 'green', { value: 2, id: 'p3-card' })], score: 0, connected: true, calledUno: false },
+      ],
+      discardPile: [makeCard('draw_two', 'red', { id: 'previous-attack' })],
+      currentColor: 'red',
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        houseRules: { ...DEFAULT_HOUSE_RULES, revengeMode: true },
+      },
+    });
+
+    const played = applyActionWithHouseRules(state, {
+      type: 'PLAY_CARD', playerId: 'p1', cardId: wd4.id,
+    });
+    const colored = applyActionWithHouseRules(played, {
+      type: 'CHOOSE_COLOR', playerId: 'p1', color: 'blue',
+    });
+    const challenged = applyActionWithHouseRules(colored, {
+      type: 'CHALLENGE', playerId: 'p2',
+    });
+
+    expect(challenged.lastAction).toMatchObject({
+      type: 'CHALLENGE',
+      succeeded: true,
+      penaltyPlayerId: 'p1',
+      penaltyCount: 8,
+    });
+    expect(challenged.pendingPenaltyDraws).toBe(8);
+    expect(challenged.pendingRevengeDraws).toBe(0);
+    expect(challenged.players[challenged.currentPlayerIndex]!.id).toBe('p1');
+  });
+
+  it('adds the revenge bonus to a failed challenge penalty', () => {
+    const wd4 = makeCard('wild_draw_four', null, { id: 'wd4-legal' });
+    const state = makeState({
+      players: [
+        {
+          id: 'p1', name: 'Alice',
+          hand: [wd4, makeCard('number', 'blue', { value: 1, id: 'different-color' })],
+          score: 0, connected: true, calledUno: false,
+        },
+        { id: 'p2', name: 'Bob', hand: [makeCard('number', 'yellow', { value: 1, id: 'p2-card' })], score: 0, connected: true, calledUno: false },
+        { id: 'p3', name: 'Carol', hand: [makeCard('number', 'green', { value: 2, id: 'p3-card' })], score: 0, connected: true, calledUno: false },
+      ],
+      discardPile: [makeCard('draw_two', 'red', { id: 'previous-attack' })],
+      currentColor: 'red',
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        houseRules: { ...DEFAULT_HOUSE_RULES, revengeMode: true },
+      },
+    });
+
+    const played = applyActionWithHouseRules(state, {
+      type: 'PLAY_CARD', playerId: 'p1', cardId: wd4.id,
+    });
+    const colored = applyActionWithHouseRules(played, {
+      type: 'CHOOSE_COLOR', playerId: 'p1', color: 'green',
+    });
+    const challenged = applyActionWithHouseRules(colored, {
+      type: 'CHALLENGE', playerId: 'p2',
+    });
+
+    expect(challenged.lastAction).toMatchObject({
+      type: 'CHALLENGE',
+      succeeded: false,
+      penaltyPlayerId: 'p2',
+      penaltyCount: 10,
+    });
+    expect(challenged.pendingPenaltyDraws).toBe(10);
+    expect(challenged.pendingRevengeDraws).toBe(0);
+    expect(challenged.players[challenged.currentPlayerIndex]!.id).toBe('p2');
+  });
+
+  it('folds an unresolved revenge WD4 bonus into the actual stack when counter-stacking', () => {
+    const firstWd4 = makeCard('wild_draw_four', null, { id: 'wd4-first' });
+    const counterWd4 = makeCard('wild_draw_four', null, { id: 'wd4-counter' });
+    const state = makeState({
+      players: [
+        {
+          id: 'p1', name: 'Alice',
+          hand: [firstWd4, makeCard('number', 'red', { value: 1, id: 'p1-extra' })],
+          score: 0, connected: true, calledUno: false,
+        },
+        {
+          id: 'p2', name: 'Bob',
+          hand: [counterWd4, makeCard('number', 'yellow', { value: 1, id: 'p2-extra' })],
+          score: 0, connected: true, calledUno: false,
+        },
+        { id: 'p3', name: 'Carol', hand: [makeCard('number', 'green', { value: 2, id: 'p3-card' })], score: 0, connected: true, calledUno: false },
+      ],
+      discardPile: [makeCard('draw_two', 'red', { id: 'previous-attack' })],
+      currentColor: 'red',
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        houseRules: {
+          ...DEFAULT_HOUSE_RULES,
+          revengeMode: true,
+          stackDrawFour: true,
+        },
+      },
+    });
+
+    const played = applyActionWithHouseRules(state, {
+      type: 'PLAY_CARD', playerId: 'p1', cardId: firstWd4.id,
+    });
+    const colored = applyActionWithHouseRules(played, {
+      type: 'CHOOSE_COLOR', playerId: 'p1', color: 'blue',
+    });
+    const countered = applyActionWithHouseRules(colored, {
+      type: 'PLAY_CARD',
+      playerId: 'p2',
+      cardId: counterWd4.id,
+      chosenColor: 'green',
+    });
+
+    expect(countered.phase).toBe('playing');
+    expect(countered.pendingRevengeDraws).toBe(0);
+    expect(countered.pendingPenaltyDraws).toBe(0);
+    // Previous WD4 (4) + its revenge bonus (4) + the newly stacked WD4 (4).
+    // Stacking itself does not trigger a second revenge post-process.
+    expect(countered.drawStack).toBe(12);
+    expect(countered.players[countered.currentPlayerIndex]!.id).toBe('p3');
+  });
+
+  it('rejects a counter-stacked WD4 without an inline color', () => {
+    const firstWd4 = makeCard('wild_draw_four', null, { id: 'wd4-first-uncolored' });
+    const counterWd4 = makeCard('wild_draw_four', null, { id: 'wd4-counter-uncolored' });
+    const state = makeState({
+      players: [
+        {
+          id: 'p1', name: 'Alice',
+          hand: [firstWd4, makeCard('number', 'red', { value: 1, id: 'p1-extra-uncolored' })],
+          score: 0, connected: true, calledUno: false,
+        },
+        {
+          id: 'p2', name: 'Bob',
+          hand: [counterWd4, makeCard('number', 'yellow', { value: 1, id: 'p2-extra-uncolored' })],
+          score: 0, connected: true, calledUno: false,
+        },
+        {
+          id: 'p3', name: 'Carol',
+          hand: [makeCard('number', 'green', { value: 2, id: 'p3-card-uncolored' })],
+          score: 0, connected: true, calledUno: false,
+        },
+      ],
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        houseRules: {
+          ...DEFAULT_HOUSE_RULES,
+          stackDrawFour: true,
+        },
+      },
+    });
+    const played = applyActionWithHouseRules(state, {
+      type: 'PLAY_CARD', playerId: 'p1', cardId: firstWd4.id,
+    });
+    const challenged = applyActionWithHouseRules(played, {
+      type: 'CHOOSE_COLOR', playerId: 'p1', color: 'blue',
+    });
+    const rejected = applyActionWithHouseRules(challenged, {
+      type: 'PLAY_CARD',
+      playerId: 'p2',
+      cardId: counterWd4.id,
+    });
+
+    expect(rejected).toBe(challenged);
+    expect(rejected.phase).toBe('challenging');
+    expect(rejected.players[1]!.hand.map(card => card.id)).toContain(counterWd4.id);
+  });
+
+  it('does not create a parallel revenge penalty during draw-two stacking', () => {
+    const drawTwo = makeCard('draw_two', 'red', { id: 'draw-two-counter' });
+    const state = makeState({
+      drawStack: 2,
+      players: [
+        {
+          id: 'p1', name: 'Alice',
+          hand: [drawTwo, makeCard('number', 'red', { value: 1, id: 'p1-extra' })],
+          score: 0, connected: true, calledUno: false,
+        },
+        { id: 'p2', name: 'Bob', hand: [makeCard('number', 'blue', { value: 1, id: 'p2-card' })], score: 0, connected: true, calledUno: false },
+        { id: 'p3', name: 'Carol', hand: [makeCard('number', 'green', { value: 2, id: 'p3-card' })], score: 0, connected: true, calledUno: false },
+      ],
+      discardPile: [makeCard('draw_two', 'red', { id: 'previous-attack' })],
+      currentColor: 'red',
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        houseRules: {
+          ...DEFAULT_HOUSE_RULES,
+          revengeMode: true,
+          stackDrawTwo: true,
+        },
+      },
+    });
+
+    const countered = applyActionWithHouseRules(state, {
+      type: 'PLAY_CARD', playerId: 'p1', cardId: drawTwo.id,
+    });
+
+    expect(countered.drawStack).toBe(4);
+    expect(countered.pendingPenaltyDraws).toBe(0);
+    expect(countered.pendingPenaltyQueue).toHaveLength(0);
+  });
+
+  it('does not leave a revenge obligation after the attack card ends the round', () => {
+    const wd4 = makeCard('wild_draw_four', null, { id: 'winning-wd4' });
+    const state = makeState({
+      players: [
+        {
+          id: 'p1', name: 'Alice', hand: [wd4],
+          score: 0, connected: true, calledUno: false,
+        },
+        { id: 'p2', name: 'Bob', hand: [makeCard('number', 'blue', { value: 1, id: 'p2-card' })], score: 0, connected: true, calledUno: false },
+        { id: 'p3', name: 'Carol', hand: [makeCard('number', 'green', { value: 2, id: 'p3-card' })], score: 0, connected: true, calledUno: false },
+      ],
+      discardPile: [makeCard('draw_two', 'red', { id: 'previous-attack' })],
+      currentColor: 'red',
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        houseRules: { ...DEFAULT_HOUSE_RULES, revengeMode: true },
+      },
+    });
+
+    const won = applyActionWithHouseRules(state, {
+      type: 'PLAY_CARD', playerId: 'p1', cardId: wd4.id,
+    });
+
+    expect(won.phase).toBe('round_end');
+    expect(won.winnerId).toBe('p1');
+    expect(won.pendingRevengeDraws).toBe(0);
+    expect(won.drawStack).toBe(0);
+    expect(won.pendingPenaltyDraws).toBe(0);
   });
 
   it('does NOT double when previous card is not an attack card', () => {

--- a/packages/shared/tests/house-rules-batch2.test.ts
+++ b/packages/shared/tests/house-rules-batch2.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { applyActionWithHouseRules } from '../src/rules/house-rules-engine';
+import { enumerateLegalActionPlans } from '../src/rules/bot/legal-action-plans';
 import { initializeGame, initializeNextRound } from '../src/rules/setup';
 import type { GameState } from '../src/types/game';
 import { DEFAULT_HOUSE_RULES } from '../src/types/house-rules';
@@ -85,6 +86,61 @@ describe('bombCard', () => {
     const carol = paid.players.find(p => p.id === 'p3')!;
     expect(bob.hand.length).toBe(2);
     expect(carol.hand.length).toBe(2);
+  });
+
+  it('does not expose PASS while an active penalty waits ahead of a queued penalty', () => {
+    const state = makeState({
+      players: [
+        {
+          id: 'p1',
+          name: 'Alice',
+          hand: [makeCard('number', 'blue', { value: 1, id: 'blocked' })],
+          score: 0,
+          connected: true,
+          calledUno: false,
+        },
+        {
+          id: 'p2',
+          name: 'Bob',
+          hand: [makeCard('number', 'yellow', { value: 2, id: 'other' })],
+          score: 0,
+          connected: true,
+          calledUno: false,
+        },
+      ],
+      currentPlayerIndex: 0,
+      deckLeft: [makeCard('number', 'green', { value: 3, id: 'penalty-card' })],
+      deckRight: [],
+      discardPile: [makeCard('number', 'red', { value: 5, id: 'top' })],
+      currentColor: 'red',
+      pendingPenaltyDraws: 2,
+      pendingPenaltyNextPlayerIndex: 1,
+      pendingPenaltyQueue: [
+        { playerId: 'p2', count: 2, nextPlayerIndex: 0, sourcePlayerId: 'p1' },
+      ],
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        houseRules: {
+          ...DEFAULT_HOUSE_RULES,
+          drawUntilPlayable: true,
+          revengeMode: true,
+          noWildFinish: true,
+        },
+      },
+    });
+
+    const afterPass = applyActionWithHouseRules(state, { type: 'PASS', playerId: 'p1' });
+    const legal = enumerateLegalActionPlans(state, 'p1');
+
+    expect(afterPass).toBe(state);
+    expect(legal.plans).not.toContainEqual([{ type: 'PASS', playerId: 'p1' }]);
+    expect(legal.plans).toContainEqual([{
+      type: 'DRAW_CARD', playerId: 'p1', side: 'left',
+    }]);
+    expect(legal.plans).toContainEqual([{
+      type: 'DRAW_CARD', playerId: 'p1', side: 'right',
+    }]);
   });
 
   it('does not trigger bomb for fewer than 3 same-number cards', () => {

--- a/packages/shared/tests/house-rules-engine.test.ts
+++ b/packages/shared/tests/house-rules-engine.test.ts
@@ -141,6 +141,35 @@ describe('noWildFinish', () => {
     const next = applyActionWithHouseRules(state, { type: 'PLAY_CARD', playerId: 'p1', cardId: 'wd4' });
     expect(next).toBe(state);
   });
+
+  it('forfeits the turn when a prohibited wild finish cannot draw its penalty', () => {
+    const wild = makeCard('wild', null, { id: 'wild1' });
+    const state = makeState({
+      players: [
+        { id: 'p1', name: 'Alice', hand: [wild], score: 0, connected: true, calledUno: false },
+        { id: 'p2', name: 'Bob', hand: [makeCard('number', 'red', { value: 1, id: 'p2c' })], score: 0, connected: true, calledUno: false },
+        { id: 'p3', name: 'Carol', hand: [makeCard('number', 'blue', { value: 2, id: 'p3c' })], score: 0, connected: true, calledUno: false },
+      ],
+      deckLeft: [],
+      deckRight: [],
+      discardPile: [makeCard('number', 'red', { value: 5, id: 'discard_top' })],
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        houseRules: { ...DEFAULT_HOUSE_RULES, noWildFinish: true },
+      },
+    });
+
+    const next = applyActionWithHouseRules(
+      state,
+      { type: 'PLAY_CARD', playerId: 'p1', cardId: 'wild1' },
+    );
+
+    expect(next.currentPlayerIndex).toBe(1);
+    expect(next.players[0]!.hand).toEqual([wild]);
+    expect(next.discardPile).toEqual(state.discardPile);
+    expect(next.lastAction).toEqual({ type: 'PASS', playerId: 'p1' });
+  });
 });
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -203,6 +232,36 @@ describe('noFunctionCardFinish', () => {
     // draw_two should be played normally, advancing to p3 (skip p2)
     expect(next.players[0]!.hand).toHaveLength(1);
     expect(next.discardPile[next.discardPile.length - 1]!.id).toBe('d2');
+  });
+
+  it('ends an exhausted all-player prohibited-finish stalemate as a draw', () => {
+    const state = makeState({
+      players: [
+        { id: 'p1', name: 'Alice', hand: [makeCard('draw_two', 'red', { id: 'p1d2' })], score: 0, connected: true, calledUno: false },
+        { id: 'p2', name: 'Bob', hand: [makeCard('draw_two', 'red', { id: 'p2d2' })], score: 0, connected: true, calledUno: false },
+        { id: 'p3', name: 'Carol', hand: [makeCard('draw_two', 'red', { id: 'p3d2' })], score: 0, connected: true, calledUno: false },
+      ],
+      deckLeft: [],
+      deckRight: [],
+      discardPile: [makeCard('number', 'red', { value: 5, id: 'discard_top' })],
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        houseRules: { ...DEFAULT_HOUSE_RULES, noFunctionCardFinish: true },
+      },
+    });
+
+    const next = applyActionWithHouseRules(
+      state,
+      { type: 'PLAY_CARD', playerId: 'p1', cardId: 'p1d2' },
+    );
+
+    expect(next.phase).toBe('round_end');
+    expect(next.winnerId).toBeNull();
+    expect(next.players.map(player => player.hand)).toEqual(
+      state.players.map(player => player.hand),
+    );
+    expect(next.discardPile).toEqual(state.discardPile);
   });
 });
 
@@ -569,6 +628,43 @@ describe('drawUntilPlayable', () => {
     const next = applyActionWithHouseRules(state, { type: 'DRAW_CARD', playerId: 'p1', side: 'left' as const });
     expect(next.players[0]!.hand).toHaveLength(1);
     expect(next.players[0]!.hand[0]!.id).toBe('red7');
+  });
+
+  it('ends an exhausted all-player PASS stalemate as a drawn round', () => {
+    const state = makeState({
+      players: [
+        {
+          id: 'p1', name: 'Alice',
+          hand: [makeCard('number', 'blue', { value: 1, id: 'p1_blue' })],
+          score: 0, connected: true, calledUno: false,
+        },
+        {
+          id: 'p2', name: 'Bob',
+          hand: [makeCard('number', 'yellow', { value: 1, id: 'p2_yellow' })],
+          score: 0, connected: true, calledUno: false,
+        },
+      ],
+      deckLeft: [],
+      deckRight: [],
+      discardPile: [makeCard('number', 'red', { value: 5, id: 'only_discard' })],
+      currentColor: 'red',
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        houseRules: { ...DEFAULT_HOUSE_RULES, drawUntilPlayable: true },
+      },
+    });
+
+    const rejectedDraw = applyActionWithHouseRules(state, {
+      type: 'DRAW_CARD', playerId: 'p1', side: 'left',
+    });
+    expect(rejectedDraw).toBe(state);
+
+    const passed = applyActionWithHouseRules(state, { type: 'PASS', playerId: 'p1' });
+    expect(passed).not.toBe(state);
+    expect(passed.phase).toBe('round_end');
+    expect(passed.winnerId).toBeNull();
+    expect(passed.players.map(player => player.score)).toEqual([0, 0]);
   });
 
   it('rejects drawing when the player already has a playable card', () => {

--- a/packages/shared/tests/house-rules-latest-bugs.test.ts
+++ b/packages/shared/tests/house-rules-latest-bugs.test.ts
@@ -189,4 +189,61 @@ describe('latest house rule bug fixes', () => {
     const afterPass = applyActionWithHouseRules(afterDraw, { type: 'PASS', playerId: 'p1' });
     expect(afterPass.currentPlayerIndex).toBe(1);
   });
+
+  it('does not let stacking restart while a resolved penalty is still being drawn', () => {
+    const drawnAttack = makeCard('draw_two', 'blue', { id: 'drawn_attack' });
+    const penaltyCard = makeCard('number', 'yellow', { value: 3, id: 'penalty_card' });
+    const state = makeState({
+      currentPlayerIndex: 1,
+      currentColor: 'blue',
+      discardPile: [makeCard('draw_two', 'blue', { id: 'attack_top' })],
+      pendingPenaltyDraws: 1,
+      pendingPenaltyNextPlayerIndex: 2,
+      pendingPenaltySourcePlayerId: 'p1',
+      players: [
+        { id: 'p1', name: 'Alice', hand: [makeCard('number', 'red', { value: 1, id: 'p1_card' })], score: 0, connected: true, autopilot: false, calledUno: false, isBot: false },
+        { id: 'p2', name: 'Bob', hand: [drawnAttack], score: 0, connected: true, autopilot: false, calledUno: false, isBot: false },
+        { id: 'p3', name: 'Carol', hand: [makeCard('number', 'green', { value: 2, id: 'p3_card' })], score: 0, connected: true, autopilot: false, calledUno: false, isBot: false },
+      ],
+      deckLeft: [penaltyCard],
+      deckRight: [],
+      deckLeftInitialCount: 1,
+      deckRightInitialCount: 0,
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        allowSpectators: true,
+        spectatorMode: 'hidden',
+        houseRules: {
+          ...DEFAULT_HOUSE_RULES,
+          stackDrawTwo: true,
+          stackDrawFour: true,
+          crossStack: true,
+        },
+      },
+    });
+
+    const playAttempt = applyActionWithHouseRules(state, {
+      type: 'PLAY_CARD',
+      playerId: 'p2',
+      cardId: drawnAttack.id,
+    });
+    expect(playAttempt).toBe(state);
+    expect(playAttempt.drawStack).toBe(0);
+    expect(playAttempt.pendingPenaltyDraws).toBe(1);
+
+    const settled = applyActionWithHouseRules(state, {
+      type: 'DRAW_CARD',
+      playerId: 'p2',
+      side: 'left',
+    });
+    expect(settled.pendingPenaltyDraws).toBe(0);
+    expect(settled.drawStack).toBe(0);
+    expect(settled.currentPlayerIndex).toBe(2);
+    expect(settled.players[1]!.hand.map(card => card.id)).toEqual([
+      drawnAttack.id,
+      penaltyCard.id,
+    ]);
+  });
+
 });

--- a/packages/shared/tests/house-rules-remaining.test.ts
+++ b/packages/shared/tests/house-rules-remaining.test.ts
@@ -1065,4 +1065,120 @@ describe('handLimit', () => {
     // No limit — drawing succeeds
     expect(next.players[0]!.hand).toHaveLength(51);
   });
+
+  // At the limit, DRAW_CARD is rejected; without a playable card the only way
+  // the turn can advance is PASS, which the engine must accept without a
+  // prior draw (otherwise the game deadlocks).
+
+  /** 10 blue cards, values 1-4 — none playable on the default red-5 top card. */
+  function unplayableHandAtLimit(prefix = 'hc'): ReturnType<typeof makeCard>[] {
+    return Array.from({ length: 10 }, (_, i) =>
+      makeCard('number', 'blue', { value: (i % 4) + 1, id: `${prefix}${i}` })
+    );
+  }
+
+  function stuckAtLimitState(extraRules: Partial<typeof DEFAULT_HOUSE_RULES> = {}) {
+    return makeState({
+      players: [
+        { id: 'p1', name: 'Alice', hand: unplayableHandAtLimit(), score: 0, connected: true, calledUno: false },
+        { id: 'p2', name: 'Bob', hand: [makeCard('number', 'blue', { value: 1, id: 'p2c' })], score: 0, connected: true, calledUno: false },
+        { id: 'p3', name: 'Carol', hand: [], score: 0, connected: true, calledUno: false },
+      ],
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        houseRules: { ...DEFAULT_HOUSE_RULES, handLimit: 10, ...extraRules },
+      },
+    });
+  }
+
+  it('allows PASS without drawing when at the limit with nothing playable', () => {
+    const state = stuckAtLimitState();
+
+    // Sanity: both PLAY and DRAW are dead ends here
+    const drawn = applyActionWithHouseRules(state, { type: 'DRAW_CARD', playerId: 'p1', side: 'left' as const });
+    expect(drawn).toStrictEqual(state);
+
+    const next = applyActionWithHouseRules(state, { type: 'PASS', playerId: 'p1' });
+
+    expect(next.currentPlayerIndex).toBe(1);
+    expect(next.players[0]!.hand).toHaveLength(10);
+  });
+
+  it('allows PASS at the limit when drawUntilPlayable is also enabled', () => {
+    const state = stuckAtLimitState({ drawUntilPlayable: true });
+
+    const next = applyActionWithHouseRules(state, { type: 'PASS', playerId: 'p1' });
+
+    expect(next.currentPlayerIndex).toBe(1);
+    expect(next.players[0]!.hand).toHaveLength(10);
+  });
+
+  it('ends the round as a draw when every player is stuck at the hand limit', () => {
+    const state = makeState({
+      deckLeft: [makeCard('number', 'green', { value: 9, id: 'draw-source' })],
+      deckRight: [],
+      players: [
+        {
+          id: 'p1', name: 'Alice', hand: unplayableHandAtLimit('p1-'),
+          score: 0, connected: true, calledUno: false,
+        },
+        {
+          id: 'p2', name: 'Bob', hand: unplayableHandAtLimit('p2-'),
+          score: 0, connected: true, calledUno: false,
+        },
+      ],
+      settings: {
+        turnTimeLimit: 30,
+        targetScore: 500,
+        houseRules: {
+          ...DEFAULT_HOUSE_RULES,
+          handLimit: 10,
+          forcedPlayAfterDraw: true,
+          bombCard: true,
+        },
+      },
+    });
+
+    const next = applyActionWithHouseRules(state, { type: 'PASS', playerId: 'p1' });
+
+    expect(next.phase).toBe('round_end');
+    expect(next.winnerId).toBeNull();
+    expect(next.lastAction).toEqual({ type: 'PASS', playerId: 'p1' });
+    expect(next.players.map(player => player.score)).toEqual([0, 0]);
+  });
+
+  it('still rejects PASS at the limit when a playable card exists', () => {
+    const state = stuckAtLimitState();
+    state.players[0]!.hand[0] = makeCard('number', 'red', { value: 1, id: 'playable' });
+
+    const next = applyActionWithHouseRules(state, { type: 'PASS', playerId: 'p1' });
+
+    expect(next).toStrictEqual(state);
+  });
+
+  it('still rejects PASS without drawing when below the limit', () => {
+    const state = stuckAtLimitState();
+    state.players[0]!.hand = state.players[0]!.hand.slice(0, 5);
+
+    const next = applyActionWithHouseRules(state, { type: 'PASS', playerId: 'p1' });
+
+    expect(next).toStrictEqual(state);
+  });
+
+  it('still forces drawing off a draw stack at the limit (obligation draws are exempt)', () => {
+    const d2Top = makeCard('draw_two', 'red', { id: 'd2top' });
+    const state = stuckAtLimitState({ stackDrawTwo: true });
+    const stacked = {
+      ...state,
+      discardPile: [...state.discardPile, d2Top],
+      drawStack: 2,
+    };
+
+    const passed = applyActionWithHouseRules(stacked, { type: 'PASS', playerId: 'p1' });
+    expect(passed).toStrictEqual(stacked);
+
+    const drawn = applyActionWithHouseRules(stacked, { type: 'DRAW_CARD', playerId: 'p1', side: 'left' as const });
+    expect(drawn.players[0]!.hand.length).toBeGreaterThan(10);
+  });
 });

--- a/packages/shared/tests/penalty-draw-flow.test.ts
+++ b/packages/shared/tests/penalty-draw-flow.test.ts
@@ -69,6 +69,43 @@ describe('penalty draw flow', () => {
     expect(afterIllegalPass).toStrictEqual(afterFirstDraw);
   });
 
+  it('settles an unfulfillable penalty stack in one action when all cards are exhausted', () => {
+    const state = makeState({
+      players: [
+        {
+          id: 'p1', name: 'Alice',
+          hand: [makeCard('number', 'blue', { value: 1, id: 'p1-card' })],
+          score: 0, connected: true, autopilot: false, calledUno: false,
+        },
+        {
+          id: 'p2', name: 'Bob',
+          hand: [makeCard('number', 'yellow', { value: 1, id: 'p2-card' })],
+          score: 0, connected: true, autopilot: false, calledUno: false,
+        },
+        {
+          id: 'p3', name: 'Carol',
+          hand: [makeCard('number', 'green', { value: 1, id: 'p3-card' })],
+          score: 0, connected: true, autopilot: false, calledUno: false,
+        },
+      ],
+      currentPlayerIndex: 1,
+      pendingPenaltyDraws: 62,
+      pendingPenaltyNextPlayerIndex: 2,
+      pendingPenaltySourcePlayerId: 'p1',
+      deckLeft: [],
+      deckRight: [],
+      discardPile: [makeCard('draw_two', 'red', { id: 'only-discard' })],
+    });
+
+    const settled = applyAction(state, {
+      type: 'DRAW_CARD', playerId: 'p2', side: 'left',
+    });
+
+    expect(settled.players[1]!.hand.map(card => card.id)).toEqual(['p2-card']);
+    expect(settled.pendingPenaltyDraws).toBe(0);
+    expect(settled.currentPlayerIndex).toBe(2);
+  });
+
   it('requires all 4 wild draw four penalty cards to be drawn after accepting', () => {
     const deckCards = Array.from({ length: 6 }, (_, i) => makeCard('number', 'blue', { value: i, id: `wd4_draw_${i}` }));
     const state = makeState({

--- a/packages/shared/tests/setup.test.ts
+++ b/packages/shared/tests/setup.test.ts
@@ -93,7 +93,7 @@ describe('initializeGame', () => {
 
     const state = initializeGame(playerData);
 
-    expect(state.phase === 'playing' || state.phase === 'choosing_color').toBe(true);
+    expect(state.phase).toBe('playing');
     expect(state.players).toHaveLength(3);
     expect(state.players[0]!.hand.length).toBeGreaterThanOrEqual(7);
     expect(state.discardPile.length).toBeGreaterThanOrEqual(1);
@@ -102,14 +102,16 @@ describe('initializeGame', () => {
     expect(state.roundNumber).toBe(1);
   });
 
-  it('handles first card effects', () => {
+  it('honors the default wildFirstTurn=false rule', () => {
     for (let i = 0; i < 50; i++) {
       const playerData = [
         { id: 'p1', name: 'Alice' },
         { id: 'p2', name: 'Bob' },
       ];
       const state = initializeGame(playerData);
-      expect(state.phase === 'playing' || state.phase === 'choosing_color').toBe(true);
+      expect(state.phase).toBe('playing');
+      expect(state.discardPile[0]!.type).not.toBe('wild');
+      expect(state.discardPile[0]!.type).not.toBe('wild_draw_four');
       expect(state.discardPile.length).toBeGreaterThanOrEqual(1);
     }
   });


### PR DESCRIPTION
## 概要
- 修复牌堆耗尽、手牌上限、累计惩罚与末牌限制组合造成的回合死锁
- 修复 WD4 复仇、叠加、反弹与免质疑组合的惩罚结算
- 为 bot/autopilot 增加纯规则引擎合法动作枚举和有界循环保护，不包含任何 RL/模型依赖
- 修复首张万能牌默认村规和 MCP 独立类型检查

## 验证
- pnpm --filter shared build
- pnpm --filter server exec tsc --noEmit
- pnpm --filter client build
- pnpm --filter @uno-online/mcp exec tsc --noEmit
- pnpm test（shared 345 / server 123 / MCP 4）