### PR TITLE
fix(release): preserve v prefix in Docker tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
           images: djkcyl/uno-online-server
           flavor: latest=false
           tags: |
-            type=semver,pattern=v{{version}},value=${{ env.RELEASE_TAG }}
+            type=raw,value=${{ env.RELEASE_TAG }}
             type=raw,value=beta,enable=${{ contains(env.RELEASE_TAG, '-beta.') }}
             type=raw,value=latest,enable=${{ !contains(env.RELEASE_TAG, '-') }}
           labels: |
@@ -104,7 +104,7 @@ jobs:
           images: djkcyl/uno-online-caddy
           flavor: latest=false
           tags: |
-            type=semver,pattern=v{{version}},value=${{ env.RELEASE_TAG }}
+            type=raw,value=${{ env.RELEASE_TAG }}
             type=raw,value=beta,enable=${{ contains(env.RELEASE_TAG, '-beta.') }}
             type=raw,value=latest,enable=${{ !contains(env.RELEASE_TAG, '-') }}
           labels: |

--- a/scripts/release/release-scripts.test.mjs
+++ b/scripts/release/release-scripts.test.mjs
@@ -76,8 +76,10 @@ test('release workflow can recover an existing tag from the default branch', () 
 });
 
 test('release workflow keeps prereleases away from stable distribution tags', () => {
+  const dockerVersionRule = 'type=raw,value=${{ env.RELEASE_TAG }}';
   const dockerLatestRule = "type=raw,value=latest,enable=${{ !contains(env.RELEASE_TAG, '-') }}";
   const dockerBetaRule = "type=raw,value=beta,enable=${{ contains(env.RELEASE_TAG, '-beta.') }}";
+  assert.equal(releaseWorkflow.split(dockerVersionRule).length - 1, 2);
   assert.equal(releaseWorkflow.split(dockerLatestRule).length - 1, 2);
   assert.equal(releaseWorkflow.split(dockerBetaRule).length - 1, 2);
   assert.ok(releaseWorkflow.includes('if [[ "$version" == *-* ]]; then'));


### PR DESCRIPTION
## 问题
Docker metadata 的 prerelease semver 规则会去掉 Git Tag 的 v 前缀，导致文档承诺的精确镜像标签缺失。

## 修复
- 精确镜像标签直接使用经过发布校验的 RELEASE_TAG
- 增加静态回归检查，server 与 caddy 都必须保留该规则

## 验证
- pnpm format
- pnpm test
- git diff --check