### PR TITLE
docs: document Komodo production deployment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -261,9 +261,10 @@ docker compose --env-file .env --env-file .env.secrets up -d --no-deps --wait se
 docker compose --env-file .env --env-file .env.secrets up -d --no-deps --wait caddy
 ```
 
-首次部署使用 `docker compose up -d`。破坏性发布应安排维护窗口：先停止接纳新房间，在旧 server 仍运行时
-等待或终止活跃房间，再停止旧 server，最后更新 schema/protocol 并部署匹配的 server 与 caddy。具体变量和
-运维说明见 `docs/deployment.md`。
+当前生产不使用省略 env 文件的裸 `docker compose up -d`。首次创建或完整恢复生产 Stack 由 Komodo 部署；
+必须脱离面板操作时，也要显式传入 `.env` 与 `.env.secrets` 并保持 Compose 项目名为 `uno-online`。破坏性发布
+应安排维护窗口：先停止接纳新房间，在旧 server 仍运行时等待或终止活跃房间，再停止旧 server，最后更新
+schema/protocol 并部署匹配的 server 与 caddy。具体变量和运维说明见 `docs/deployment.md`。
 
 ## 版本号与完整发版流程
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,7 +195,8 @@ pnpm --dir packages/mcp exec npm pack --dry-run
 `.github/workflows/ci.yml` 会在 PR 与 main push 上执行完整验证和两个 Docker target 构建。
 `.github/workflows/release.yml` 通常由合法 SemVer Tag push 触发；已有 Tag 的发布故障也可从 `main` 通过
 `workflow_dispatch` 指定原 Tag 恢复。两种入口都只检出现有 Tag，并执行相同的 Tag/main/版本校验。
-生产服务器部署仍是显式运维步骤，不由 GitHub 自动 SSH 或重启。
+GitHub Actions 不会 SSH 或直接重启生产服务器。生产 Komodo 会按计划轮询当前镜像通道并更新兼容版本；
+破坏性发布仍是显式运维步骤。
 
 `Dockerfile` 有两个发布目标：
 
@@ -222,6 +223,21 @@ docker build -f mumble.Dockerfile -t djkcyl/uno-online-mumble-gateway:latest .
 - Compose 的 `UNO_IMAGE_TAG` 选择 `latest`、`beta` 或精确版本；`server` 与 `caddy` 必须始终使用同一 Tag
 - `server` 与 `caddy` 都有容器健康检查；部署工具应等待健康状态后再报告成功
 
+### 生产 Komodo
+
+- 面板只通过 SSH 隧道访问服务器 `127.0.0.1:9120`，不要公开管理端口；新用户注册保持关闭
+- UNO Stack 工作目录是 `/etc/komodo/stacks/uno-online`，Stack/Compose 项目名均为 `uno-online`
+- 面板管理的 `.env` 只包含 `UNO_IMAGE_TAG` 与 `RUNTIME_SCHEMA_VERSION`；其余生产变量位于权限为 `0600` 的
+  `.env.secrets`，作为 Track Disabled 的 Additional Env File 使用
+- `Switch UNO to Beta` 与 `Switch UNO to Stable` Actions 负责切换通道并部署；精确回滚版本仍在 Stack
+  Environment 中手工设置
+- 每天 03:00 的 Global Auto Update 只检查 `server` 与 `caddy`；`redis`、`mumble` 和
+  `mumble-gateway` 必须留在自动更新忽略列表
+- Stack 启用 Pre Pull Images，关闭 Destroy Before Deploy；不要让自动部署先执行 `compose down`
+- 每天 01:00 备份 Komodo 数据库到 `/etc/komodo/backups`；默认保留最近 14 份
+- 手动执行 Compose 时必须同时传入 `--env-file .env --env-file .env.secrets`，且保持项目名为
+  `uno-online`
+
 ### 发布兼容性判定
 
 应用 SemVer、运行时 schema 与网络协议是三个独立版本维度。每次发版必须分别判断：
@@ -240,9 +256,9 @@ docker build -f mumble.Dockerfile -t djkcyl/uno-online-mumble-gateway:latest .
 兼容更新已运行的 Compose 环境时，仅拉取并重建应用容器：
 
 ```bash
