### PR TITLE
fix(release): support prerelease recovery

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,18 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing release tag to publish or recover
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-${{ inputs.tag || github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -18,6 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     environment: release
+    env:
+      RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
     permissions:
       contents: write
       id-token: write
@@ -26,15 +34,21 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Verify tag commit belongs to main
         run: |
           git fetch origin main --no-tags
-          release_commit=$(git rev-list -n 1 "$GITHUB_REF_NAME")
+          if ! git rev-parse --verify --quiet "refs/tags/$RELEASE_TAG^{commit}" >/dev/null; then
+            echo "::error::Release input must name an existing Git tag."
+            exit 1
+          fi
+          release_commit=$(git rev-list -n 1 "refs/tags/$RELEASE_TAG")
           if ! git merge-base --is-ancestor "$release_commit" origin/main; then
             echo "::error::Release tag must point to a commit reachable from origin/main."
             exit 1
           fi
+          echo "RELEASE_COMMIT=$release_commit" >> "$GITHUB_ENV"
 
       - name: Set up pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
@@ -50,7 +64,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Verify release metadata
-        run: pnpm release:check "$GITHUB_REF_NAME"
+        run: pnpm release:check "$RELEASE_TAG"
 
       - name: Build all packages
         run: pnpm build
@@ -77,8 +91,10 @@ jobs:
           images: djkcyl/uno-online-server
           flavor: latest=false
           tags: |
-            type=semver,pattern=v{{version}}
-            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
+            type=semver,pattern=v{{version}},value=${{ env.RELEASE_TAG }}
+            type=raw,value=latest,enable=${{ !contains(env.RELEASE_TAG, '-') }}
+          labels: |
+            org.opencontainers.image.revision=${{ env.RELEASE_COMMIT }}
 
       - name: Generate caddy image metadata
         id: caddy-meta
@@ -87,8 +103,10 @@ jobs:
           images: djkcyl/uno-online-caddy
           flavor: latest=false
           tags: |
-            type=semver,pattern=v{{version}}
-            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
+            type=semver,pattern=v{{version}},value=${{ env.RELEASE_TAG }}
+            type=raw,value=latest,enable=${{ !contains(env.RELEASE_TAG, '-') }}
+          labels: |
+            org.opencontainers.image.revision=${{ env.RELEASE_COMMIT }}
 
       - name: Build and push server image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
@@ -126,20 +144,26 @@ jobs:
           if npm view "@uno-online/mcp@$version" version --json >/dev/null 2>&1; then
             echo "@uno-online/mcp@$version already exists; skipping npm publish."
           else
-            npm publish --access public --provenance
+            publish_args=(--access public --provenance)
+            if [[ "$version" == *-* ]]; then
+              prerelease_tag=${version#*-}
+              prerelease_tag=${prerelease_tag%%.*}
+              publish_args+=(--tag "$prerelease_tag")
+            fi
+            npm publish "${publish_args[@]}"
           fi
 
       - name: Generate release notes
-        run: pnpm release:notes "$GITHUB_REF_NAME" > "$RUNNER_TEMP/release-notes.md"
+        run: pnpm release:notes "$RELEASE_TAG" > "$RUNNER_TEMP/release-notes.md"
 
       - name: Create or update GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
-            gh release edit "$GITHUB_REF_NAME" --title "UNO Online $GITHUB_REF_NAME" --notes-file "$RUNNER_TEMP/release-notes.md"
-          elif [[ "$GITHUB_REF_NAME" == *-* ]]; then
-            gh release create "$GITHUB_REF_NAME" --verify-tag --title "UNO Online $GITHUB_REF_NAME" --notes-file "$RUNNER_TEMP/release-notes.md" --prerelease
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release edit "$RELEASE_TAG" --title "UNO Online $RELEASE_TAG" --notes-file "$RUNNER_TEMP/release-notes.md"
+          elif [[ "$RELEASE_TAG" == *-* ]]; then
+            gh release create "$RELEASE_TAG" --verify-tag --title "UNO Online $RELEASE_TAG" --notes-file "$RUNNER_TEMP/release-notes.md" --prerelease
           else
-            gh release create "$GITHUB_REF_NAME" --verify-tag --title "UNO Online $GITHUB_REF_NAME" --notes-file "$RUNNER_TEMP/release-notes.md"
+            gh release create "$RELEASE_TAG" --verify-tag --title "UNO Online $RELEASE_TAG" --notes-file "$RUNNER_TEMP/release-notes.md"
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -283,6 +283,6 @@ GitHub 自动发布只负责验证和发布制品；版本判断、兼容性判�
     破坏性发布维护窗口切换 schema/protocol，再更新 Compose 应用容器。
 11. **发布后验证**：检查 `/api/health`、`/api/server/info`、浏览器登录/重连以及版本化 Docker/MCP 制品。
 
-预发布 Tag（如 `v1.2.0-rc.1`）会生成 prerelease，只推版本镜像，不更新 Docker `latest`。语音网关镜像
+预发布 Tag（如 `v1.2.0-beta.0`）会生成 prerelease，只推版本镜像，不更新 Docker `latest`。语音网关镜像
 不在自动发版范围内。仓库 Secrets、npm Trusted Publisher 和 GitHub Environment 的一次性配置见
 `docs/ci-release.md`。

--- a/docs/ci-release.md
+++ b/docs/ci-release.md
@@ -19,7 +19,8 @@
 
 ### Release
 
-`.github/workflows/release.yml` 仅由 `v*.*.*` Tag push 触发。工作流会：
+`.github/workflows/release.yml` 通常由 `v*.*.*` Tag push 触发；已有 Tag 的故障恢复也可从 GitHub UI 或
+`gh workflow run` 手动触发。无论触发方式如何，工作流都只检出现有 Tag，并执行相同的 Tag/main/版本校验。工作流会：
 
 1. 确认 Tag 指向 `origin/main` 可达的提交。
 2. 确认 Tag、根版本、六个 workspace 版本一致。
@@ -32,7 +33,8 @@
 6. 通过 npm Trusted Publishing（OIDC）发布 `@uno-online/mcp@<版本号>`。
 7. 从 CHANGELOG 生成或更新 GitHub Release。
 
-预发布 Tag（例如 `v1.2.0-rc.1`）会创建 GitHub prerelease，不更新 Docker `latest`。
+预发布 Tag（例如 `v1.2.0-beta.0`）会创建 GitHub prerelease，不更新 Docker `latest`；npm 包使用预发布标识的
+第一个字段作为 dist-tag，例如 `0.15.0-beta.0` 发布到 `beta`，不会覆盖 `latest`。
 工作流不发布 `mumble-gateway`，也不连接或重启生产服务器。
 
 ## 一次性配置
@@ -91,4 +93,12 @@ Tag push 后在 GitHub Actions 等待 `Release / Publish release` 全部完成�
 - 同一 workflow 可以安全 rerun：已存在的 MCP 版本会跳过 npm publish，GitHub Release 会更新正文。
 - Docker 发布失败时可 rerun；相同版本 Tag 始终从同一 Git 提交重新构建。
 - 如果 Tag/版本/changelog 校验失败，删除尚未产生任何制品的错误 Tag，修正版本 PR 后创建正确的新 Tag。
-- 如果已经有任一制品成功发布，不要删除重用版本号；修复后发布新的 patch 版本。
+- 如果已经有任一制品成功发布，不要删除或移动 Tag。若只需修复发布工作流而制品源码不变，先通过 PR 修复
+  `release.yml`，再从默认分支针对原 Tag 执行恢复发布：
+
+  ```bash
+  gh workflow run release.yml --ref main -f tag=v<版本号>
+  ```
+
+  手动运行仍会检出原 Tag 并执行完整校验；已有 npm 版本会跳过，Docker 镜像从同一 Tag 重建，GitHub Release
+  会创建或更新。若必须修改制品源码，则发布新的版本，不能复用原版本号。

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -4,7 +4,7 @@
   "description": "MCP Server for UNO Online — let AI clients play UNO via MCP tools",
   "type": "module",
   "bin": {
-    "uno-mcp": "./dist/index.js"
+    "uno-mcp": "dist/index.js"
   },
   "main": "./dist/index.js",
   "files": [
@@ -26,7 +26,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/letsuno/uno-online.git",
+    "url": "git+https://github.com/letsuno/uno-online.git",
     "directory": "packages/mcp"
   },
   "dependencies": {


### PR DESCRIPTION
修复 npm 11 要求 prerelease 显式 dist-tag 的问题，0.15.0-beta.0 将发布到现有 beta tag，不覆盖 latest；同时增加针对不可移动既有 Tag 的 workflow_dispatch 恢复入口，手动恢复仍检出原 Tag、校验其属于 main，并从原提交重建制品。同步规范化 MCP npm 元数据并更新发布文档。当前 beta.0 的两个 Docker 镜像已成功发布，npm 与 GitHub prerelease 尚未生成；合并后将针对原 Tag 执行恢复发布。