### PR TITLE
fix(release): pass tag arguments correctly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Verify release metadata
-        run: pnpm release:check -- "$GITHUB_REF_NAME"
+        run: pnpm release:check "$GITHUB_REF_NAME"
 
       - name: Build all packages
         run: pnpm build
@@ -130,7 +130,7 @@ jobs:
           fi
 
       - name: Generate release notes
-        run: pnpm release:notes -- "$GITHUB_REF_NAME" > "$RUNNER_TEMP/release-notes.md"
+        run: pnpm release:notes "$GITHUB_REF_NAME" > "$RUNNER_TEMP/release-notes.md"
 
       - name: Create or update GitHub Release
         env:


### PR DESCRIPTION
移除 pnpm 脚本调用中会被原样传给 Node 的多余 --，修复 Release 元数据校验把版本误识别为 -- 的问题，并同步修正后续 release notes 调用。失败的 v0.15.0-beta.0 工作流在发布任何制品前退出；合并后将按文档删除并重新创建该 Tag。