-docker compose pull server caddy
-docker compose up -d --no-deps --wait server
-docker compose up -d --no-deps --wait caddy
+docker compose --env-file .env --env-file .env.secrets pull server caddy
+docker compose --env-file .env --env-file .env.secrets up -d --no-deps --wait server
+docker compose --env-file .env --env-file .env.secrets up -d --no-deps --wait caddy
 ```
 
 首次部署使用 `docker compose up -d`。破坏性发布应安排维护窗口：先停止接纳新房间，在旧 server 仍运行时
@@ -283,8 +299,9 @@ GitHub 自动发布只负责验证和发布制品；版本判断、兼容性判�
 9. **等待自动发版**：Tag push 触发 `Release` workflow。它会再次校验 Tag/main/版本/changelog，执行
    build/test/MCP pack，推送 `server` 与 `caddy` 的 `v<版本号>` 镜像、稳定版 `latest`，通过 npm OIDC
    发布 MCP，最后从 CHANGELOG 创建 GitHub Release。任一步失败都不能视为发版完成。
-10. **按兼容性策略部署**：自动发版不连接生产服务器。确认 workflow 全绿后，保留 Redis/JWT，或在
-    破坏性发布维护窗口切换 schema/protocol，再更新 Compose 应用容器。
+10. **按兼容性策略部署**：自动发版不连接生产服务器。兼容发布由生产 Komodo 在下次 Global Auto Update
+    更新当前通道，也可在面板中立即部署；破坏性发布必须在推送会移动当前镜像通道的版本 Tag 前关闭 Stack
+    Auto Update，并在维护窗口排空房间、切换 schema/protocol、部署和验证后再恢复自动更新。
 11. **发布后验证**：检查 `/api/health`、`/api/server/info`、浏览器登录/重连以及版本化 Docker/MCP 制品。
 
 预发布 Tag（如 `v1.2.0-beta.0`）会生成 prerelease，推送精确版本镜像并更新 Docker `beta`，但不更新 Docker

--- a/docs/ci-release.md
+++ b/docs/ci-release.md
@@ -39,6 +39,12 @@
 `latest`。
 工作流不发布 `mumble-gateway`，也不连接或重启生产服务器。
 
+生产 Komodo 每天 03:00 检查当前选择的镜像通道，并自动更新 UNO 的 `server` 与 `caddy`。因此“GitHub
+workflow 不直接部署”不等于“生产永远需要手工部署”：兼容版本会在制品发布后由 Komodo 的下一次检查接管；
+需要立即上线时可在 Komodo 中手动 Check/Deploy。Beta 制品只有在 Stack 已切到 `beta` 时才会自动上线。
+破坏性发布必须在推送会移动当前镜像通道的版本 Tag 之前关闭 Stack Auto Update，具体操作见
+[部署文档](deployment.md)。
+
 ## 一次性配置
 
 ### Docker Hub
@@ -89,8 +95,8 @@ git tag -a v<版本号> -m "release: v<版本号>"
 git push origin v<版本号>
 ```
 
-Tag push 后在 GitHub Actions 等待 `Release / Publish release` 全部完成，再按
-[部署文档](deployment.md) 更新生产环境。
+Tag push 后在 GitHub Actions 等待 `Release / Publish release` 全部完成。状态兼容发布可等待 Komodo 下次自动
+更新，或在面板中立即部署；破坏性发布按[部署文档](deployment.md)中的维护窗口流程手动执行。
 
 ## 失败与重试
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,9 +1,14 @@
 # UNO Online — 部署与镜像
 
