### PR TITLE
feat(deploy): add release channel switching

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,10 @@ DOMAIN=example.com
 # Caddy 站点地址（有域名时设为域名，本地开发设为 :80）
 CADDY_SITE_ADDRESS=example.com
 
+# --- 部署镜像通道 ---
+# latest=最新正式版，beta=最新测试版，也可填写 vX.Y.Z[-beta.N] 锁定或回滚到精确版本
+UNO_IMAGE_TAG=latest
+
 # --- 端口 ---
 # 本地开发使用 http://localhost:5173；生产部署改为 https://${DOMAIN}
 CLIENT_URL=http://localhost:5173

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,7 @@ jobs:
           flavor: latest=false
           tags: |
             type=semver,pattern=v{{version}},value=${{ env.RELEASE_TAG }}
+            type=raw,value=beta,enable=${{ contains(env.RELEASE_TAG, '-beta.') }}
             type=raw,value=latest,enable=${{ !contains(env.RELEASE_TAG, '-') }}
           labels: |
             org.opencontainers.image.revision=${{ env.RELEASE_COMMIT }}
@@ -104,6 +105,7 @@ jobs:
           flavor: latest=false
           tags: |
             type=semver,pattern=v{{version}},value=${{ env.RELEASE_TAG }}
+            type=raw,value=beta,enable=${{ contains(env.RELEASE_TAG, '-beta.') }}
             type=raw,value=latest,enable=${{ !contains(env.RELEASE_TAG, '-') }}
           labels: |
             org.opencontainers.image.revision=${{ env.RELEASE_COMMIT }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,16 +183,18 @@ MCP 工具名称和参数以 `packages/mcp/src/tools/` 为准；修改 Socket �
 pnpm --filter shared build
 pnpm --filter @uno-online/mcp build
 pnpm --dir packages/mcp exec npm pack --dry-run
-cd packages/mcp && npm publish --access public
 ```
 
-发布包应只包含 `dist/index.js` 和 `package.json`。版本号由 `pnpm version:sync` 同步；
+以上命令只做本地构建与打包预检；正式 npm 发布统一由版本 Tag 触发的 GitHub Actions 通过 OIDC 完成，不把
+本地 `npm publish` 作为标准发版步骤。发布包应只包含 `dist/index.js` 和 `package.json`。版本号由
+`pnpm version:sync` 同步；
 `McpServer` 版本由 tsup 从包版本注入 `__PKG_VERSION__`，不要手工维护源码常量。
 
 ## Docker 与部署
 
 `.github/workflows/ci.yml` 会在 PR 与 main push 上执行完整验证和两个 Docker target 构建。
-`.github/workflows/release.yml` 只在推送合法 `vX.Y.Z` Tag 后发布 Docker、MCP npm 包和 GitHub Release。
+`.github/workflows/release.yml` 通常由合法 SemVer Tag push 触发；已有 Tag 的发布故障也可从 `main` 通过
+`workflow_dispatch` 指定原 Tag 恢复。两种入口都只检出现有 Tag，并执行相同的 Tag/main/版本校验。
 生产服务器部署仍是显式运维步骤，不由 GitHub 自动 SSH 或重启。
 
 `Dockerfile` 有两个发布目标：
@@ -283,6 +285,6 @@ GitHub 自动发布只负责验证和发布制品；版本判断、兼容性判�
     破坏性发布维护窗口切换 schema/protocol，再更新 Compose 应用容器。
 11. **发布后验证**：检查 `/api/health`、`/api/server/info`、浏览器登录/重连以及版本化 Docker/MCP 制品。
 
-预发布 Tag（如 `v1.2.0-beta.0`）会生成 prerelease，只推版本镜像，不更新 Docker `latest`。语音网关镜像
-不在自动发版范围内。仓库 Secrets、npm Trusted Publisher 和 GitHub Environment 的一次性配置见
-`docs/ci-release.md`。
+预发布 Tag（如 `v1.2.0-beta.0`）会生成 prerelease，只推版本镜像，不更新 Docker `latest`；MCP npm 包会
+使用第一个预发布标识作为 dist-tag（该示例为 `beta`），不会覆盖 npm `latest`。语音网关镜像不在自动发版
+范围内。仓库 Secrets、npm Trusted Publisher、GitHub Environment、故障恢复命令等见 `docs/ci-release.md`。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,6 +219,8 @@ docker build -f mumble.Dockerfile -t djkcyl/uno-online-mumble-gateway:latest .
 - 发布期间保持 `JWT_SECRET` 不变，否则现有浏览器身份全部失效
 - server 必须接收 `SIGTERM` 并在 Compose 的 30 秒宽限内完成 drain/flush；不要直接 `SIGKILL`
 - 只运行一个 game server；不要用新旧 server 重叠的滚动发布
+- Compose 的 `UNO_IMAGE_TAG` 选择 `latest`、`beta` 或精确版本；`server` 与 `caddy` 必须始终使用同一 Tag
+- `server` 与 `caddy` 都有容器健康检查；部署工具应等待健康状态后再报告成功
 
 ### 发布兼容性判定
 
@@ -239,8 +241,8 @@ docker build -f mumble.Dockerfile -t djkcyl/uno-online-mumble-gateway:latest .
 
 ```bash
 docker compose pull server caddy
-docker compose up -d --no-deps server
-docker compose up -d --no-deps caddy
+docker compose up -d --no-deps --wait server
+docker compose up -d --no-deps --wait caddy
 ```
 
 首次部署使用 `docker compose up -d`。破坏性发布应安排维护窗口：先停止接纳新房间，在旧 server 仍运行时
@@ -285,6 +287,7 @@ GitHub 自动发布只负责验证和发布制品；版本判断、兼容性判�
     破坏性发布维护窗口切换 schema/protocol，再更新 Compose 应用容器。
 11. **发布后验证**：检查 `/api/health`、`/api/server/info`、浏览器登录/重连以及版本化 Docker/MCP 制品。
 
-预发布 Tag（如 `v1.2.0-beta.0`）会生成 prerelease，只推版本镜像，不更新 Docker `latest`；MCP npm 包会
-使用第一个预发布标识作为 dist-tag（该示例为 `beta`），不会覆盖 npm `latest`。语音网关镜像不在自动发版
-范围内。仓库 Secrets、npm Trusted Publisher、GitHub Environment、故障恢复命令等见 `docs/ci-release.md`。
+预发布 Tag（如 `v1.2.0-beta.0`）会生成 prerelease，推送精确版本镜像并更新 Docker `beta`，但不更新 Docker
+`latest`；MCP npm 包使用第一个预发布标识作为 dist-tag（该示例为 `beta`），不会覆盖 npm `latest`。语音网关
+镜像不在自动发版范围内。仓库 Secrets、npm Trusted Publisher、GitHub Environment、故障恢复命令等见
+`docs/ci-release.md`。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - ./data/redis:/data
 
   server:
-    image: djkcyl/uno-online-server:latest
+    image: djkcyl/uno-online-server:${UNO_IMAGE_TAG:-latest}
     depends_on:
       redis:
         condition: service_healthy
@@ -55,13 +55,26 @@ services:
       - ./data/sqlite:/data
       - ${UNO_AI_PLUGINS_HOST_DIR:-./data/ai-plugins}:/ai/plugins:ro
       - ${UNO_AI_PLUGIN_STATE_HOST_DIR:-./data/ai-plugin-state}:/ai/state
+    healthcheck:
+      test:
+        [
+          'CMD',
+          'node',
+          '-e',
+          "fetch('http://127.0.0.1:3001/api/health').then(response => { if (!response.ok) process.exit(1); }).catch(() => process.exit(1));",
+        ]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 20s
     stop_grace_period: 30s
     restart: unless-stopped
 
   caddy:
-    image: djkcyl/uno-online-caddy:latest
+    image: djkcyl/uno-online-caddy:${UNO_IMAGE_TAG:-latest}
     depends_on:
-      - server
+      server:
+        condition: service_healthy
     environment:
       DOMAIN: ${DOMAIN:-localhost}
       CADDY_SITE_ADDRESS: ${CADDY_SITE_ADDRESS:-:80}
@@ -71,6 +84,12 @@ services:
     volumes:
       - ./data/caddy/data:/data
       - ./data/caddy/config:/config
+    healthcheck:
+      test: ['CMD-SHELL', 'wget -q -O /dev/null http://127.0.0.1:2019/config/ || exit 1']
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
     restart: unless-stopped
 
   mumble:

--- a/docs/ci-release.md
+++ b/docs/ci-release.md
@@ -41,10 +41,13 @@
 
 ### Docker Hub
 
-在 GitHub 仓库 `Settings → Secrets and variables → Actions` 添加：
+在 GitHub 仓库 `Settings → Environments → release → Environment secrets` 添加：
 
 - `DOCKERHUB_USERNAME`：对 `djkcyl/uno-online-server` 和 `djkcyl/uno-online-caddy` 有 push 权限的账号
 - `DOCKERHUB_TOKEN`：Docker Hub access token，不要保存账号密码
+
+Release job 绑定 `release` Environment，因此当前统一使用 Environment secrets，不需要再创建同名的仓库级
+Actions secrets。
 
 ### npm Trusted Publisher
 
@@ -65,7 +68,7 @@
 
 ### main 保护
 
-在 main 的规则中要求 PR，并把以下检查设为 required：
+在 `Settings → Rules → Rulesets` 中为 `main` 启用分支规则，要求 PR，并把以下检查设为 required：
 
 - `Validate`
 - `Docker targets`

--- a/docs/ci-release.md
+++ b/docs/ci-release.md
@@ -30,11 +30,13 @@
    - `djkcyl/uno-online-server:v<版本号>`
    - `djkcyl/uno-online-caddy:v<版本号>`
    - 稳定版本同时更新两个镜像的 `latest`
+   - `*-beta.N` 版本同时更新两个镜像的 `beta`，但不更新 `latest`
 6. 通过 npm Trusted Publishing（OIDC）发布 `@uno-online/mcp@<版本号>`。
 7. 从 CHANGELOG 生成或更新 GitHub Release。
 
-预发布 Tag（例如 `v1.2.0-beta.0`）会创建 GitHub prerelease，不更新 Docker `latest`；npm 包使用预发布标识的
-第一个字段作为 dist-tag，例如 `0.15.0-beta.0` 发布到 `beta`，不会覆盖 `latest`。
+预发布 Tag（例如 `v1.2.0-beta.0`）会创建 GitHub prerelease，更新 Docker `beta` 但不更新 Docker
+`latest`；npm 包使用预发布标识的第一个字段作为 dist-tag，例如 `0.15.0-beta.0` 发布到 `beta`，不会覆盖
+`latest`。
 工作流不发布 `mumble-gateway`，也不连接或重启生产服务器。
 
 ## 一次性配置

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -9,8 +9,11 @@ server/caddy 镜像、MCP npm 包与 GitHub Release 由版本 Tag 自动发布�
 cp .env.example .env
 # 编辑 .env：生产环境至少设置 DOMAIN、CADDY_SITE_ADDRESS、JWT_SECRET、GitHub OAuth 凭证
 
-docker compose up -d --build
+docker compose pull
+docker compose up -d
 ```
+
+Compose 使用已经发布到镜像仓库的镜像，没有本地 `build:` 配置，因此部署时不要使用无效的 `--build` 参数。
 
 验证：
 
@@ -18,6 +21,17 @@ docker compose up -d --build
 curl http://localhost/api/health
 curl http://localhost/api/server/info
 ```
+
+状态兼容版本发布成功后，只更新应用容器，不重建 Redis、SQLite 或语音服务：
+
+```bash
+docker compose pull server caddy
+docker compose up -d --no-deps server
+docker compose up -d --no-deps caddy
+```
+
+执行 server 更新时，Compose 会先向旧容器发送 `SIGTERM` 并等待其在停机宽限内退出，再启动新容器。运行时
+schema 或 Socket 协议破坏性发布不能直接执行这组命令，必须先按下文策略排空活跃房间。
 
 ## 关键配置
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -15,6 +15,18 @@ docker compose up -d
 
 Compose 使用已经发布到镜像仓库的镜像，没有本地 `build:` 配置，因此部署时不要使用无效的 `--build` 参数。
 
+`UNO_IMAGE_TAG` 同时控制 server 与 caddy 的镜像版本：
+
+| 值              | 用途                       |
+| --------------- | -------------------------- |
+| `latest`        | 跟随最新正式版             |
+| `beta`          | 跟随最新 `*-beta.N` 测试版 |
+| `v1.2.3`        | 锁定或回滚到精确正式版本   |
+| `v1.2.3-beta.0` | 锁定或回滚到精确测试版本   |
+
+Release workflow 只在所有构建、测试和打包预检通过后推送镜像。正式 Tag 更新 `latest`，Beta Tag 更新 `beta`；
+精确版本 Tag 永远保留，可用于回滚。
+
 验证：
 
 ```bash
@@ -26,12 +38,31 @@ curl http://localhost/api/server/info
 
 ```bash
 docker compose pull server caddy
-docker compose up -d --no-deps server
-docker compose up -d --no-deps caddy
+docker compose up -d --no-deps --wait server
+docker compose up -d --no-deps --wait caddy
 ```
 
 执行 server 更新时，Compose 会先向旧容器发送 `SIGTERM` 并等待其在停机宽限内退出，再启动新容器。运行时
 schema 或 Socket 协议破坏性发布不能直接执行这组命令，必须先按下文策略排空活跃房间。
+
+## Komodo 管理与自动更新
+
+[Komodo](https://komo.do/docs/deploy/compose) 可以直接接管现有 Compose 项目，不要求迁移数据目录或配置
+GitHub OAuth：
+
+1. Stack 使用 `Files on host`，`run_directory` 指向当前 Compose 所在目录。
+2. `project_name` 必须与服务器上 `docker compose ls` 显示的现有项目名相同。
+3. 初次接管保持当前 `.env`、相对挂载路径和 `./data` 目录不变。
+4. 在 Stack 环境变量中设置 `UNO_IMAGE_TAG=latest` 或 `UNO_IMAGE_TAG=beta`，修改后 Deploy 即可切换通道。
+5. 开启 `poll_for_updates` 可显示当前通道的新镜像；开启 `auto_update` 后会自动 pull 并重新部署当前通道。
+
+正式版与 Beta 共用 SQLite、Redis 和 JWT 时，自动更新仍受本页兼容性规则约束。若新版本改变运行时结构或
+Socket 协议，应先关闭 `auto_update`、排空房间并完成 schema/protocol 切换；若 Beta 修改了持久用户数据库
+schema，切回旧版本前必须确认迁移可回退。需要稳定回滚点时，把 `UNO_IMAGE_TAG` 改成上一个精确版本，而不是
+继续跟随可移动的 `latest`/`beta`。
+
+管理面板拥有 Docker 主机控制权限，不应直接暴露到公网。单人运维可只绑定到 `127.0.0.1`，通过 SSH 端口转发
+访问。
 
 ## 关键配置
 
@@ -41,6 +72,7 @@ schema 或 Socket 协议破坏性发布不能直接执行这组命令，必须�
 - `DATABASE_PATH`：SQLite 数据库路径，Docker 默认是 `/data/uno.db`。
 - `REDIS_URL`：生产环境必填；开发模式未设置时使用内存 KV。若设置 `REDIS_PASSWORD`，连接 URL 也必须包含同一密码。
 - `RUNTIME_SCHEMA_VERSION`：临时房间/游戏状态的 schema 代号，默认 `1`。状态兼容发布保持不变；破坏性发布先排空旧房间，再递增该值以隔离旧 namespace。服务端不会读取或迁移旧 namespace。
+- `UNO_IMAGE_TAG`：server/caddy 共用的镜像通道或精确版本，默认 `latest`。
 - `CADDY_SITE_ADDRESS`：Caddy 站点地址，可用域名或 `:80`。
 - `TURNSTILE_SITE_KEY` / `TURNSTILE_SECRET_KEY`：可选；Cloudflare Turnstile 人机验证，两者同时配置后注册/登录页启用 CAPTCHA。
 - `WEBAUTHN_RP_NAME`：可选；WebAuthn 依赖方名称，默认 `UNO Online`。

--- a/scripts/release/release-scripts.test.mjs
+++ b/scripts/release/release-scripts.test.mjs
@@ -10,6 +10,7 @@ const repoRoot = resolve(releaseDirectory, '../..');
 const checkScript = join(releaseDirectory, 'check-release.mjs');
 const notesScript = join(releaseDirectory, 'release-notes.mjs');
 const releaseWorkflow = readFileSync(join(repoRoot, '.github/workflows/release.yml'), 'utf8');
+const composeDefinition = readFileSync(join(repoRoot, 'docker-compose.yml'), 'utf8');
 const currentVersion = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf8')).version;
 const coreVersionMatch = /^(\d+)\.(\d+)\.(\d+)/u.exec(currentVersion);
 assert.ok(coreVersionMatch, 'root package version must start with major.minor.patch');
@@ -62,9 +63,19 @@ test('release workflow can recover an existing tag from the default branch', () 
 
 test('release workflow keeps prereleases away from stable distribution tags', () => {
   const dockerLatestRule = "type=raw,value=latest,enable=${{ !contains(env.RELEASE_TAG, '-') }}";
+  const dockerBetaRule = "type=raw,value=beta,enable=${{ contains(env.RELEASE_TAG, '-beta.') }}";
   assert.equal(releaseWorkflow.split(dockerLatestRule).length - 1, 2);
+  assert.equal(releaseWorkflow.split(dockerBetaRule).length - 1, 2);
   assert.ok(releaseWorkflow.includes('if [[ "$version" == *-* ]]; then'));
   assert.ok(releaseWorkflow.includes('prerelease_tag=${version#*-}'));
   assert.ok(releaseWorkflow.includes('publish_args+=(--tag "$prerelease_tag")'));
   assert.ok(releaseWorkflow.includes('elif [[ "$RELEASE_TAG" == *-* ]]; then'));
+});
+
+test('compose can switch release channels and waits for healthy application containers', () => {
+  assert.ok(composeDefinition.includes('djkcyl/uno-online-server:${UNO_IMAGE_TAG:-latest}'));
+  assert.ok(composeDefinition.includes('djkcyl/uno-online-caddy:${UNO_IMAGE_TAG:-latest}'));
+  assert.ok(composeDefinition.includes("fetch('http://127.0.0.1:3001/api/health')"));
+  assert.ok(composeDefinition.includes('http://127.0.0.1:2019/config/'));
+  assert.match(composeDefinition, /server:\s*\n\s*condition: service_healthy/u);
 });

--- a/scripts/release/release-scripts.test.mjs
+++ b/scripts/release/release-scripts.test.mjs
@@ -9,6 +9,7 @@ const releaseDirectory = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(releaseDirectory, '../..');
 const checkScript = join(releaseDirectory, 'check-release.mjs');
 const notesScript = join(releaseDirectory, 'release-notes.mjs');
+const releaseWorkflow = readFileSync(join(repoRoot, '.github/workflows/release.yml'), 'utf8');
 const currentVersion = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf8')).version;
 const coreVersionMatch = /^(\d+)\.(\d+)\.(\d+)/u.exec(currentVersion);
 assert.ok(coreVersionMatch, 'root package version must start with major.minor.patch');
@@ -50,4 +51,20 @@ test('release notes contain versioned Docker and MCP install commands', () => {
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, new RegExp('uno-online-server:v' + currentVersion.replaceAll('.', '\\.'), 'u'));
   assert.match(result.stdout, new RegExp('@uno-online/mcp@' + currentVersion.replaceAll('.', '\\.'), 'u'));
+});
+
+test('release workflow can recover an existing tag from the default branch', () => {
+  assert.match(releaseWorkflow, /workflow_dispatch:\s*\n\s*inputs:\s*\n\s*tag:/u);
+  assert.ok(releaseWorkflow.includes('RELEASE_TAG: ${{ inputs.tag || github.ref_name }}'));
+  assert.ok(releaseWorkflow.includes('ref: ${{ env.RELEASE_TAG }}'));
+  assert.ok(releaseWorkflow.includes('refs/tags/$RELEASE_TAG^{commit}'));
+});
+
+test('release workflow keeps prereleases away from stable distribution tags', () => {
+  const dockerLatestRule = "type=raw,value=latest,enable=${{ !contains(env.RELEASE_TAG, '-') }}";
+  assert.equal(releaseWorkflow.split(dockerLatestRule).length - 1, 2);
+  assert.ok(releaseWorkflow.includes('if [[ "$version" == *-* ]]; then'));
+  assert.ok(releaseWorkflow.includes('prerelease_tag=${version#*-}'));
+  assert.ok(releaseWorkflow.includes('publish_args+=(--tag "$prerelease_tag")'));
+  assert.ok(releaseWorkflow.includes('elif [[ "$RELEASE_TAG" == *-* ]]; then'));
 });


### PR DESCRIPTION
增加正式版/Beta 镜像通道切换与自动更新基础能力：Compose 通过 UNO_IMAGE_TAG 在 latest、beta 和精确版本间切换；Release workflow 为 Beta 同步 Docker beta Tag；server/caddy 增加健康检查与健康等待；更新 AGENTS.md、CI/发版、部署和 Komodo 接管/回滚说明，并补充静态回归测试。验证：pnpm test、pnpm build、pnpm release:check v0.15.0-beta.0、git diff --check。当前本机未安装 Docker CLI，Compose 实际解析由 GitHub Docker CI 和服务器接管前检查完成。