-server/caddy 镜像、MCP npm 包与 GitHub Release 由版本 Tag 自动发布；生产 Compose 更新仍需人工确认兼容性后
-执行。工作流与一次性仓库配置见 [CI 与自动发版](ci-release.md)。
+server/caddy 镜像、MCP npm 包与 GitHub Release 由版本 Tag 自动发布。当前生产环境由 Komodo 管理：状态兼容
+版本会自动更新当前选择的 `latest` 或 `beta` 通道；破坏性版本仍须先人工完成兼容性判断和维护窗口安排。
+工作流与一次性仓库配置见 [CI 与自动发版](ci-release.md)。
 
-## Docker Compose
+## 独立 Docker Compose 部署（非当前生产环境）
+
+以下步骤用于尚未接入 Komodo 的新主机或独立环境。当前生产服务器不要按本节从 `.env.example` 重新生成配置，
+应使用下文的 Komodo 流程；必须脱离面板操作时，使用[手动回退到 Compose](#手动回退到-compose)中的双 env
+文件命令。
 
 ```bash
 cp .env.example .env
@@ -34,7 +39,7 @@ curl http://localhost/api/health
 curl http://localhost/api/server/info
 ```
 
-状态兼容版本发布成功后，只更新应用容器，不重建 Redis、SQLite 或语音服务：
+独立 Compose 环境收到状态兼容版本后，只更新应用容器，不重建 Redis、SQLite 或语音服务：
 
 ```bash
 docker compose pull server caddy

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -47,22 +47,72 @@ schema 或 Socket 协议破坏性发布不能直接执行这组命令，必须�
 
 ## Komodo 管理与自动更新
 
-[Komodo](https://komo.do/docs/deploy/compose) 可以直接接管现有 Compose 项目，不要求迁移数据目录或配置
-GitHub OAuth：
+生产环境由 [Komodo](https://komo.do/docs/deploy/compose) 管理，当前布局如下：
 
-1. Stack 使用 `Files on host`，`run_directory` 指向当前 Compose 所在目录。
-2. `project_name` 必须与服务器上 `docker compose ls` 显示的现有项目名相同。
-3. 初次接管保持当前 `.env`、相对挂载路径和 `./data` 目录不变。
-4. 在 Stack 环境变量中设置 `UNO_IMAGE_TAG=latest` 或 `UNO_IMAGE_TAG=beta`，修改后 Deploy 即可切换通道。
-5. 开启 `poll_for_updates` 可显示当前通道的新镜像；开启 `auto_update` 后会自动 pull 并重新部署当前通道。
+- Komodo Core、MongoDB 与 Periphery 位于 `/etc/komodo/compose`。
+- UNO Stack 名为 `uno-online`，Compose 项目名同为 `uno-online`，工作目录是
+  `/etc/komodo/stacks/uno-online`，使用服务器上的 `docker-compose.yml`。
+- 面板管理的 `.env` 只保存 `UNO_IMAGE_TAG` 和 `RUNTIME_SCHEMA_VERSION`。
+- `.env.secrets` 保存其余生产变量，权限为 `0600`；它作为不跟踪的 Additional Env File 传给 Compose，不能在
+  面板中显示、提交到 Git 或再次定义镜像通道/schema。
+- SQLite、Caddy 和语音数据仍使用工作目录下的 `./data` 挂载。Redis 也是独立挂载；兼容发布保留它，明确的
+  破坏性发布才按维护计划重建或切换 namespace。
 
-正式版与 Beta 共用 SQLite、Redis 和 JWT 时，自动更新仍受本页兼容性规则约束。若新版本改变运行时结构或
-Socket 协议，应先关闭 `auto_update`、排空房间并完成 schema/protocol 切换；若 Beta 修改了持久用户数据库
-schema，切回旧版本前必须确认迁移可回退。需要稳定回滚点时，把 `UNO_IMAGE_TAG` 改成上一个精确版本，而不是
-继续跟随可移动的 `latest`/`beta`。
+Komodo 只监听服务器的 `127.0.0.1:9120`，新用户注册已关闭。通过 SSH 隧道访问：
 
-管理面板拥有 Docker 主机控制权限，不应直接暴露到公网。单人运维可只绑定到 `127.0.0.1`，通过 SSH 端口转发
-访问。
+```bash
+ssh -N -L 9120:127.0.0.1:9120 root@<server>
+```
+
+随后打开 `http://127.0.0.1:9120`。不要把管理端口或 Periphery 直接暴露到公网；它们拥有 Docker 主机控制
+权限。
+
+### 切换正式版、Beta 与精确版本
+
+Actions 中有两条已验证的切换动作：
+
+- `Switch UNO to Beta`：把 `UNO_IMAGE_TAG` 改为 `beta` 并部署 Stack。
+- `Switch UNO to Stable`：把 `UNO_IMAGE_TAG` 改为 `latest` 并部署 Stack。
+
+在对应 Action 页面选择 **Run Action** 并完成名称确认即可切换。切换后在 Stack 页面确认状态为 `running`，并
+检查 `/api/server/info` 的版本。若要固定回滚点，在 Stack 的 Environment 中把 `UNO_IMAGE_TAG` 改为精确
+版本（如 `v1.2.3`），保存后手动 Deploy；不要用会继续移动的 `latest`/`beta` 代替固定回滚版本。
+
+### 自动更新与备份
+
+Komodo 的 `Global Auto Update` 每天 03:00（`Asia/Shanghai`）运行。UNO Stack 已启用：
+
+- Poll for Updates、Auto Update、Full Stack Auto Update；
+- Pre Pull Images；
+- Destroy Before Deploy 关闭；
+- 自动更新检查忽略 `redis`、`mumble` 和 `mumble-gateway`，只有 `server` 与 `caddy` 跟随当前通道。
+
+Full Stack Auto Update 会运行一次完整的 Compose 部署，但 Compose 不会重建配置和镜像均未变化的服务。自动
+更新不会在 `latest` 与 `beta` 之间自动切换，只会更新当前选择的通道。
+
+`Backup Core Database` 每天 01:00 运行，备份写入 `/etc/komodo/backups`；Komodo 默认保留最近 14 份。该
+过程已手动执行验证。初次迁移前的应用配置和数据另存于 `/root/uno-online-backups/pre-komodo-20260818`。
+
+正式版与 Beta 共用 SQLite、Redis 和 JWT，因此自动更新仍受本页兼容性规则约束：
+
+- 状态兼容发布可以保持自动更新开启，Komodo 会在下次检查时部署当前通道的新镜像。
+- 运行时 schema、Socket 协议或不可回退的 SQLite schema 发生破坏性变化时，必须在推送会移动当前通道的 Tag
+  **之前**关闭 Stack Auto Update，排空房间并完成 schema/protocol/数据库迁移安排；维护窗口部署和验证完成后
+  再恢复自动更新。
+- Beta 修改了持久用户数据库 schema 时，切回稳定版之前必须确认数据库迁移可回退。
+
+### 手动回退到 Compose
+
+Komodo 不可用时仍可直接操作同一 Compose 项目。两个 env 文件都必须显式传入：
+
+```bash
+cd /etc/komodo/stacks/uno-online
+docker compose --env-file .env --env-file .env.secrets pull server caddy
+docker compose --env-file .env --env-file .env.secrets up -d --no-deps --wait server
+docker compose --env-file .env --env-file .env.secrets up -d --no-deps --wait caddy
+```
+
+不要从 `.env.example` 覆盖生产 `.env.secrets`，也不要另起 Compose 项目名，否则会创建一套重复容器和网络。
 
 ## 关键配置
 


### PR DESCRIPTION
## Summary
- record the live Komodo stack, environment split, SSH-only access, and manual fallback
- document verified stable/beta switch actions, scheduled image updates, and update exclusions
- align release and AGENTS guidance with Komodo deployment and backup behavior

## Verification
- pnpm.cmd format:check
- live stable/beta/stable switch validation
- production health, persistent SQLite counts, registration lock, and backup output checks